### PR TITLE
xparser 0.17.1 (Chris Greenough, Feb. 2014)

### DIFF
--- a/Doxyfile.txt
+++ b/Doxyfile.txt
@@ -1,0 +1,259 @@
+# Doxyfile 1.4.6
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+PROJECT_NAME           = xparser
+PROJECT_NUMBER         = 0.16.2
+OUTPUT_DIRECTORY       = 
+CREATE_SUBDIRS         = NO
+OUTPUT_LANGUAGE        = English
+USE_WINDOWS_ENCODING   = YES
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        = 
+STRIP_FROM_INC_PATH    = 
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+MULTILINE_CPP_IS_BRIEF = NO
+DETAILS_AT_TOP         = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 8
+ALIASES                = 
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+BUILTIN_STL_SUPPORT    = NO
+DISTRIBUTE_GROUP_DOC   = NO
+SUBGROUPING            = NO
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+SHOW_INCLUDE_FILES     = YES
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_BY_SCOPE_NAME     = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       = 
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_DIRECTORIES       = NO
+FILE_VERSION_FILTER    = 
+#---------------------------------------------------------------------------
+# configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = YES
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           = log.txt
+#---------------------------------------------------------------------------
+# configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = 
+FILE_PATTERNS          = *.c \
+                         *.h \
+                         *.cc \
+                         *.cxx \
+                         *.cpp \
+                         *.c++ \
+                         *.d \
+                         *.java \
+                         *.ii \
+                         *.ixx \
+                         *.ipp \
+                         *.i++ \
+                         *.inl \
+                         *.hh \
+                         *.hxx \
+                         *.hpp \
+                         *.h++ \
+                         *.idl \
+                         *.odl \
+                         *.cs \
+                         *.php \
+                         *.php3 \
+                         *.inc \
+                         *.m \
+                         *.mm \
+                         *.dox \
+                         *.py
+RECURSIVE              = NO
+EXCLUDE                = 
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       = 
+EXAMPLE_PATH           = 
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             = 
+INPUT_FILTER           = 
+FILTER_PATTERNS        = 
+FILTER_SOURCE_FILES    = NO
+#---------------------------------------------------------------------------
+# configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = NO
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          = 
+#---------------------------------------------------------------------------
+# configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            = 
+HTML_FOOTER            = 
+HTML_STYLESHEET        = 
+HTML_ALIGN_MEMBERS     = YES
+GENERATE_HTMLHELP      = NO
+CHM_FILE               = 
+HHC_LOCATION           = 
+GENERATE_CHI           = NO
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+DISABLE_INDEX          = NO
+ENUM_VALUES_PER_LINE   = 4
+GENERATE_TREEVIEW      = NO
+TREEVIEW_WIDTH         = 250
+#---------------------------------------------------------------------------
+# configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = YES
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+#COMPACT_LATEX          = NO
+#PAPER_TYPE             = a4wide
+EXTRA_PACKAGES         = 
+#LATEX_HEADER           = 
+PDF_HYPERLINKS         = NO
+USE_PDFLATEX           = NO
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+#---------------------------------------------------------------------------
+# configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    = 
+RTF_EXTENSIONS_FILE    = 
+#---------------------------------------------------------------------------
+# configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_SCHEMA             = 
+XML_DTD                = 
+XML_PROGRAMLISTING     = YES
+#---------------------------------------------------------------------------
+# configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX = 
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor   
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           = 
+INCLUDE_FILE_PATTERNS  = 
+PREDEFINED             = 
+EXPAND_AS_DEFINED      = 
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration::additions related to external references   
+#---------------------------------------------------------------------------
+TAGFILES               = 
+GENERATE_TAGFILE       = 
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+PERL_PATH              = /usr/bin/perl
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool   
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = YES
+TEMPLATE_RELATIONS     = YES
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = YES
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+DOT_PATH               = 
+DOTFILE_DIRS           = 
+MAX_DOT_GRAPH_WIDTH    = 1024
+MAX_DOT_GRAPH_HEIGHT   = 1024
+MAX_DOT_GRAPH_DEPTH    = 1000
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES
+#---------------------------------------------------------------------------
+# Configuration::additions related to the search engine   
+#---------------------------------------------------------------------------
+SEARCHENGINE           = NO

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -6,19 +6,41 @@
 # The assumption is that the user only provides C files
 # and a model files <file>.xml
 #
-DEFINES       = -DNONE
-LIBMBOARD_DIR = libmboard
+#===================================================
+# Change this variable for the location of the 
+# Message Board Library installation
+#===================================================
+LIBMBOARD_DIR = /usr/local/lib
 LIBMBOARD_INC = $(LIBMBOARD_DIR)/include
 LIBMBOARD_LIB = $(LIBMBOARD_DIR)/lib
 
-CC      = <?if serial?>gcc<?end if?><?if parallel?>mpicc<?end if?>
-CFLAGS  = -std=c99 -Wall -I$(LIBMBOARD_INC) ${DEFINES}
+#====================================================
+# Change these for your compliler/loaded
+#====================================================
+SERIAL_CCOMP	= gcc
+PARALLEL_CCOMP	= mpicc
 
-<?if debug?>CFLAGS += -D_DEBUG_MODE -g<?end if?>
+SERIAL_LOADER	= gcc
+PARALLEL_LOADER	= mpif77
+
+DEFINES		=
+<?if gsl_lib?>DEFINES		+= -DGSL_LIB<?end if?>
+#DEFINES	+= -DSTART_END 
+#DEFINES	+= -DGRAPHICS
+
+# C Compiler
+CC      = <?if serial?>$(SERIAL_CCOMP)<?end if?><?if parallel?>$(PARALLEL_CCOMP)<?end if?>
+CFLAGS  =  -I$(LIBMBOARD_INC) ${DEFINES}
+<?if debug?>CFLAGS += -std=c99 -Wall -D_DEBUG_MODE -g<?end if?>
 <?if final?>CFLAGS += -O3<?end if?>
 
-LDFLAGS = -L$(LIBMBOARD_LIB)
-LIBS    = <?if serial?>-lmboard_s<?if debug?>d<?end if?> <?end if?><?if parallel?>-lmboard_p<?if debug?>d<?end if?> <?end if?> -lm
+LD       = <?if serial?>$(SERIAL_LOADER)<?end if?><?if parallel?>$(PARALLEL_LOADER)<?end if?>
+
+LDFLAGS  = -L$(LIBMBOARD_LIB)
+<?if gsl_lib?>
+LIBS	+= -lgsl -lgslcblas
+<?end if?>
+LIBS    += <?if serial?>-lmboard_s<?if debug?>d<?end if?> <?end if?><?if parallel?>-lmboard_p<?if debug?>d<?end if?> <?end if?> -lm
 
 #FLAME source files
 FLAME   = main.c memory.c xml.c messageboards.c partitioning.c rules.c timing.c
@@ -39,7 +61,7 @@ RM = rm -f
 all: $(SOURCES) $(FLAME) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS)
+	$(LD) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS)
 
 $(OBJECTS): $(DEPS)
 
@@ -47,6 +69,14 @@ $(OBJECTS): $(DEPS)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) $(OBJECTS) $(EXECUTABLE) $(EXECUTABLE).exe
+	$(RM) $(OBJECTS) $(EXECUTABLE) $(EXECUTABLE).exe 
 vclean:
 	$(RM) main $(EXECUTABLE) $(EXECUTABLE).exe $(OBJECTS)  $(FLAME) $(HEADERS)  $(AUX) Makefile
+format:
+	astyle -A3 $(SOURCES)
+	for file in $(patsubst %.c,%.h, $(SOURCES)) ; do \
+	echo $$file ; \
+	astyle -A3 $$file ; \
+	done 
+print:
+	a2ps -R -f10 --column=1 $(SOURCES)

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,115 @@
+===================================================================
+
+@@@@@@@ @          @    @     @ @@@@@@@
+@       @         @ @   @@   @@ @
+@       @        @   @  @ @ @ @ @
+@@@@@   @       @     @ @  @  @ @@@@@
+@       @       @@@@@@@ @     @ @
+@       @       @     @ @     @ @
+@       @@@@@@@ @     @ @     @ @@@@@@@
+
+The Flexible Large-scale Agent Modelling Environment
+
+xparser - FLAME program generator
+
+(C) 2014 STFC Rutherford Appleton Laboratory/Sheffield University
+
+===================================================================
+
+FLAME is a generic agent-based modelling system which can be used 
+to develop applications in many areas. It generates a complete 
+agent-based application which can be compiled and built on the 
+majority of computing systems ranging from laptops to super-computers.
+
+The FLAME website www.flame.ac.uk contains details on FLAME and the
+projects in which it has been used.
+
+===================================================================
+
+This directory contains all the files of the FLAME xparser
+
+Files included
+==============
+
+xparser.c		- main program
+dependencygraph.c	- dependency graph generator
+memory.c		- memory generation and management
+parsetemplate.c		- template parser and code generator
+readmodel.c		- model reader
+
+header.h		- xparser.c header file
+Makefile		- make file
+
+Template files
+==============
+
+These files are processed by the xparser to generate the application
+code using the model (xml) and functions (c) files.
+
+These file should not be changed in anyway:
+
+main.tmpl
+header.tmpl
+low_primes.tmpl
+memory.tmpl
+messageboards.tmpl
+partitioning.tmpl
+rules.tmpl
+timing.tmpl
+xml.tmpl
+
+Doxyfile.tmpl
+
+It might be necessary to change this file to reflect your installation
+of FLAME and the message board library files. DO SO WITH GREAT CARE.
+
+Makefile.tmpl
+
+Building the xparser
+====================
+
+Should be a simple 'make' command.
+
+Running the xparser
+===================
+
+Given that the model developer has written a model file(s) (.xml) and
+a set of transitions functions (.c file(s)), and referenced the C files in the
+.xml file(s), the next step is to run the xparser.
+
+Typing xparser will produce:
+
+xparser (Version 0.17.1)
+Usage: xparser [XMML file] [-s | -p] [-f]
+        -s      Serial mode (default)
+        -p      Parallel mode
+        -f      Final production mode
+
+The xparser requires the location of the template files. This can be provided
+through the environment variable FLAME_XPARSER_DIR (recommended) or by making
+links to or copies of the template files in the model directory (not recommended).
+
+If really necessary the template location can be explicitly compiled into the xparser
+by editing the FLAME_XPARSER_DIR macro in the xparser header file - header.h.
+
+Using the GSL Library
+=====================
+Random numbers are very important to FLAME and the generators provided by the
+native operating system may be considered inadequate. FLAME provides a mechanism
+for calling the GSL generators, provided that they have been installed on the target system.
+
+By defining the <constant> GSL_RNG_SEED of type float in the <environment> section
+of the model XML, the xparser will generate additional code to call the GSL Random Number
+Generators. In this version of FLAME this is only the mt19937 type of generator.
+
+The seed of the generation sequence can be provided through the <GSL_RNG_SEED> tag
+in the initial data. If the variable is not provided, it is automatically set to 0
+(xparser debug mode) or by using the current time (xparser production mode).
+
+The generator type and initial seed can be set using the system environment variables
+GSL_RNG_TYPE and GSL_RNG_SEED. The seed provided in the initial data files will
+override those given by the system environment variables.
+
+
+Chris Greenough - Feb 2014
+

--- a/Readme2.txt
+++ b/Readme2.txt
@@ -1,0 +1,23 @@
+XParser 0.17.1
+This version of xparser was released by Chris Greenough in Feb. 2014.
+
+It contains:
+- Support for GNU GSL library for statistical functions
+- System and FLAME environment variables (see Readme.txt):
+
+1. System environment: FLAME_XPARSER_DIR: If this is set, xparser assumes the flame templates are in that folder. If not set, xparser looks in the current folder for templates.
+
+2. Flame environment constant in model.xml to set the random seed: GSL_RNG_SEED.
+If this constant is present in model.xml, then the Makefile_templ will include code to link in the GSL libraries. The RNG is initialized by code in main.templ as replacement for the standard RNG of C.
+
+3. Setting the GSL random seed depends on whether xparser is run in debug or production mode:
+a. In debug mode: value depends on user-defined constant GSL_RNG_SEED:
+a1. If GSL_RNG_SEED == 0: set gsl_seed=gsl_rng_default_seed (0 by default).
+a2. If GSL_RNG_SEED =!= 0: set gsl_seed=GSL_RNG_SEED (user-defined).
+b. In production mode: value depends on value of gsl_rng_default_seed:
+b1. If gsl_rng_default_seed ==0: gsl_seed is initialized on time (default).
+b2. If gsl_rng_default_seed =!= 0: gsl_seed=gsl_rng_default_seed (see 4. below)
+
+4. System environment: GSL_RNG_TYPE and GSL_RNG_SEED
+- Without any environment variables, GSL uses the initial defaults, an mt19937 generator with a default seed of gsl_rng_default_seed=0.
+- See also: https://www.gnu.org/software/gsl/manual/html_node/Random-number-environment-variables.html

--- a/dependencygraph.c
+++ b/dependencygraph.c
@@ -4,22 +4,21 @@
  * Added colour arrays
  * added output_stategraph_colour() fn
  * **/
- 
- 
-const char *colour_map[]={"blue", "blueviolet", "brown" ,"burlywood4", "cadetblue", "chartreuse","darkgreen","deeppink",  "cyan4", "firebrick", "gold", "lightpink3", "lightslateblue", "magenta", "red", "yellow"};
-const char *colour_map_light[]={"antiquewhite", "aquamarine", "azure3" ,"brown1", "chartreuse1", "orchid1","lightsalmon4","darkgoldenrod1",  "darkkhaki", "darkolivegreen3", "darkslateblue", "forestgreen", "gray70", "indianred", "lightslateblue", "maroon3"};
+
+
+const char *colour_map[]= {"blue", "blueviolet", "brown" ,"burlywood4", "cadetblue", "chartreuse","darkgreen","deeppink",  "cyan4", "firebrick", "gold", "lightpink3", "lightslateblue", "magenta", "red", "yellow"};
+const char *colour_map_light[]= {"antiquewhite", "aquamarine", "azure3" ,"brown1", "chartreuse1", "orchid1","lightsalmon4","darkgoldenrod1",  "darkkhaki", "darkolivegreen3", "darkslateblue", "forestgreen", "gray70", "indianred", "lightslateblue", "maroon3"};
 
 void latex_print_to_file(char * text, FILE *file)
 {
-	int i;
-	
-	if(text == NULL) return;
-	
-	for(i = 0; i < (int)strlen(text); i++)
-	{
-		if(text[i] == '_' || text[i] == '&' || text[i] == '%' || text[i] == '#') fputs("\\", file);
-		fputc(text[i], file);
-	}
+    int i;
+
+    if(text == NULL) return;
+
+    for(i = 0; i < (int)strlen(text); i++) {
+        if(text[i] == '_' || text[i] == '&' || text[i] == '%' || text[i] == '#') fputs("\\", file);
+        fputc(text[i], file);
+    }
 }
 
 /** \fn void output_latex(char * filename, char * filepath, model_data * modeldata)
@@ -30,396 +29,388 @@ void latex_print_to_file(char * text, FILE *file)
  */
 void output_latex(char * filename, char * filepath, model_data * modeldata)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	
-	xmachine * current_xmachine;
-	variable * current_variable;
-	xmachine_function * current_function;
-	xmachine_message * current_message;
-	variable * current_envvar;
-	model_datatype * current_datatype;
-	
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
-	
-	fputs("\\documentclass[a4paper,11pt]{article}\n", file);
-	fputs("\\usepackage[table]{xcolor}\n", file);
-	fputs("\\usepackage{amsfonts}\n", file);
-	fputs("\\usepackage{amssymb}\n", file);
-	fputs("\\usepackage{amsmath}\n", file);
-	fputs("\\usepackage{euscript}\n", file);
-	fputs("\\usepackage{boxedminipage}\n", file);
-	fputs("\\usepackage{lscape}\n", file);
-	fputs("\\usepackage{minitoc}\n", file);
-	fputs("\\usepackage{epsfig,psfrag,graphicx,verbatim}\n", file);
-	fputs("\\usepackage{natbib}\n", file);
-	fputs("\\usepackage{booktabs, longtable}\n", file);
-	fputs("\\usepackage{url}\n", file);
-	fputs("\\usepackage{makeidx}\n\n", file);
-	
-	fputs("%% Define a new 'code' style for the url package that will use a sans serif font.\n", file);
-	fputs("\\makeatletter\n", file);
-	fputs("\\def\\url@codestyle{%\n", file);
-	fputs("  \\@ifundefined{selectfont}{\\def\\UrlFont{\\sf}}{\\def\\UrlFont{\\sffamily}}}\n", file);
-	fputs("\\makeatother\n", file);
-	fputs("%% Now actually use the newly defined style.\n", file);
-	fputs("\\urlstyle{code}\n\n", file);
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
 
-	fputs("\\vfuzz2pt % Don't report over-full v-boxes if over-edge is small\n", file);
-	fputs("\\hfuzz2pt % Don't report over-full h-boxes if over-edge is small\n", file);
+    xmachine * current_xmachine;
+    variable * current_variable;
+    xmachine_function * current_function;
+    xmachine_message * current_message;
+    variable * current_envvar;
+    model_datatype * current_datatype;
 
-	fputs("\\setlength{\\oddsidemargin}{0cm}\n", file);
-	fputs("\\setlength{\\evensidemargin}{0cm}\n", file);
-	fputs("\\setlength{\\textwidth}{16cm}\n", file);
-	fputs("\\setlength{\\textheight}{23cm}\n", file);
-	
-	fputs("\\title{", file);
-	fputs(modeldata->name, file);
-	fputs(" Reference Manual}\n", file);
-	fputs("\\author{", file);
-	fputs("Author names to add", file);
-	fputs("}\n", file);
-	fputs("\\date{\\today}\n\n", file);
-	fputs("\\makeindex\n\n", file);
-	fputs("\\begin{document}\n", file);
-	fputs("\\rowcolors[]{2}{lightgray!40}{yellow!25} %% color table rows with alternating colors\n", file);
-	fputs("\\maketitle\n", file);
-	fputs("\\tableofcontents\n", file);
-	fputs("\\clearpage\n\n", file);
-	
-	fputs("\\section{", file);
-	fputs(modeldata->name, file);
-	fputs(" FLAME Implementation}\n", file);
-	
-	current_xmachine = * modeldata->p_xmachines;
-	for(current_xmachine = * modeldata->p_xmachines; current_xmachine != NULL; current_xmachine = current_xmachine->next)
-	{
-		//fputs("\n\n\\clearpage", file);
-		
-		//Section header
-		fputs("\n\\subsection{", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs("}\n\n", file);
-		
-		//MEMORY TABLE
-/*
-		fputs("\\subsubsection{Memory}\n\n", file);
-		fputs("See Table \\ref{Table: ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" Memory}.\n\n", file);
-*/				
-		//fputs("\\begin{landscape}\n", file);
-		fputs("\\begin{longtable}[H!]{ll}\n", file);
-		fputs("\\caption{{\\bfseries List of memory variables for ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" agent.}}\n", file);
-		fputs("\\label{Table: ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" Memory}\\\\\n", file);
-		
-		fputs("\\toprule \n", file);
-		fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-		fputs("\\midrule\n", file);
-		fputs("\\endfirsthead\n", file);
-		
-		fputs("\\multicolumn{2}{c}%\n", file);
-		fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
-		fputs("\\toprule\n", file);
-		fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-		fputs("\\midrule\n", file);
-		fputs("\\endhead\n", file);
-		
-		fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
-		fputs("\\endfoot\n", file);
-		
-		fputs("\\bottomrule\n", file);
-		fputs("\\endlastfoot\n", file);
-		
-		for(current_variable = current_xmachine->variables; current_variable != NULL;
-					current_variable = current_variable->next)
-		{
-			fputs("\\midrule\n", file);
-			fputs("\\parbox{5cm}{\\url{", file);
-			fputs(current_variable->type, file);
-			fputs("} \\url{", file);
-			fputs(current_variable->name, file);
-			fputs("}}", file);
-			fputs(" \\index{\\url{", file);
-			fputs(current_variable->name, file);
-			fputs("}} & \\parbox{10cm}{", file);
-			latex_print_to_file(current_variable->description, file);
-			fputs("} \\\\\n", file);
-			//if(current_variable->next != NULL) fputs("\\midrule\n", file);
-		}
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
 
-		fputs("\\end{longtable}\n", file);
-		//fputs("\\end{landscape}\n\n", file);
+    fputs("\\documentclass[a4paper,11pt]{article}\n", file);
+    fputs("\\usepackage[table]{xcolor}\n", file);
+    fputs("\\usepackage{amsfonts}\n", file);
+    fputs("\\usepackage{amssymb}\n", file);
+    fputs("\\usepackage{amsmath}\n", file);
+    fputs("\\usepackage{euscript}\n", file);
+    fputs("\\usepackage{boxedminipage}\n", file);
+    fputs("\\usepackage{lscape}\n", file);
+    fputs("\\usepackage{minitoc}\n", file);
+    fputs("\\usepackage{epsfig,psfrag,graphicx,verbatim}\n", file);
+    fputs("\\usepackage{natbib}\n", file);
+    fputs("\\usepackage{booktabs, longtable}\n", file);
+    fputs("\\usepackage{url}\n", file);
+    fputs("\\usepackage{makeidx}\n\n", file);
 
-		//FUNCTION TABLE
-/*
-		fputs("\\subsubsection{Functions}\n", file);
+    fputs("%% Define a new 'code' style for the url package that will use a sans serif font.\n", file);
+    fputs("\\makeatletter\n", file);
+    fputs("\\def\\url@codestyle{%\n", file);
+    fputs("  \\@ifundefined{selectfont}{\\def\\UrlFont{\\sf}}{\\def\\UrlFont{\\sffamily}}}\n", file);
+    fputs("\\makeatother\n", file);
+    fputs("%% Now actually use the newly defined style.\n", file);
+    fputs("\\urlstyle{code}\n\n", file);
 
-		fputs("See Table \\ref{Table: ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" Functions}.\n\n", file);
-*/				
-		//fputs("\\begin{landscape}\n", file);
-		fputs("\\begin{longtable}[H!]{ll}\n", file);
-		fputs("\\caption{{\\bfseries List of functions for ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" agent.}}\n", file);
-		fputs("\\label{Table: ", file);
-		latex_print_to_file(current_xmachine->name, file);
-		fputs(" Functions}\\\\\n", file);
-		
-		fputs("\\toprule \n", file);
-		fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-		fputs("\\midrule\n", file);
-		fputs("\\endfirsthead\n", file);
-		
-		fputs("\\multicolumn{2}{c}%\n", file);
-		fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
-		fputs("\\toprule\n", file);
-		fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-		fputs("\\midrule\n", file);
-		fputs("\\endhead\n", file);
-		
-		fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
-		fputs("\\endfoot\n", file);
-		
-		fputs("\\bottomrule\n", file);
-		fputs("\\endlastfoot\n", file);
+    fputs("\\vfuzz2pt % Don't report over-full v-boxes if over-edge is small\n", file);
+    fputs("\\hfuzz2pt % Don't report over-full h-boxes if over-edge is small\n", file);
 
-		for(current_function = current_xmachine->functions; current_function != NULL;
-			current_function = current_function->next)
-		{
-			fputs("\\midrule\n", file);
-			fputs("\\parbox{5cm}{\\url{", file);
-			fputs(current_function->name, file);
-			fputs("}}", file);
-			fputs(" \\index{\\url{", file);
-			fputs(current_function->name, file);
-			fputs("}} & \\parbox{10cm}{", file);
-			latex_print_to_file(current_function->description, file);
-			fputs("} \\\\\n", file);
-		}
-		fputs("\\end{longtable}\n", file);
-		//fputs("\\end{landscape}\n\n", file);
-	
-		//fputs("\\subsubsection{States}\n", file);		
-		//fputs("\\paragraph{State:}\\url{State_name}.\n", file);
+    fputs("\\setlength{\\oddsidemargin}{0cm}\n", file);
+    fputs("\\setlength{\\evensidemargin}{0cm}\n", file);
+    fputs("\\setlength{\\textwidth}{16cm}\n", file);
+    fputs("\\setlength{\\textheight}{23cm}\n", file);
 
-		//FUNCTION LIST
+    fputs("\\title{", file);
+    fputs(modeldata->name, file);
+    fputs(" Reference Manual}\n", file);
+    fputs("\\author{", file);
+    fputs("Author names to add", file);
+    fputs("}\n", file);
+    fputs("\\date{\\today}\n\n", file);
+    fputs("\\makeindex\n\n", file);
+    fputs("\\begin{document}\n", file);
+    fputs("\\rowcolors[]{2}{lightgray!40}{yellow!25} %% color table rows with alternating colors\n", file);
+    fputs("\\maketitle\n", file);
+    fputs("\\tableofcontents\n", file);
+    fputs("\\clearpage\n\n", file);
 
-		//fputs("\\subsubsection{Functions}\n", file);
-/*
-		for(current_function = current_xmachine->functions; current_function != NULL;
-			current_function = current_function->next)
-		{
+    fputs("\\section{", file);
+    fputs(modeldata->name, file);
+    fputs(" FLAME Implementation}\n", file);
 
-			fputs("\n\\paragraph{Function:}\\url{", file);
-			fputs(current_function->name, file);
-			fputs("}.\n", file);
+    current_xmachine = * modeldata->p_xmachines;
+    for(current_xmachine = * modeldata->p_xmachines; current_xmachine != NULL; current_xmachine = current_xmachine->next) {
+        //fputs("\n\n\\clearpage", file);
 
-			fputs("\\paragraph{Description}\n", file);
-			latex_print_to_file(current_function->description, file);
-			fputs("\n", file);
+        //Section header
+        fputs("\n\\subsection{", file);
+        latex_print_to_file(current_xmachine->name, file);
+        fputs("}\n\n", file);
 
-			fputs("\\paragraph{Code}\n", file);
-			fputs("\\begin{verbatim}\n\n", file);
-			fputs("\\end{verbatim}\n", file);	
-		}
-*/
-	}//end of xmachine
-	
-	//MESSAGE TABLE
-	fputs("\\subsection{Messages}\n", file);	
-	fputs("See Table \\ref{Table: Messages}.", file);
+        //MEMORY TABLE
+        /*
+        		fputs("\\subsubsection{Memory}\n\n", file);
+        		fputs("See Table \\ref{Table: ", file);
+        		latex_print_to_file(current_xmachine->name, file);
+        		fputs(" Memory}.\n\n", file);
+        */
+        //fputs("\\begin{landscape}\n", file);
+        fputs("\\begin{longtable}[H!]{ll}\n", file);
+        fputs("\\caption{{\\bfseries List of memory variables for ", file);
+        latex_print_to_file(current_xmachine->name, file);
+        fputs(" agent.}}\n", file);
+        fputs("\\label{Table: ", file);
+        latex_print_to_file(current_xmachine->name, file);
+        fputs(" Memory}\\\\\n", file);
 
-	//fputs("\\begin{landscape}\n", file);
-	fputs("\\begin{longtable}[H!]{ll}\n", file);
-	
-	fputs("\\caption{{\\bfseries List of messages.}}\n", file);
-	fputs("\\label{Table: Messages}\\\\\n", file);
-	
-	fputs("\\toprule \n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endfirsthead\n", file);
-	
-	fputs("\\multicolumn{2}{c}%\n", file);
-	fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
-	fputs("\\toprule\n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endhead\n", file);
-	
-	fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
-	fputs("\\endfoot\n", file);
-	
-	fputs("\\bottomrule\n", file);
-	fputs("\\endlastfoot\n", file);
-	
-	for(current_message = * modeldata->p_xmessages; current_message != NULL;
-		current_message = current_message->next)
-	{
-		fputs("\\url{", file);
-		fputs(current_message->name, file);
-		fputs("} & \\parbox{10cm}{", file);
-		latex_print_to_file(current_message->description, file);
-		fputs("}\\\\\n", file);
-		//fputs("\\midrule\n", file);
-		for(current_variable = current_message->vars; current_variable != NULL;
-							current_variable = current_variable->next)
-		{
-			fputs("    \\url{", file);
-			fputs(current_variable->type, file);
-			fputs("} \\url{", file);
-			fputs(current_variable->name, file);	
-			fputs("}", file);
-			fputs(" \\index{\\url{", file);
-			fputs(current_variable->name, file);
-			fputs("}} & \\parbox{10cm}{", file);
-			latex_print_to_file(current_variable->description, file);
-			fputs("}\\\\\n", file);
-		}
-		if(current_message->next != NULL) fputs("\\midrule\n", file);
-	}
-	
-	fputs("\\end{longtable}\n", file);
-	//fputs("\\end{landscape}\n\n", file);
-	
-	//CONSTANTS TABLE
+        fputs("\\toprule \n", file);
+        fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+        fputs("\\midrule\n", file);
+        fputs("\\endfirsthead\n", file);
 
-	fputs("\\subsection{Constants}\n", file);
-	//fputs("See Table \\ref{Table: constants}.\n", file);
-	
-	//fputs("\\begin{landscape}\n", file);
-	fputs("\\begin{longtable}[H!]{ll}\n", file);
+        fputs("\\multicolumn{2}{c}%\n", file);
+        fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
+        fputs("\\toprule\n", file);
+        fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+        fputs("\\midrule\n", file);
+        fputs("\\endhead\n", file);
 
-	fputs("\\caption{{\\bfseries List of constants.}}\n", file);
-	fputs("\\label{Table: constants}\\\\\n", file);
-	
-	fputs("\\toprule \n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endfirsthead\n", file);
-	
-	fputs("\\multicolumn{2}{c}%\n", file);
-	fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
-	fputs("\\toprule\n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endhead\n", file);
-	
-	fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
-	fputs("\\endfoot\n", file);
-	
-	fputs("\\bottomrule\n", file);
-	fputs("\\endlastfoot\n", file);
-	
-	for(current_envvar = * modeldata->p_envvars; current_envvar != NULL;
-		current_envvar = current_envvar->next)
-	{
-		fputs("\\url{", file);
-		fputs(current_envvar->type, file);
-		fputs("} \\url{", file);
-		fputs(current_envvar->name, file);	
-		fputs("}", file);
-		fputs(" \\index{\\url{", file);
-		fputs(current_envvar->name, file);
-		fputs("}} & \\parbox{10cm}{", file);
-		latex_print_to_file(current_envvar->description, file);
-		fputs("}\\\\\n", file);
-		//if(current_envvar->next != NULL) fputs("\\midrule\n", file);
-	}
-	
-	fputs("\\end{longtable}\n", file);
-	//fputs("\\end{landscape}\n\n", file);
-	
-	//ADT TABLE
-	fputs("\\subsection{Datatypes}\n", file);
-	//fputs("See Table \\ref{Table: datatypes}.\n", file);
+        fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
+        fputs("\\endfoot\n", file);
 
-	//fputs("\\begin{landscape}\n", file);
-	fputs("\\begin{longtable}[H!]{ll}\n", file);
+        fputs("\\bottomrule\n", file);
+        fputs("\\endlastfoot\n", file);
 
-	fputs("\\caption{{\\bfseries List of attributes for ADTs.}}\n", file);
-	fputs("\\label{Table: datatypes}\\\\\n", file);
-	
-	fputs("\\toprule \n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endfirsthead\n", file);
-	
-	fputs("\\multicolumn{2}{c}%\n", file);
-	fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
-	fputs("\\toprule\n", file);
-	fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
-	fputs("\\midrule\n", file);
-	fputs("\\endhead\n", file);
-	
-	fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
-	fputs("\\endfoot\n", file);
-	
-	fputs("\\bottomrule\n", file);
-	fputs("\\endlastfoot\n", file);
-	
-	for(current_datatype = * modeldata->p_datatypes; current_datatype != NULL;
-		current_datatype = current_datatype->next)
-	{
-		fputs("\\url{", file);
-		fputs(current_datatype->name, file);
-		fputs("}", file);
-		fputs(" \\index{\\url{", file);
-		fputs(current_datatype->name, file);
-		fputs("}} & \\parbox{10cm}{", file);
-		latex_print_to_file(current_datatype->desc, file);	
-		fputs("} \\\\\n", file);
-		//fputs("\\midrule    \n", file);
+        for(current_variable = current_xmachine->variables; current_variable != NULL;
+                current_variable = current_variable->next) {
+            fputs("\\midrule\n", file);
+            fputs("\\parbox{5cm}{\\url{", file);
+            fputs(current_variable->type, file);
+            fputs("} \\url{", file);
+            fputs(current_variable->name, file);
+            fputs("}}", file);
+            fputs(" \\index{\\url{", file);
+            fputs(current_variable->name, file);
+            fputs("}} & \\parbox{10cm}{", file);
+            latex_print_to_file(current_variable->description, file);
+            fputs("} \\\\\n", file);
+            //if(current_variable->next != NULL) fputs("\\midrule\n", file);
+        }
 
-		for(current_variable = current_datatype->vars; current_variable != NULL;
-			current_variable = current_variable->next)
-		{
-			fputs("    \\url{", file);
-			fputs(current_variable->type, file);
-			fputs("} \\url{", file);
-			fputs(current_variable->name, file);
-			fputs("} & \\parbox{8cm}{", file);
-			latex_print_to_file(current_variable->description, file);
-			fputs("}\\\\\n", file);
-		}
+        fputs("\\end{longtable}\n", file);
+        //fputs("\\end{landscape}\n\n", file);
 
-		if(current_datatype->next != NULL) fputs("\\midrule\n", file);
-	}
-	
-	fputs("\\end{longtable}\n", file);
-	//fputs("\\end{landscape}\n\n", file);
+        //FUNCTION TABLE
+        /*
+        		fputs("\\subsubsection{Functions}\n", file);
 
-/*
-	fputs("\\clearpage\n", file);
-	fputs("\n\\subsection{Stategraph}\n", file);
-	fputs("\\begin{figure}[Hpb!]\n", file);
-	fputs("\\centering\\leavevmode\n", file);
-	fputs("%\\resizebox{!}{19cm}{\\includegraphics{stategraph.eps}}\n", file);
-	fputs("\\caption{Stategraph.}\n", file);
-	fputs("\\label{Figure: Stategraph}\n", file);
-	fputs("\\end{figure}\n", file);
-*/	
-	fputs("\n\\printindex\n", file);
-	
-	fputs("\n\\end{document}\n", file);
+        		fputs("See Table \\ref{Table: ", file);
+        		latex_print_to_file(current_xmachine->name, file);
+        		fputs(" Functions}.\n\n", file);
+        */
+        //fputs("\\begin{landscape}\n", file);
+        fputs("\\begin{longtable}[H!]{ll}\n", file);
+        fputs("\\caption{{\\bfseries List of functions for ", file);
+        latex_print_to_file(current_xmachine->name, file);
+        fputs(" agent.}}\n", file);
+        fputs("\\label{Table: ", file);
+        latex_print_to_file(current_xmachine->name, file);
+        fputs(" Functions}\\\\\n", file);
 
-	
-	/* Close the file */
-	fclose(file);
+        fputs("\\toprule \n", file);
+        fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+        fputs("\\midrule\n", file);
+        fputs("\\endfirsthead\n", file);
+
+        fputs("\\multicolumn{2}{c}%\n", file);
+        fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
+        fputs("\\toprule\n", file);
+        fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+        fputs("\\midrule\n", file);
+        fputs("\\endhead\n", file);
+
+        fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
+        fputs("\\endfoot\n", file);
+
+        fputs("\\bottomrule\n", file);
+        fputs("\\endlastfoot\n", file);
+
+        for(current_function = current_xmachine->functions; current_function != NULL;
+                current_function = current_function->next) {
+            fputs("\\midrule\n", file);
+            fputs("\\parbox{5cm}{\\url{", file);
+            fputs(current_function->name, file);
+            fputs("}}", file);
+            fputs(" \\index{\\url{", file);
+            fputs(current_function->name, file);
+            fputs("}} & \\parbox{10cm}{", file);
+            latex_print_to_file(current_function->description, file);
+            fputs("} \\\\\n", file);
+        }
+        fputs("\\end{longtable}\n", file);
+        //fputs("\\end{landscape}\n\n", file);
+
+        //fputs("\\subsubsection{States}\n", file);
+        //fputs("\\paragraph{State:}\\url{State_name}.\n", file);
+
+        //FUNCTION LIST
+
+        //fputs("\\subsubsection{Functions}\n", file);
+        /*
+        		for(current_function = current_xmachine->functions; current_function != NULL;
+        			current_function = current_function->next)
+        		{
+
+        			fputs("\n\\paragraph{Function:}\\url{", file);
+        			fputs(current_function->name, file);
+        			fputs("}.\n", file);
+
+        			fputs("\\paragraph{Description}\n", file);
+        			latex_print_to_file(current_function->description, file);
+        			fputs("\n", file);
+
+        			fputs("\\paragraph{Code}\n", file);
+        			fputs("\\begin{verbatim}\n\n", file);
+        			fputs("\\end{verbatim}\n", file);
+        		}
+        */
+    }//end of xmachine
+
+    //MESSAGE TABLE
+    fputs("\\subsection{Messages}\n", file);
+    fputs("See Table \\ref{Table: Messages}.", file);
+
+    //fputs("\\begin{landscape}\n", file);
+    fputs("\\begin{longtable}[H!]{ll}\n", file);
+
+    fputs("\\caption{{\\bfseries List of messages.}}\n", file);
+    fputs("\\label{Table: Messages}\\\\\n", file);
+
+    fputs("\\toprule \n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endfirsthead\n", file);
+
+    fputs("\\multicolumn{2}{c}%\n", file);
+    fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
+    fputs("\\toprule\n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endhead\n", file);
+
+    fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
+    fputs("\\endfoot\n", file);
+
+    fputs("\\bottomrule\n", file);
+    fputs("\\endlastfoot\n", file);
+
+    for(current_message = * modeldata->p_xmessages; current_message != NULL;
+            current_message = current_message->next) {
+        fputs("\\url{", file);
+        fputs(current_message->name, file);
+        fputs("} & \\parbox{10cm}{", file);
+        latex_print_to_file(current_message->description, file);
+        fputs("}\\\\\n", file);
+        //fputs("\\midrule\n", file);
+        for(current_variable = current_message->vars; current_variable != NULL;
+                current_variable = current_variable->next) {
+            fputs("    \\url{", file);
+            fputs(current_variable->type, file);
+            fputs("} \\url{", file);
+            fputs(current_variable->name, file);
+            fputs("}", file);
+            fputs(" \\index{\\url{", file);
+            fputs(current_variable->name, file);
+            fputs("}} & \\parbox{10cm}{", file);
+            latex_print_to_file(current_variable->description, file);
+            fputs("}\\\\\n", file);
+        }
+        if(current_message->next != NULL) fputs("\\midrule\n", file);
+    }
+
+    fputs("\\end{longtable}\n", file);
+    //fputs("\\end{landscape}\n\n", file);
+
+    //CONSTANTS TABLE
+
+    fputs("\\subsection{Constants}\n", file);
+    //fputs("See Table \\ref{Table: constants}.\n", file);
+
+    //fputs("\\begin{landscape}\n", file);
+    fputs("\\begin{longtable}[H!]{ll}\n", file);
+
+    fputs("\\caption{{\\bfseries List of constants.}}\n", file);
+    fputs("\\label{Table: constants}\\\\\n", file);
+
+    fputs("\\toprule \n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endfirsthead\n", file);
+
+    fputs("\\multicolumn{2}{c}%\n", file);
+    fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
+    fputs("\\toprule\n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endhead\n", file);
+
+    fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
+    fputs("\\endfoot\n", file);
+
+    fputs("\\bottomrule\n", file);
+    fputs("\\endlastfoot\n", file);
+
+    for(current_envvar = * modeldata->p_envvars; current_envvar != NULL;
+            current_envvar = current_envvar->next) {
+        fputs("\\url{", file);
+        fputs(current_envvar->type, file);
+        fputs("} \\url{", file);
+        fputs(current_envvar->name, file);
+        fputs("}", file);
+        fputs(" \\index{\\url{", file);
+        fputs(current_envvar->name, file);
+        fputs("}} & \\parbox{10cm}{", file);
+        latex_print_to_file(current_envvar->description, file);
+        fputs("}\\\\\n", file);
+        //if(current_envvar->next != NULL) fputs("\\midrule\n", file);
+    }
+
+    fputs("\\end{longtable}\n", file);
+    //fputs("\\end{landscape}\n\n", file);
+
+    //ADT TABLE
+    fputs("\\subsection{Datatypes}\n", file);
+    //fputs("See Table \\ref{Table: datatypes}.\n", file);
+
+    //fputs("\\begin{landscape}\n", file);
+    fputs("\\begin{longtable}[H!]{ll}\n", file);
+
+    fputs("\\caption{{\\bfseries List of attributes for ADTs.}}\n", file);
+    fputs("\\label{Table: datatypes}\\\\\n", file);
+
+    fputs("\\toprule \n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endfirsthead\n", file);
+
+    fputs("\\multicolumn{2}{c}%\n", file);
+    fputs("{{\\bfseries \\tablename\\ \\thetable{} -- continued from previous page}} \\\\\n", file);
+    fputs("\\toprule\n", file);
+    fputs("\\bfseries Name & \\bfseries Description \\\\ \\hline \n", file);
+    fputs("\\midrule\n", file);
+    fputs("\\endhead\n", file);
+
+    fputs("\\multicolumn{2}{r}{{\\emph{Continued on next page}}} \\\\\n", file);
+    fputs("\\endfoot\n", file);
+
+    fputs("\\bottomrule\n", file);
+    fputs("\\endlastfoot\n", file);
+
+    for(current_datatype = * modeldata->p_datatypes; current_datatype != NULL;
+            current_datatype = current_datatype->next) {
+        fputs("\\url{", file);
+        fputs(current_datatype->name, file);
+        fputs("}", file);
+        fputs(" \\index{\\url{", file);
+        fputs(current_datatype->name, file);
+        fputs("}} & \\parbox{10cm}{", file);
+        latex_print_to_file(current_datatype->desc, file);
+        fputs("} \\\\\n", file);
+        //fputs("\\midrule    \n", file);
+
+        for(current_variable = current_datatype->vars; current_variable != NULL;
+                current_variable = current_variable->next) {
+            fputs("    \\url{", file);
+            fputs(current_variable->type, file);
+            fputs("} \\url{", file);
+            fputs(current_variable->name, file);
+            fputs("} & \\parbox{8cm}{", file);
+            latex_print_to_file(current_variable->description, file);
+            fputs("}\\\\\n", file);
+        }
+
+        if(current_datatype->next != NULL) fputs("\\midrule\n", file);
+    }
+
+    fputs("\\end{longtable}\n", file);
+    //fputs("\\end{landscape}\n\n", file);
+
+    /*
+    	fputs("\\clearpage\n", file);
+    	fputs("\n\\subsection{Stategraph}\n", file);
+    	fputs("\\begin{figure}[Hpb!]\n", file);
+    	fputs("\\centering\\leavevmode\n", file);
+    	fputs("%\\resizebox{!}{19cm}{\\includegraphics{stategraph.eps}}\n", file);
+    	fputs("\\caption{Stategraph.}\n", file);
+    	fputs("\\label{Figure: Stategraph}\n", file);
+    	fputs("\\end{figure}\n", file);
+    */
+    fputs("\n\\printindex\n", file);
+
+    fputs("\n\\end{document}\n", file);
+
+
+    /* Close the file */
+    fclose(file);
 }
 
 /** \fn void output_dgraph(char * filename, char * filepath, model_data * modeldata)
@@ -430,64 +421,61 @@ void output_latex(char * filename, char * filepath, model_data * modeldata)
  */
 void output_dgraph(char * filename, char * filepath, model_data * modeldata)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	adj_function * current_adj_function;
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    adj_function * current_adj_function;
 
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
 
-	fputs("digraph dependency_graph {\n", file);
-	fputs("\trankdir=BT;\n", file);
-	fputs("\tsize=\"8,5;\"\n", file); /* cg 9/8/07 - bug - ; missing */
-	fputs("\tnode [shape = rect];\n", file);
+    fputs("digraph dependency_graph {\n", file);
+    fputs("\trankdir=BT;\n", file);
+    fputs("\tsize=\"8,5;\"\n", file); /* cg 9/8/07 - bug - ; missing */
+    fputs("\tnode [shape = rect];\n", file);
 
-	fputs("\t\n\t/* Functions */\n", file);
-	/* For every function */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			fputs("\t", file);
-			fputs(current_function->name, file);
-			fputs("[label = \"", file);
-			fputs(current_function->name, file);
-			fputs("\"]\n", file);
+    fputs("\t\n\t/* Functions */\n", file);
+    /* For every function */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            fputs("\t", file);
+            fputs(current_function->name, file);
+            fputs("[label = \"", file);
+            fputs(current_function->name, file);
+            fputs("\"]\n", file);
 
-			/* For every dependency */
-			current_adj_function = current_function->depends;
-			while(current_adj_function)
-			{
-				fputs("\t", file);
-				fputs(current_function->name, file);
-				fputs(" -> ", file);
-				fputs(current_adj_function->function->name, file);
-				fputs(" [ label = \"<depends on ", file);
-				fputs(current_adj_function->type, file);
-				fputs(">\" ];\n", file);
+            /* For every dependency */
+            current_adj_function = current_function->depends;
+            while(current_adj_function) {
+                fputs("\t", file);
+                fputs(current_function->name, file);
+                fputs(" -> ", file);
+                fputs(current_adj_function->function->name, file);
+                fputs(" [ label = \"<depends on ", file);
+                fputs(current_adj_function->type, file);
+                fputs(">\" ];\n", file);
 
-				current_adj_function = current_adj_function->next;
-			}
+                current_adj_function = current_adj_function->next;
+            }
 
-			current_function = current_function->next;
-		}
+            current_function = current_function->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
-	fputs("}", file);
+        current_xmachine = current_xmachine->next;
+    }
+    fputs("}", file);
 
-	/* Close the file */
-	fclose(file);
+    /* Close the file */
+    fclose(file);
 }
 
 /** \fn void printRule(rule_data * current_rule_data, FILE *file)
@@ -499,47 +487,41 @@ void printRule(rule_data * current_rule_data, FILE *file)
 {
     char buffer[1000];
 
-	/* If current_rule_data is NULL */
-	if(current_rule_data != NULL)
-	{
-		if(current_rule_data->not == 1) fputs("not ( ", file);
+    /* If current_rule_data is NULL */
+    if(current_rule_data != NULL) {
+        if(current_rule_data->not == 1) fputs("not ( ", file);
 
-		if(current_rule_data->time_rule == 1)
-		{
-			fputs("Periodicity: ", file);
-			fputs(current_rule_data->lhs, file);
-			fputs("\\nPhase: ", file);
-			fputs(current_rule_data->rhs, file);
-		}
-		/* If interaction radius */
-        else if(current_rule_data->box > 0)
-        {
+        if(current_rule_data->time_rule == 1) {
+            fputs("Periodicity: ", file);
+            fputs(current_rule_data->lhs, file);
+            fputs("\\nPhase: ", file);
+            fputs(current_rule_data->rhs, file);
+        }
+        /* If interaction radius */
+        else if(current_rule_data->box > 0) {
             fputs("Box", file);
             sprintf(buffer, "%d", current_rule_data->box);
             fputs(buffer, file);
             fputs("d: ", file);
             fputs(current_rule_data->lhs_print, file);
+        } else {
+            /* Handle values */
+            if(current_rule_data->lhs != NULL) fputs(current_rule_data->lhs_print, file);
+            else printRule(current_rule_data->lhs_rule, file);
+
+            if(current_rule_data->op != NULL) {
+                fputs(" ", file);
+                fputs(current_rule_data->op_print, file);
+                if(strcmp(current_rule_data->op, "&&") == 0 || strcmp(current_rule_data->op, "||") == 0) fputs("\\n", file);
+                else fputs(" ", file);
+            }
+
+            if(current_rule_data->rhs != NULL) fputs(current_rule_data->rhs_print, file);
+            else printRule(current_rule_data->rhs_rule, file);
         }
-		else
-		{
-			/* Handle values */
-			if(current_rule_data->lhs != NULL) fputs(current_rule_data->lhs_print, file);
-			else printRule(current_rule_data->lhs_rule, file);
 
-			if(current_rule_data->op != NULL)
-			{
-				fputs(" ", file);
-				fputs(current_rule_data->op_print, file);
-				if(strcmp(current_rule_data->op, "&&") == 0 || strcmp(current_rule_data->op, "||") == 0) fputs("\\n", file);
-				else fputs(" ", file);
-			}
-
-			if(current_rule_data->rhs != NULL) fputs(current_rule_data->rhs_print, file);
-			else printRule(current_rule_data->rhs_rule, file);
-		}
-
-		if(current_rule_data->not == 1) fputs(" )", file);
-	}
+        if(current_rule_data->not == 1) fputs(" )", file);
+    }
 }
 
 /** \fn void output_stategraph(char * filename, char * filepath, model_data * modeldata, int flag)
@@ -551,510 +533,478 @@ void printRule(rule_data * current_rule_data, FILE *file)
  */
 void output_stategraph(char * filename, char * filepath, model_data * modeldata, int flag)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	int i, j;
-
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_state * current_state;
-	xmachine_message * current_message;
-	xmachine_ioput * current_ioput;
-	sync * current_sync;
-	function_pointer * current_function_pointer;
-	//flame_communication * current_communication;
-
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
-
-	fputs("digraph state_graph {\n", file);
-	fputs("\trankdir=TB;\n", file);
-	fputs("\tsize=\"8,5;\"\n", file);
-	//fputs("\tnode [shape = rect];\n", file);
-
-	/* Invisible level nodes */
-	fputs("\t\n\t/* Layers */\n", file);
-	for(i = 0; i <= modeldata->layer_total; i++)
-	{
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		//fputs(" [style=invis, shape=point];\n", file);
-		fputs(" [shape=plaintext, label=\"layer ", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("\"];\n", file);
-		//fputs(";\n", file);
-
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_b", file);
-		fputs(" [style=invis, shape=point];\n", file);
-
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_a", file);
-		fputs(" [style=invis, shape=point];\n", file);
-
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_b", file);
-		fputs(" -> layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs(" [style=invis];\n", file);
-
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs(" -> layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_a", file);
-		fputs(" [style=invis];\n", file);
-
-		if(i != 0)
-		{
-			fputs("\tlayer_", file);
-			sprintf(buffer, "%d", i-1);
-			fputs(buffer, file);
-			fputs("_a -> layer_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs("_b [style=invis];\n", file);
-		}
-	}
-
-	fputs("\t\n\t/* States */\n", file);
-	/* For every state */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		current_state = current_xmachine->states;
-		while(current_state)
-		{
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_state->name, file);
-			fputs(" [label = \"", file);
-			fputs(current_state->name, file);
-			fputs("\"]\n", file);
-
-			current_state = current_state->next;
-		}
-
-		current_xmachine = current_xmachine->next;
-	}
-
-	/* For every function */
-	fputs("\t\n\t/* Functions */\n", file);
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" [label = \"", file);
-			fputs(current_function->name, file);
-			fputs("\", shape = rect]\n", file);
-
-			current_function = current_function->next;
-		}
-
-		current_xmachine = current_xmachine->next;
-	}
-
-	/* For each message type */
-	fputs("\t\n\t/* Message types */\n", file);
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		fputs("\t", file);
-		fputs(current_message->name, file);
-		fputs("_message", file);
-		fputs(" [ label = \"", file);
-		fputs(current_message->name, file);
-		//fputs("\\n", file);
-		//printRule(current_communication->filter_rule, file);
-		fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
-
-		i = 0;
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message", file);
-			fputs(" -> ", file);
-			fputs(current_message->name, file);
-			fputs("_message_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ color=\"#00ff00\" ];\n", file);
-
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ label = \"start ", file);
-			sprintf(buffer, "%d", current_sync->lastdepend->function->rank_in);
-			fputs(buffer, file);
-			fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
-
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" -> ", file);
-			fputs(current_message->name, file);
-			fputs("_message_end_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ color=\"#00ff00\" ];\n", file);
-
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_end_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ label = \"end ", file);
-			sprintf(buffer, "%d", current_sync->firstdependent->function->rank_in);
-			fputs(buffer, file);
-			fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
-
-			current_function_pointer = current_sync->inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
-
-				fputs("\t", file);
-				fputs(current_message->name, file);
-				fputs("_message_end_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(" -> ", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\" label = \"", file);
-			//	printRule(current_ioput->filter_rule, file);
-
-				current_ioput = current_function->inputs;
-				while(current_ioput)
-				{
-					if(strcmp(current_ioput->messagetype, current_message->name) == 0)
-					{
-						printRule(current_ioput->filter_rule, file);
-					}
-					/* Print if random */
-					if(current_ioput->random == 1) fputs("\\nrandom", file);
-					/* Print if sort */
-					if(current_ioput->sort_function != NULL)
-					{
-						fputs("\\nsort: ", file);
-						fputs(current_ioput->sort_function, file);
-					}
-
-					current_ioput = current_ioput->next;
-				}
-
-				fputs("\" ];\n", file);
-
-				current_function_pointer = current_function_pointer->next;
-			}
-
-			i++;
-
-			current_sync = current_sync->next;
-		}
-
-
-		current_message = current_message->next;
-	}
-
-	fputs("\t\n\t/* Transitions */\n", file);
-	/* For every transition */
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		if(flag == 0)
-		{
-			fputs("subgraph cluster_", file);
-			fputs(current_xmachine->name, file);
-			fputs(" {\n", file);
-			fputs("\tlabel = \"Agent ", file);
-			fputs(current_xmachine->name, file);
-			fputs("\";\n", file);
-		}
-
-		/* For each function */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs(" -> ", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			if(current_function->condition_function == NULL)
-			{
-				fputs(";\n", file);
-			}
-			else
-			{
-				fputs(" [ label = \"", file);
-				// TODO
-				//fputs(current_function->condition, file);
-				printRule(current_function->condition_rule, file);
-				fputs("\"];\n", file);
-			}
-
-
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" -> ", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(";\n", file);
-
-			current_function = current_function->next;
-		}
-
-		if(flag == 0)
-		{
-			fputs("}\n", file);
-		}
-
-		current_xmachine = current_xmachine->next;
-	}
-
-
-
-
-	fputs("\t\n\t/* Communications */\n", file);
-	/* For every communication */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			current_ioput = current_function->outputs;
-			while(current_ioput)
-			{
-				fputs("\t", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" -> ", file);
-				fputs(current_ioput->messagetype, file);
-				fputs("_message", file);
-				fputs(" [ color=\"#00ff00\" ];\n", file);
-
-				current_ioput = current_ioput->next;
-			}
-
-			/*current_ioput = current_function->inputs;
-			while(current_ioput)
-			{
-				fputs("\t", file);
-				fputs(current_ioput->messagetype, file);
-				fputs("_message", file);
-				fputs(" -> ", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\" label = \"", file);
-				printRule(current_ioput->filter_rule, file);
-				fputs("\" ];\n", file);
-
-				current_ioput = current_ioput->next;
-			}*/
-
-			current_function = current_function->next;
-		}
-
-		current_xmachine = current_xmachine->next;
-	}
-
-
-	/*current_communication = * modeldata->p_communications;
-	while(current_communication)
-	{
-		fputs("\t", file);
-		fputs(current_communication->output_function->agent_name, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->name, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->current_state, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->next_state, file);
-		fputs(" -> ", file);
-		fputs(current_communication->messagetype, file);
-		fputs("_message", file);
-		fputs(" [ color=\"#00ff00\" ];\n", file);
-
-		fputs("\t", file);
-		fputs(current_communication->messagetype, file);
-		fputs("_message", file);
-		fputs(" -> ", file);
-		fputs(current_communication->input_function->agent_name, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->name, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->current_state, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->next_state, file);
-		fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
-
-		current_communication = current_communication->next;
-	}*/
-
-	for(i = 0; i <= modeldata->layer_total; i++)
-	{
-		fputs("\t{ rank=same; layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("; ", file);
-
-		current_xmachine = * modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			// For each function
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				if(current_function->rank_in == i)
-				{
-					fputs(" ", file);
-					fputs(current_xmachine->name, file);
-					fputs("_", file);
-					fputs(current_function->name, file);
-					fputs("_", file);
-					fputs(current_function->current_state, file);
-					fputs("_", file);
-					fputs(current_function->next_state, file);
-					fputs("; ", file);
-				}
-
-				current_function = current_function->next;
-			}
-
-			current_xmachine = current_xmachine->next;
-		}
-
-		fputs("}\n", file);
-
-		fputs("\t{ rank=same; layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_b; ", file);
-		current_message = * modeldata->p_xmessages;
-		while(current_message)
-		{
-			j = 0;
-			current_sync = current_message->syncs;
-			while(current_sync)
-			{
-				if(i == current_sync->firstdependent->function->rank_in)
-				{
-					fputs(current_message->name, file);
-					fputs("_message_end_", file);
-					sprintf(buffer, "%d", j);
-					fputs(buffer, file);
-					fputs("; ", file);
-				}
-
-				j++;
-
-				current_sync = current_sync->next;
-			}
-
-			current_message = current_message->next;
-		}
-		fputs("}\n", file);
-
-		fputs("\t{ rank=same; layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("_a; ", file);
-		current_message = * modeldata->p_xmessages;
-		while(current_message)
-		{
-			j = 0;
-			current_sync = current_message->syncs;
-			while(current_sync)
-			{
-				if(i == current_sync->lastdepend->function->rank_in)
-				{
-					fputs(current_message->name, file);
-					fputs("_message_start_", file);
-					sprintf(buffer, "%d", j);
-					fputs(buffer, file);
-					fputs("; ", file);
-				}
-
-				j++;
-
-				current_sync = current_sync->next;
-			}
-
-			current_message = current_message->next;
-		}
-		fputs("}\n", file);
-
-	}
-	fputs("}", file);
-
-	/* Close the file */
-	fclose(file);
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
+    int i, j;
+
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_state * current_state;
+    xmachine_message * current_message;
+    xmachine_ioput * current_ioput;
+    sync * current_sync;
+    function_pointer * current_function_pointer;
+    //flame_communication * current_communication;
+
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
+
+    fputs("digraph state_graph {\n", file);
+    fputs("\trankdir=TB;\n", file);
+    fputs("\tsize=\"8,5;\"\n", file);
+    //fputs("\tnode [shape = rect];\n", file);
+
+    /* Invisible level nodes */
+    fputs("\t\n\t/* Layers */\n", file);
+    for(i = 0; i <= modeldata->layer_total; i++) {
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        //fputs(" [style=invis, shape=point];\n", file);
+        fputs(" [shape=plaintext, label=\"layer ", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("\"];\n", file);
+        //fputs(";\n", file);
+
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_b", file);
+        fputs(" [style=invis, shape=point];\n", file);
+
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_a", file);
+        fputs(" [style=invis, shape=point];\n", file);
+
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_b", file);
+        fputs(" -> layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs(" [style=invis];\n", file);
+
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs(" -> layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_a", file);
+        fputs(" [style=invis];\n", file);
+
+        if(i != 0) {
+            fputs("\tlayer_", file);
+            sprintf(buffer, "%d", i-1);
+            fputs(buffer, file);
+            fputs("_a -> layer_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs("_b [style=invis];\n", file);
+        }
+    }
+
+    fputs("\t\n\t/* States */\n", file);
+    /* For every state */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        current_state = current_xmachine->states;
+        while(current_state) {
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_state->name, file);
+            fputs(" [label = \"", file);
+            fputs(current_state->name, file);
+            fputs("\"]\n", file);
+
+            current_state = current_state->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+    /* For every function */
+    fputs("\t\n\t/* Functions */\n", file);
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" [label = \"", file);
+            fputs(current_function->name, file);
+            fputs("\", shape = rect]\n", file);
+
+            current_function = current_function->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+    /* For each message type */
+    fputs("\t\n\t/* Message types */\n", file);
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        fputs("\t", file);
+        fputs(current_message->name, file);
+        fputs("_message", file);
+        fputs(" [ label = \"", file);
+        fputs(current_message->name, file);
+        //fputs("\\n", file);
+        //printRule(current_communication->filter_rule, file);
+        fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+
+        i = 0;
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message", file);
+            fputs(" -> ", file);
+            fputs(current_message->name, file);
+            fputs("_message_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ color=\"#00ff00\" ];\n", file);
+
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ label = \"start ", file);
+            sprintf(buffer, "%d", current_sync->lastdepend->function->rank_in);
+            fputs(buffer, file);
+            fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" -> ", file);
+            fputs(current_message->name, file);
+            fputs("_message_end_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ color=\"#00ff00\" ];\n", file);
+
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_end_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ label = \"end ", file);
+            sprintf(buffer, "%d", current_sync->firstdependent->function->rank_in);
+            fputs(buffer, file);
+            fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+
+            current_function_pointer = current_sync->inputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
+
+                fputs("\t", file);
+                fputs(current_message->name, file);
+                fputs("_message_end_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(" -> ", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" [ color=\"#00ff00\" label = \"", file);
+                //	printRule(current_ioput->filter_rule, file);
+
+                current_ioput = current_function->inputs;
+                while(current_ioput) {
+                    if(strcmp(current_ioput->messagetype, current_message->name) == 0) {
+                        printRule(current_ioput->filter_rule, file);
+                    }
+                    /* Print if random */
+                    if(current_ioput->random == 1) fputs("\\nrandom", file);
+                    /* Print if sort */
+                    if(current_ioput->sort_function != NULL) {
+                        fputs("\\nsort: ", file);
+                        fputs(current_ioput->sort_function, file);
+                    }
+
+                    current_ioput = current_ioput->next;
+                }
+
+                fputs("\" ];\n", file);
+
+                current_function_pointer = current_function_pointer->next;
+            }
+
+            i++;
+
+            current_sync = current_sync->next;
+        }
+
+
+        current_message = current_message->next;
+    }
+
+    fputs("\t\n\t/* Transitions */\n", file);
+    /* For every transition */
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        if(flag == 0) {
+            fputs("subgraph cluster_", file);
+            fputs(current_xmachine->name, file);
+            fputs(" {\n", file);
+            fputs("\tlabel = \"Agent ", file);
+            fputs(current_xmachine->name, file);
+            fputs("\";\n", file);
+        }
+
+        /* For each function */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs(" -> ", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            if(current_function->condition_function == NULL) {
+                fputs(";\n", file);
+            } else {
+                fputs(" [ label = \"", file);
+                // TODO
+                //fputs(current_function->condition, file);
+                printRule(current_function->condition_rule, file);
+                fputs("\"];\n", file);
+            }
+
+
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" -> ", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(";\n", file);
+
+            current_function = current_function->next;
+        }
+
+        if(flag == 0) {
+            fputs("}\n", file);
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+
+
+
+    fputs("\t\n\t/* Communications */\n", file);
+    /* For every communication */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            current_ioput = current_function->outputs;
+            while(current_ioput) {
+                fputs("\t", file);
+                fputs(current_xmachine->name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" -> ", file);
+                fputs(current_ioput->messagetype, file);
+                fputs("_message", file);
+                fputs(" [ color=\"#00ff00\" ];\n", file);
+
+                current_ioput = current_ioput->next;
+            }
+
+            /*current_ioput = current_function->inputs;
+            while(current_ioput)
+            {
+            	fputs("\t", file);
+            	fputs(current_ioput->messagetype, file);
+            	fputs("_message", file);
+            	fputs(" -> ", file);
+            	fputs(current_xmachine->name, file);
+            	fputs("_", file);
+            	fputs(current_function->name, file);
+            	fputs("_", file);
+            	fputs(current_function->current_state, file);
+            	fputs("_", file);
+            	fputs(current_function->next_state, file);
+            	fputs(" [ color=\"#00ff00\" label = \"", file);
+            	printRule(current_ioput->filter_rule, file);
+            	fputs("\" ];\n", file);
+
+            	current_ioput = current_ioput->next;
+            }*/
+
+            current_function = current_function->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+
+    /*current_communication = * modeldata->p_communications;
+    while(current_communication)
+    {
+    	fputs("\t", file);
+    	fputs(current_communication->output_function->agent_name, file);
+    	fputs("_", file);
+    	fputs(current_communication->output_function->name, file);
+    	fputs("_", file);
+    	fputs(current_communication->output_function->current_state, file);
+    	fputs("_", file);
+    	fputs(current_communication->output_function->next_state, file);
+    	fputs(" -> ", file);
+    	fputs(current_communication->messagetype, file);
+    	fputs("_message", file);
+    	fputs(" [ color=\"#00ff00\" ];\n", file);
+
+    	fputs("\t", file);
+    	fputs(current_communication->messagetype, file);
+    	fputs("_message", file);
+    	fputs(" -> ", file);
+    	fputs(current_communication->input_function->agent_name, file);
+    	fputs("_", file);
+    	fputs(current_communication->input_function->name, file);
+    	fputs("_", file);
+    	fputs(current_communication->input_function->current_state, file);
+    	fputs("_", file);
+    	fputs(current_communication->input_function->next_state, file);
+    	fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
+
+    	current_communication = current_communication->next;
+    }*/
+
+    for(i = 0; i <= modeldata->layer_total; i++) {
+        fputs("\t{ rank=same; layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("; ", file);
+
+        current_xmachine = * modeldata->p_xmachines;
+        while(current_xmachine) {
+            // For each function
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                if(current_function->rank_in == i) {
+                    fputs(" ", file);
+                    fputs(current_xmachine->name, file);
+                    fputs("_", file);
+                    fputs(current_function->name, file);
+                    fputs("_", file);
+                    fputs(current_function->current_state, file);
+                    fputs("_", file);
+                    fputs(current_function->next_state, file);
+                    fputs("; ", file);
+                }
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+
+        fputs("}\n", file);
+
+        fputs("\t{ rank=same; layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_b; ", file);
+        current_message = * modeldata->p_xmessages;
+        while(current_message) {
+            j = 0;
+            current_sync = current_message->syncs;
+            while(current_sync) {
+                if(i == current_sync->firstdependent->function->rank_in) {
+                    fputs(current_message->name, file);
+                    fputs("_message_end_", file);
+                    sprintf(buffer, "%d", j);
+                    fputs(buffer, file);
+                    fputs("; ", file);
+                }
+
+                j++;
+
+                current_sync = current_sync->next;
+            }
+
+            current_message = current_message->next;
+        }
+        fputs("}\n", file);
+
+        fputs("\t{ rank=same; layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("_a; ", file);
+        current_message = * modeldata->p_xmessages;
+        while(current_message) {
+            j = 0;
+            current_sync = current_message->syncs;
+            while(current_sync) {
+                if(i == current_sync->lastdepend->function->rank_in) {
+                    fputs(current_message->name, file);
+                    fputs("_message_start_", file);
+                    sprintf(buffer, "%d", j);
+                    fputs(buffer, file);
+                    fputs("; ", file);
+                }
+
+                j++;
+
+                current_sync = current_sync->next;
+            }
+
+            current_message = current_message->next;
+        }
+        fputs("}\n", file);
+
+    }
+    fputs("}", file);
+
+    /* Close the file */
+    fclose(file);
 }
 
 /** \fn void output_communication_graph(char * filename, char * filepath, model_data * modeldata)
@@ -1065,898 +1015,847 @@ void output_stategraph(char * filename, char * filepath, model_data * modeldata,
  */
 void output_communication_graph(char * filename, char * filepath, model_data * modeldata)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	int count, flag;
-	xmachine * current_xmachine;
-	xmachine * current_xmachine2;
-	flame_communication * current_communication;
-	//xmachine_function * current_function;
-	//adj_function * current_adj_function;
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
+    int count, flag;
+    xmachine * current_xmachine;
+    xmachine * current_xmachine2;
+    flame_communication * current_communication;
+    //xmachine_function * current_function;
+    //adj_function * current_adj_function;
 
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
 
-	fputs("/* circo -Tps communication_graph.dot -o communication_graph.ps */\n", file);
-	fputs("graph communication_graph {\n", file);
-	fputs("\trankdir=BT;\n", file);
-	fputs("\tsize=\"8,5;\"\n", file);
-	//fputs("\tnode [shape = rect];\n", file);
+    fputs("/* circo -Tps communication_graph.dot -o communication_graph.ps */\n", file);
+    fputs("graph communication_graph {\n", file);
+    fputs("\trankdir=BT;\n", file);
+    fputs("\tsize=\"8,5;\"\n", file);
+    //fputs("\tnode [shape = rect];\n", file);
 
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		fputs("\t", file);
-		fputs(current_xmachine->name, file);
-		fputs("_agent [label = \"", file);
-		fputs(current_xmachine->name, file);
-		fputs("\"]\n", file);
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        fputs("\t", file);
+        fputs(current_xmachine->name, file);
+        fputs("_agent [label = \"", file);
+        fputs(current_xmachine->name, file);
+        fputs("\"]\n", file);
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 
-	/* For every agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		flag = 0;
-		/* Count communication with other agent types */
-		current_xmachine2 = * modeldata->p_xmachines;
-		while(current_xmachine2)
-		{
-			if(current_xmachine == current_xmachine2) flag = 1;
+    /* For every agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        flag = 0;
+        /* Count communication with other agent types */
+        current_xmachine2 = * modeldata->p_xmachines;
+        while(current_xmachine2) {
+            if(current_xmachine == current_xmachine2) flag = 1;
 
-			if(flag == 1)
-			{
-				count = 0;
-				current_communication = * modeldata->p_communications;
-				while(current_communication)
-				{
-					if( strcmp(current_communication->output_function->agent_name, current_xmachine->name) == 0 &&
-						strcmp(current_communication->input_function->agent_name, current_xmachine2->name) == 0	)
-					{ count++; }
+            if(flag == 1) {
+                count = 0;
+                current_communication = * modeldata->p_communications;
+                while(current_communication) {
+                    if( strcmp(current_communication->output_function->agent_name, current_xmachine->name) == 0 &&
+                            strcmp(current_communication->input_function->agent_name, current_xmachine2->name) == 0	) {
+                        count++;
+                    }
 
-					if( strcmp(current_communication->output_function->agent_name, current_xmachine2->name) == 0 &&
-						strcmp(current_communication->input_function->agent_name, current_xmachine->name) == 0	)
-					{ count++; }
+                    if( strcmp(current_communication->output_function->agent_name, current_xmachine2->name) == 0 &&
+                            strcmp(current_communication->input_function->agent_name, current_xmachine->name) == 0	) {
+                        count++;
+                    }
 
-					current_communication = current_communication->next;
-				}
-				if(count > 0)
-				{
-					fputs(current_xmachine->name, file);
-					fputs("_agent -- ", file);
-					fputs(current_xmachine2->name, file);
-					fputs("_agent [ style=\"setlinewidth(", file);
-					sprintf(buffer, "%d", count);
-					fputs(buffer, file);
-					fputs(")\" weight=", file);
-					sprintf(buffer, "%d", count);
-					fputs(buffer, file);
-					fputs(" color=\"#00ff00\" ];\n", file);
-				}
-			}
-			current_xmachine2 = current_xmachine2->next;
-		}
+                    current_communication = current_communication->next;
+                }
+                if(count > 0) {
+                    fputs(current_xmachine->name, file);
+                    fputs("_agent -- ", file);
+                    fputs(current_xmachine2->name, file);
+                    fputs("_agent [ style=\"setlinewidth(", file);
+                    sprintf(buffer, "%d", count);
+                    fputs(buffer, file);
+                    fputs(")\" weight=", file);
+                    sprintf(buffer, "%d", count);
+                    fputs(buffer, file);
+                    fputs(" color=\"#00ff00\" ];\n", file);
+                }
+            }
+            current_xmachine2 = current_xmachine2->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 
-	current_communication = * modeldata->p_communications;
-	while(current_communication)
-	{
-		/*fputs("\t", file);
-		fputs(current_communication->output_function->agent_name, file);
-		fputs("_agent -> ", file);
-		fputs(current_communication->input_function->agent_name, file);
-		fputs("_agent [ label = \"", file);
-		fputs(current_communication->messagetype, file);
-		fputs("\" color=\"#00ff00\" ];\n", file);
-		*/
+    current_communication = * modeldata->p_communications;
+    while(current_communication) {
+        /*fputs("\t", file);
+        fputs(current_communication->output_function->agent_name, file);
+        fputs("_agent -> ", file);
+        fputs(current_communication->input_function->agent_name, file);
+        fputs("_agent [ label = \"", file);
+        fputs(current_communication->messagetype, file);
+        fputs("\" color=\"#00ff00\" ];\n", file);
+        */
 
-		current_communication = current_communication->next;
-	}
+        current_communication = current_communication->next;
+    }
 
-	fputs("}", file);
+    fputs("}", file);
 
-	/* Close the file */
-	fclose(file);
+    /* Close the file */
+    fclose(file);
 }
 
 void output_process_order_graph(char * filename, char * filepath, model_data * modeldata)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	int i;
-	xmachine * current_xmachine;
-	//xmachine * current_xmachine2;
-	//flame_communication * current_communication;
-	xmachine_function * current_function;
-	xmachine_function * last_function;
-	//adj_function * current_adj_function;
-	xmachine_message * current_message;
-	xmachine_ioput * current_ioput;
-	function_pointer * current_function_pointer;
-	layer * current_layer;
-	sync * current_sync;
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
+    int i;
+    xmachine * current_xmachine;
+    //xmachine * current_xmachine2;
+    //flame_communication * current_communication;
+    xmachine_function * current_function;
+    xmachine_function * last_function;
+    //adj_function * current_adj_function;
+    xmachine_message * current_message;
+    xmachine_ioput * current_ioput;
+    function_pointer * current_function_pointer;
+    layer * current_layer;
+    sync * current_sync;
 
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
 
-	fputs("digraph communication_graph {\n", file);
-	fputs("\trankdir=BT;\n", file);
-	fputs("\tsize=\"8,5;\"\n", file);
+    fputs("digraph communication_graph {\n", file);
+    fputs("\trankdir=BT;\n", file);
+    fputs("\tsize=\"8,5;\"\n", file);
 
-	i = 0;
-	current_layer = * modeldata->p_layers;
-	while(current_layer)
-	{
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs(" [ color=\"#ff0000\" label=\"layer ", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("\"];\n", file);
+    i = 0;
+    current_layer = * modeldata->p_layers;
+    while(current_layer) {
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs(" [ color=\"#ff0000\" label=\"layer ", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("\"];\n", file);
 
-		if(i > 0)
-		{
-			fputs("\tlayer_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" ->", file);
-			fputs(last_function->agent_name, file);
-			fputs("_", file);
-			fputs(last_function->name, file);
-			fputs("_", file);
-			fputs(last_function->current_state, file);
-			fputs("_", file);
-			fputs(last_function->next_state, file);
-			fputs(";\n", file);
-		}
+        if(i > 0) {
+            fputs("\tlayer_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" ->", file);
+            fputs(last_function->agent_name, file);
+            fputs("_", file);
+            fputs(last_function->name, file);
+            fputs("_", file);
+            fputs(last_function->current_state, file);
+            fputs("_", file);
+            fputs(last_function->next_state, file);
+            fputs(";\n", file);
+        }
 
-		current_function_pointer = current_layer->functions;
-		while(current_function_pointer)
-		{
-			current_function = current_function_pointer->function;
+        current_function_pointer = current_layer->functions;
+        while(current_function_pointer) {
+            current_function = current_function_pointer->function;
 
-			fputs("\t", file);
-			fputs(current_function->agent_name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" [ shape = rect label=\"", file);
-			fputs(current_function->agent_name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" [", file);
-			sprintf(buffer, "%d", current_function->score);
-			fputs(buffer, file);
-			fputs("]\" ];\n", file);
+            fputs("\t", file);
+            fputs(current_function->agent_name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" [ shape = rect label=\"", file);
+            fputs(current_function->agent_name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" [", file);
+            sprintf(buffer, "%d", current_function->score);
+            fputs(buffer, file);
+            fputs("]\" ];\n", file);
 
-			if(current_function_pointer == current_layer->functions)
-			{
-				fputs("\t", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" -> layer_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(";\n", file);
-			}
-			else
-			{
-				fputs("\t", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" -> ", file);
-				fputs(last_function->agent_name, file);
-				fputs("_", file);
-				fputs(last_function->name, file);
-				fputs("_", file);
-				fputs(last_function->current_state, file);
-				fputs("_", file);
-				fputs(last_function->next_state, file);
-				fputs(";\n", file);
-			}
+            if(current_function_pointer == current_layer->functions) {
+                fputs("\t", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" -> layer_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(";\n", file);
+            } else {
+                fputs("\t", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" -> ", file);
+                fputs(last_function->agent_name, file);
+                fputs("_", file);
+                fputs(last_function->name, file);
+                fputs("_", file);
+                fputs(last_function->current_state, file);
+                fputs("_", file);
+                fputs(last_function->next_state, file);
+                fputs(";\n", file);
+            }
 
-			last_function = current_function;
-			current_function_pointer = current_function_pointer->next;
-		}
+            last_function = current_function;
+            current_function_pointer = current_function_pointer->next;
+        }
 
-		i++;
-		current_layer = current_layer->next;
-	}
+        i++;
+        current_layer = current_layer->next;
+    }
 
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		fputs("\t", file);
-		fputs(current_message->name, file);
-		fputs("_message", file);
-		fputs(" [ label = \"", file);
-		fputs(current_message->name, file);
-		//fputs("\\n", file);
-		//printRule(current_communication->filter_rule, file);
-		fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        fputs("\t", file);
+        fputs(current_message->name, file);
+        fputs("_message", file);
+        fputs(" [ label = \"", file);
+        fputs(current_message->name, file);
+        //fputs("\\n", file);
+        //printRule(current_communication->filter_rule, file);
+        fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
 
-		/*if(current_message->last != NULL)
-		{
-			fputs("\t{ rank=same; layer_", file);
-			sprintf(buffer, "%d", current_message->last->rank_in + 1);
-			fputs(buffer, file);
-			fputs("; ", file);
-			fputs(current_message->name, file);
-			fputs("_message; }\n", file);
-		}*/
+        /*if(current_message->last != NULL)
+        {
+        	fputs("\t{ rank=same; layer_", file);
+        	sprintf(buffer, "%d", current_message->last->rank_in + 1);
+        	fputs(buffer, file);
+        	fputs("; ", file);
+        	fputs(current_message->name, file);
+        	fputs("_message; }\n", file);
+        }*/
 
-		i = 0;
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
+        i = 0;
+        current_sync = current_message->syncs;
+        while(current_sync) {
 
 
-			//total += ( first_dependent_index - current_sync->depends->function->index );
+            //total += ( first_dependent_index - current_sync->depends->function->index );
 
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ label = \"start", file);
-			fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ label = \"start", file);
+            fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
 
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" -> ", file);
-			fputs(current_message->name, file);
-			fputs("_message [ color=\"#00ff00\" label=\"", file);
-			fputs(current_sync->name, file);
-			if(current_sync->has_agent_and_message_vars) fputs(" (F)", file);
-			fputs("\"];\n", file);
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" -> ", file);
+            fputs(current_message->name, file);
+            fputs("_message [ color=\"#00ff00\" label=\"", file);
+            fputs(current_sync->name, file);
+            if(current_sync->has_agent_and_message_vars) fputs(" (F)", file);
+            fputs("\"];\n", file);
 
-			fputs("\t{ rank=same; ", file);
-			fputs(current_sync->lastdepend->function->agent_name, file);
-			fputs("_", file);
-			fputs(current_sync->lastdepend->function->name, file);
-			fputs("_", file);
-			fputs(current_sync->lastdepend->function->current_state, file);
-			fputs("_", file);
-			fputs(current_sync->lastdepend->function->next_state, file);
-			fputs("; ", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs("; }\n", file);
+            fputs("\t{ rank=same; ", file);
+            fputs(current_sync->lastdepend->function->agent_name, file);
+            fputs("_", file);
+            fputs(current_sync->lastdepend->function->name, file);
+            fputs("_", file);
+            fputs(current_sync->lastdepend->function->current_state, file);
+            fputs("_", file);
+            fputs(current_sync->lastdepend->function->next_state, file);
+            fputs("; ", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs("; }\n", file);
 
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_end_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ label = \"end", file);
-			fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_end_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ label = \"end", file);
+            fputs("\" color=\"#00ff00\" shape = parallelogram];\n", file);
 
-			fputs("\t", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_end_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" -> ", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_start_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [ color=\"#00ff00\" ];\n", file);
+            fputs("\t", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_end_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" -> ", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_start_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [ color=\"#00ff00\" ];\n", file);
 
-			current_function_pointer = current_sync->inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+            current_function_pointer = current_sync->inputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				fputs("\t", file);
-				fputs(current_message->name, file);
-				fputs("_message_sync_end_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(" -> ", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
+                fputs("\t", file);
+                fputs(current_message->name, file);
+                fputs("_message_sync_end_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(" -> ", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-			current_function_pointer = current_sync->outputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+            current_function_pointer = current_sync->outputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				fputs("\t", file);
-				fputs(current_message->name, file);
-				fputs("_message_sync_start_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(" -> ", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
+                fputs("\t", file);
+                fputs(current_message->name, file);
+                fputs("_message_sync_start_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(" -> ", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
 
-				current_function_pointer = current_function_pointer->next;
-			}
-			current_function_pointer = current_sync->filter_variable_changing_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+                current_function_pointer = current_function_pointer->next;
+            }
+            current_function_pointer = current_sync->filter_variable_changing_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				fputs("\t", file);
-				fputs(current_message->name, file);
-				fputs("_message_sync_start_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(" -> ", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
+                fputs("\t", file);
+                fputs(current_message->name, file);
+                fputs("_message_sync_start_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(" -> ", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
 
-				current_function_pointer = current_function_pointer->next;
-			}
-			current_function_pointer = current_sync->previous_sync_inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+                current_function_pointer = current_function_pointer->next;
+            }
+            current_function_pointer = current_sync->previous_sync_inputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				fputs("\t", file);
-				fputs(current_message->name, file);
-				fputs("_message_sync_start_", file);
-				sprintf(buffer, "%d", i);
-				fputs(buffer, file);
-				fputs(" -> ", file);
-				fputs(current_function->agent_name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
+                fputs("\t", file);
+                fputs(current_message->name, file);
+                fputs("_message_sync_start_", file);
+                sprintf(buffer, "%d", i);
+                fputs(buffer, file);
+                fputs(" -> ", file);
+                fputs(current_function->agent_name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" [ color=\"#00ff00\", constraint=false, style=dashed ];\n", file);
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-			fputs("\t{ rank=same; ", file);
-			fputs(current_sync->firstdependent->function->agent_name, file);
-			fputs("_", file);
-			fputs(current_sync->firstdependent->function->name, file);
-			fputs("_", file);
-			fputs(current_sync->firstdependent->function->current_state, file);
-			fputs("_", file);
-			fputs(current_sync->firstdependent->function->next_state, file);
-			fputs("; ", file);
-			fputs(current_message->name, file);
-			fputs("_message_sync_end_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs("; }\n", file);
+            fputs("\t{ rank=same; ", file);
+            fputs(current_sync->firstdependent->function->agent_name, file);
+            fputs("_", file);
+            fputs(current_sync->firstdependent->function->name, file);
+            fputs("_", file);
+            fputs(current_sync->firstdependent->function->current_state, file);
+            fputs("_", file);
+            fputs(current_sync->firstdependent->function->next_state, file);
+            fputs("; ", file);
+            fputs(current_message->name, file);
+            fputs("_message_sync_end_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs("; }\n", file);
 
-			i++;
-			current_sync = current_sync->next;
-		}
+            i++;
+            current_sync = current_sync->next;
+        }
 
-		current_message = current_message->next;
-	}
+        current_message = current_message->next;
+    }
 
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		// For each function
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			current_ioput = current_function->outputs;
-			while(current_ioput)
-			{
-				fputs("\t", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" -> ", file);
-				fputs(current_ioput->messagetype, file);
-				fputs("_message", file);
-				fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        // For each function
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            current_ioput = current_function->outputs;
+            while(current_ioput) {
+                fputs("\t", file);
+                fputs(current_xmachine->name, file);
+                fputs("_", file);
+                fputs(current_function->name, file);
+                fputs("_", file);
+                fputs(current_function->current_state, file);
+                fputs("_", file);
+                fputs(current_function->next_state, file);
+                fputs(" -> ", file);
+                fputs(current_ioput->messagetype, file);
+                fputs("_message", file);
+                fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
 
-				current_ioput = current_ioput->next;
-			}
+                current_ioput = current_ioput->next;
+            }
 
-			/*current_ioput = current_function->inputs;
-			while(current_ioput)
-			{
-				fputs("\t", file);
-				fputs(current_ioput->messagetype, file);
-				fputs("_message", file);
-				fputs(" -> ", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_function->name, file);
-				fputs("_", file);
-				fputs(current_function->current_state, file);
-				fputs("_", file);
-				fputs(current_function->next_state, file);
-				fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
+            /*current_ioput = current_function->inputs;
+            while(current_ioput)
+            {
+            	fputs("\t", file);
+            	fputs(current_ioput->messagetype, file);
+            	fputs("_message", file);
+            	fputs(" -> ", file);
+            	fputs(current_xmachine->name, file);
+            	fputs("_", file);
+            	fputs(current_function->name, file);
+            	fputs("_", file);
+            	fputs(current_function->current_state, file);
+            	fputs("_", file);
+            	fputs(current_function->next_state, file);
+            	fputs(" [ color=\"#00ff00\" constraint=false ];\n", file);
 
-				current_ioput = current_ioput->next;
-			}*/
+            	current_ioput = current_ioput->next;
+            }*/
 
-			current_function = current_function->next;
-		}
+            current_function = current_function->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 
-	fputs("}", file);
+    fputs("}", file);
 
-	/* Close the file */
-	fclose(file);
+    /* Close the file */
+    fclose(file);
 }
 
 
 void output_stategraph_colour(char * filename, char * filepath, model_data * modeldata, int flag)
 {
-	/* File to write to */
-	FILE *file;
-	/* Buffer for concatenating strings */
-	char buffer[1000];
-	int i;
-	int counter_colour=0;
-	int counter_colour_2=0;
-	/*int display_colour=0;*/
-	int model_display_colour=0;
-	int length_colour_int=0;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_state * current_state;
-	flame_communication * current_communication;
+    /* File to write to */
+    FILE *file;
+    /* Buffer for concatenating strings */
+    char buffer[1000];
+    int i;
+    int counter_colour=0;
+    int counter_colour_2=0;
+    /*int display_colour=0;*/
+    int model_display_colour=0;
+    int length_colour_int=0;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_state * current_state;
+    flame_communication * current_communication;
 
-	model_colour *p_model_colours=NULL;
-	agent_colour *p_agent_colours=NULL;
-	//agent_colour *agent_colour_tail=NULL;
-	
-	//agent_colour *temp_agent_colour;
-	
-	
-	//model_colour *temp_model_colour;
-	
-	/* place in 'data' the file to write to */
-	sprintf(buffer, "%s%s", filepath, filename);
-	/* print out the location of the source file */
-	printf("Writing file : %s\n", buffer);
-	/* open the file to write to */
-	file = fopen(buffer, "w");
+    model_colour *p_model_colours=NULL;
+    agent_colour *p_agent_colours=NULL;
+    //agent_colour *agent_colour_tail=NULL;
 
-	fputs("digraph state_graph {\n", file);
-	fputs("\trankdir=TB;\n", file);
-	fputs("\tsize=\"8,5;\"\n", file);
-	//fputs("\tnode [shape = rect];\n", file);
-
-	/* Invisible level nodes */
-	for(i = 0; i <= modeldata->layer_total; i++)
-	{
-		fputs("\tlayer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		//fputs(" [style=invis, shape=point];\n", file);
-		fputs(" [shape=plaintext, label=\"layer ", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("\"];\n", file);
-		//fputs(";\n", file);
-
-		if(i != 0)
-		{
-			fputs("\tlayer_", file);
-			sprintf(buffer, "%d", i-1);
-			fputs(buffer, file);
-			fputs(" -> layer_", file);
-			sprintf(buffer, "%d", i);
-			fputs(buffer, file);
-			fputs(" [style=invis];\n", file);
-		}
-	}
-
-	fputs("\t\n\t/* States */\n", file);
-	/* For every state */
-	current_xmachine = * modeldata->p_xmachines;
-	
-	counter_colour=-1;
-	while(current_xmachine)
-	{
-		counter_colour++;
-		if(counter_colour>=15)//more than 16 agents
-		{
-			counter_colour=0;
-		}
-		current_state = current_xmachine->states;
-		while(current_state)
-		{
-			//assign colour to start state
-		/*	if(current_state==current_xmachine->start_state)
-			{//fputs("\", color=green]; \n", file);
-				
-				fputs("\t", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_state->name, file);
-				fputs(" [label = \"", file);
-				fputs(current_state->name, file);
-				fputs("\", color=",file);
-				fputs(colour_map[counter_colour],file);
-				fputs("]; \n", file);
-				//printf("M:%s - %s - colour %s \n", current_xmachine->name, current_state->name, colour_map[counter_colour]);
-				//printf("M3 %s",current_xmachine->number);
-				//add the colour map linked list here
-				//if((temp_agent_colour=malloc(sizeof(agent_colour)))==NULL)
-				//{					
-				//	add_agent_colours(p_agent_colours, current_xmachine->name, counter_colour);
-				//}
-				addagent_colour(&p_agent_colours,current_xmachine->name,counter_colour);
-				
-			}
-			//else print normal state colour
-			else
-			{ 
-				fputs("\t", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_state->name, file);
-				fputs(" [label = \"", file);
-				fputs(current_state->name, file);
-				fputs("\"]\n", file);
-			}*/
-				fputs("\t", file);
-				fputs(current_xmachine->name, file);
-				fputs("_", file);
-				fputs(current_state->name, file);
-				fputs(" [label = \"", file);
-				fputs(current_state->name, file);
-				fputs("\"]\n", file);
-			current_state = current_state->next;
-		}
-		
-		current_xmachine = current_xmachine->next;
-	}
-	/* For every function */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		counter_colour_2=-1;
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			counter_colour_2++;
-			if(counter_colour_2>=15) 
-				counter_colour_2=0;
-			//printf("Length of linked list is %d \n",length_colour(&p_model_colours));
-			length_colour_int=length_colour(&p_model_colours);
-			addmodel_colour(&p_model_colours,current_function->file,length_colour_int);
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" [label = \"", file);
-			fputs(current_function->name, file);
-			//fputs("\", shape = rect]\n", file);
-			//printf("^^^^^ Function %s in file %s\n",current_function->name, current_function->file );
-			fputs("\", shape = box,style=filled,color=",file);
-			model_display_colour=displaymodel_colour(&p_model_colours,current_function->file);
-			fputs(colour_map_light[model_display_colour],file);
-			fputs("];\n", file);
-			//printout colours somewhere
-			
-			
-			current_function = current_function->next;
-		}
-
-		current_xmachine = current_xmachine->next;
-	}
-	fputs("\t\n\t/* Transitions */\n", file);
-	/* For every transition */
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		if(flag == 0)
-		{
-			fputs("subgraph cluster_", file);
-			fputs(current_xmachine->name, file);
-			fputs(" {\n", file);
-			fputs("\tlabel = \"Agent ", file);
-			fputs(current_xmachine->name, file);
-			fputs("\";\n", file);
-		}
-
-		/* For each function */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs(" -> ", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			if(current_function->condition_function == NULL)
-			{
-				fputs(";\n", file);
-			}
-			else
-			{
-				fputs(" [ label = \"", file);
-				// TODO
-				//fputs(current_function->condition, file);
-				printRule(current_function->condition_rule, file);
-				fputs("\"];\n", file);
-			}
+    //agent_colour *temp_agent_colour;
 
 
-			fputs("\t", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->name, file);
-			fputs("_", file);
-			fputs(current_function->current_state, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(" -> ", file);
-			fputs(current_xmachine->name, file);
-			fputs("_", file);
-			fputs(current_function->next_state, file);
-			fputs(";\n", file);
+    //model_colour *temp_model_colour;
 
-			current_function = current_function->next;
-		}
+    /* place in 'data' the file to write to */
+    sprintf(buffer, "%s%s", filepath, filename);
+    /* print out the location of the source file */
+    printf("Writing file : %s\n", buffer);
+    /* open the file to write to */
+    file = fopen(buffer, "w");
 
-		if(flag == 0)
-		{
-			fputs("}\n", file);
-		}
+    fputs("digraph state_graph {\n", file);
+    fputs("\trankdir=TB;\n", file);
+    fputs("\tsize=\"8,5;\"\n", file);
+    //fputs("\tnode [shape = rect];\n", file);
 
-		current_xmachine = current_xmachine->next;
-	}
-	fputs("\t\n\t/* Communications */\n", file);
-	/* For every communication */
-	current_communication = * modeldata->p_communications;
-	while(current_communication)
-	{
-		fputs("\t", file);
-		fputs(current_communication->output_function->agent_name, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->name, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->current_state, file);
-		fputs("_", file);
-		fputs(current_communication->output_function->next_state, file);
-		fputs(" -> ", file);
-		fputs(current_communication->input_function->agent_name, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->name, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->current_state, file);
-		fputs("_", file);
-		fputs(current_communication->input_function->next_state, file);
-		fputs(" [ label = \"", file);
-		fputs(current_communication->messagetype, file);
-		fputs("\" color=\"#00ff00\" constraint=false];\n", file);
-		
-		//display_colour=displayagent_colour(&p_agent_colours,current_communication->output_function->agent_name);
-		//printf("colousr111111111 %s ", colour_map[display_colour]);
-		current_communication = current_communication->next;
-		//fputs("\" color=",file);
-		//fputs(colour_map[display_colour],file);
-		//fputs(" constraint=false];\n", file);
-	}
+    /* Invisible level nodes */
+    for(i = 0; i <= modeldata->layer_total; i++) {
+        fputs("\tlayer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        //fputs(" [style=invis, shape=point];\n", file);
+        fputs(" [shape=plaintext, label=\"layer ", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("\"];\n", file);
+        //fputs(";\n", file);
 
-	for(i = 0; i <= modeldata->layer_total; i++)
-	{
-		fputs("\t{ rank=same; layer_", file);
-		sprintf(buffer, "%d", i);
-		fputs(buffer, file);
-		fputs("; ", file);
+        if(i != 0) {
+            fputs("\tlayer_", file);
+            sprintf(buffer, "%d", i-1);
+            fputs(buffer, file);
+            fputs(" -> layer_", file);
+            sprintf(buffer, "%d", i);
+            fputs(buffer, file);
+            fputs(" [style=invis];\n", file);
+        }
+    }
 
-		current_xmachine = * modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			// For each function
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				if(current_function->rank_in == i)
-				{
-					fputs(" ", file);
-					fputs(current_xmachine->name, file);
-					fputs("_", file);
-					fputs(current_function->name, file);
-					fputs("_", file);
-					fputs(current_function->current_state, file);
-					fputs("_", file);
-					fputs(current_function->next_state, file);
-					fputs("; ", file);
-				}
+    fputs("\t\n\t/* States */\n", file);
+    /* For every state */
+    current_xmachine = * modeldata->p_xmachines;
 
-				current_function = current_function->next;
-			}
+    counter_colour=-1;
+    while(current_xmachine) {
+        counter_colour++;
+        if(counter_colour>=15) { //more than 16 agents
+            counter_colour=0;
+        }
+        current_state = current_xmachine->states;
+        while(current_state) {
+            //assign colour to start state
+            /*	if(current_state==current_xmachine->start_state)
+            	{//fputs("\", color=green]; \n", file);
 
-			current_xmachine = current_xmachine->next;
-		}
+            		fputs("\t", file);
+            		fputs(current_xmachine->name, file);
+            		fputs("_", file);
+            		fputs(current_state->name, file);
+            		fputs(" [label = \"", file);
+            		fputs(current_state->name, file);
+            		fputs("\", color=",file);
+            		fputs(colour_map[counter_colour],file);
+            		fputs("]; \n", file);
+            		//printf("M:%s - %s - colour %s \n", current_xmachine->name, current_state->name, colour_map[counter_colour]);
+            		//printf("M3 %s",current_xmachine->number);
+            		//add the colour map linked list here
+            		//if((temp_agent_colour=malloc(sizeof(agent_colour)))==NULL)
+            		//{
+            		//	add_agent_colours(p_agent_colours, current_xmachine->name, counter_colour);
+            		//}
+            		addagent_colour(&p_agent_colours,current_xmachine->name,counter_colour);
 
-		fputs("}\n", file);
-	}
-	fputs("}", file);
+            	}
+            	//else print normal state colour
+            	else
+            	{
+            		fputs("\t", file);
+            		fputs(current_xmachine->name, file);
+            		fputs("_", file);
+            		fputs(current_state->name, file);
+            		fputs(" [label = \"", file);
+            		fputs(current_state->name, file);
+            		fputs("\"]\n", file);
+            	}*/
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_state->name, file);
+            fputs(" [label = \"", file);
+            fputs(current_state->name, file);
+            fputs("\"]\n", file);
+            current_state = current_state->next;
+        }
 
-	freeagent_colours(&p_agent_colours);
-	freemodel_colours(&p_model_colours);
-	/* Close the file */
-	fclose(file);
-	//free colour list
-	
+        current_xmachine = current_xmachine->next;
+    }
+    /* For every function */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        counter_colour_2=-1;
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            counter_colour_2++;
+            if(counter_colour_2>=15)
+                counter_colour_2=0;
+            //printf("Length of linked list is %d \n",length_colour(&p_model_colours));
+            length_colour_int=length_colour(&p_model_colours);
+            addmodel_colour(&p_model_colours,current_function->file,length_colour_int);
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" [label = \"", file);
+            fputs(current_function->name, file);
+            //fputs("\", shape = rect]\n", file);
+            //printf("^^^^^ Function %s in file %s\n",current_function->name, current_function->file );
+            fputs("\", shape = box,style=filled,color=",file);
+            model_display_colour=displaymodel_colour(&p_model_colours,current_function->file);
+            fputs(colour_map_light[model_display_colour],file);
+            fputs("];\n", file);
+            //printout colours somewhere
+
+
+            current_function = current_function->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+    fputs("\t\n\t/* Transitions */\n", file);
+    /* For every transition */
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        if(flag == 0) {
+            fputs("subgraph cluster_", file);
+            fputs(current_xmachine->name, file);
+            fputs(" {\n", file);
+            fputs("\tlabel = \"Agent ", file);
+            fputs(current_xmachine->name, file);
+            fputs("\";\n", file);
+        }
+
+        /* For each function */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs(" -> ", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            if(current_function->condition_function == NULL) {
+                fputs(";\n", file);
+            } else {
+                fputs(" [ label = \"", file);
+                // TODO
+                //fputs(current_function->condition, file);
+                printRule(current_function->condition_rule, file);
+                fputs("\"];\n", file);
+            }
+
+
+            fputs("\t", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->name, file);
+            fputs("_", file);
+            fputs(current_function->current_state, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(" -> ", file);
+            fputs(current_xmachine->name, file);
+            fputs("_", file);
+            fputs(current_function->next_state, file);
+            fputs(";\n", file);
+
+            current_function = current_function->next;
+        }
+
+        if(flag == 0) {
+            fputs("}\n", file);
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+    fputs("\t\n\t/* Communications */\n", file);
+    /* For every communication */
+    current_communication = * modeldata->p_communications;
+    while(current_communication) {
+        fputs("\t", file);
+        fputs(current_communication->output_function->agent_name, file);
+        fputs("_", file);
+        fputs(current_communication->output_function->name, file);
+        fputs("_", file);
+        fputs(current_communication->output_function->current_state, file);
+        fputs("_", file);
+        fputs(current_communication->output_function->next_state, file);
+        fputs(" -> ", file);
+        fputs(current_communication->input_function->agent_name, file);
+        fputs("_", file);
+        fputs(current_communication->input_function->name, file);
+        fputs("_", file);
+        fputs(current_communication->input_function->current_state, file);
+        fputs("_", file);
+        fputs(current_communication->input_function->next_state, file);
+        fputs(" [ label = \"", file);
+        fputs(current_communication->messagetype, file);
+        fputs("\" color=\"#00ff00\" constraint=false];\n", file);
+
+        //display_colour=displayagent_colour(&p_agent_colours,current_communication->output_function->agent_name);
+        //printf("colousr111111111 %s ", colour_map[display_colour]);
+        current_communication = current_communication->next;
+        //fputs("\" color=",file);
+        //fputs(colour_map[display_colour],file);
+        //fputs(" constraint=false];\n", file);
+    }
+
+    for(i = 0; i <= modeldata->layer_total; i++) {
+        fputs("\t{ rank=same; layer_", file);
+        sprintf(buffer, "%d", i);
+        fputs(buffer, file);
+        fputs("; ", file);
+
+        current_xmachine = * modeldata->p_xmachines;
+        while(current_xmachine) {
+            // For each function
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                if(current_function->rank_in == i) {
+                    fputs(" ", file);
+                    fputs(current_xmachine->name, file);
+                    fputs("_", file);
+                    fputs(current_function->name, file);
+                    fputs("_", file);
+                    fputs(current_function->current_state, file);
+                    fputs("_", file);
+                    fputs(current_function->next_state, file);
+                    fputs("; ", file);
+                }
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+
+        fputs("}\n", file);
+    }
+    fputs("}", file);
+
+    freeagent_colours(&p_agent_colours);
+    freemodel_colours(&p_model_colours);
+    /* Close the file */
+    fclose(file);
+    //free colour list
+
 }
 
 int find_loop(xmachine_function * current, xmachine_function * depends)
 {
-	adj_function * current_adj_function;
-	adj_function * current_adj_function2;
-	int flag = 0, rc;
+    adj_function * current_adj_function;
+    adj_function * current_adj_function2;
+    int flag = 0, rc;
 
-	/*printf("Function: %s - %s (%s-%s)\n", current->name, depends->name, depends->current_state, depends->next_state);*/
+    /*printf("Function: %s - %s (%s-%s)\n", current->name, depends->name, depends->current_state, depends->next_state);*/
 
-	/* Check if current function is dependent on itself */
-	current_adj_function = current->alldepends;
-	while(current_adj_function)
-	{
-		//printf("\t%s - %s\n", current->name, current_adj_function->function->name);
+    /* Check if current function is dependent on itself */
+    current_adj_function = current->alldepends;
+    while(current_adj_function) {
+        //printf("\t%s - %s\n", current->name, current_adj_function->function->name);
 
-		if((xmachine_function*)depends == (xmachine_function*)current)
-		{
-			flag = 1;
-			current_adj_function = NULL;
-		}
-		else current_adj_function = current_adj_function->next;
-	}
+        if((xmachine_function*)depends == (xmachine_function*)current) {
+            flag = 1;
+            current_adj_function = NULL;
+        } else current_adj_function = current_adj_function->next;
+    }
 
-	/* If there is a self dependency then generate error */
-	if(flag == 1)
-	{
-		fprintf(stderr, "ERROR: Function %s has loop:\n", depends->name);
+    /* If there is a self dependency then generate error */
+    if(flag == 1) {
+        fprintf(stderr, "ERROR: Function %s has loop:\n", depends->name);
 
-		current_adj_function = current->recentdepends;
-		while(current_adj_function)
-		{
-			fprintf(stderr, "       %s\n", current_adj_function->function->name);
+        current_adj_function = current->recentdepends;
+        while(current_adj_function) {
+            fprintf(stderr, "       %s\n", current_adj_function->function->name);
 
-			if(depends == current_adj_function->function)
-			{
-				current_adj_function = NULL;
-			}
-			else current_adj_function = current_adj_function->next;
-		}
+            if(depends == current_adj_function->function) {
+                current_adj_function = NULL;
+            } else current_adj_function = current_adj_function->next;
+        }
 
-		return -1;
-	}
-	/* If there is no self dependency (yet) then try next layer of dependencies */
-	else
-	{
-		/* Add current dependency to a list so we only check each dependency once */
-		add_adj_function_simple(current, depends);
+        return -1;
+    }
+    /* If there is no self dependency (yet) then try next layer of dependencies */
+    else {
+        /* Add current dependency to a list so we only check each dependency once */
+        add_adj_function_simple(current, depends);
 
-		add_adj_function_recent(current, depends);
+        add_adj_function_recent(current, depends);
 
-		/* Check if function checked already */
-		current_adj_function = depends->dependson;
-		while(current_adj_function)
-		{
-			/* If function not check yet */
-			flag = 0;
-			current_adj_function2 = current->alldepends;
-			while(current_adj_function2)
-			{
-				if(current_adj_function2->function == current_adj_function->function) flag = 1;
+        /* Check if function checked already */
+        current_adj_function = depends->dependson;
+        while(current_adj_function) {
+            /* If function not check yet */
+            flag = 0;
+            current_adj_function2 = current->alldepends;
+            while(current_adj_function2) {
+                if(current_adj_function2->function == current_adj_function->function) flag = 1;
 
-				current_adj_function2 = current_adj_function2->next;
-			}
+                current_adj_function2 = current_adj_function2->next;
+            }
 
-			/* If function hasn't been checked then excute recursive algorithm */
-			if(flag == 0)
-			{
-				rc = find_loop(current, current_adj_function->function);
-				if(rc == -1) return -1;
-			}
+            /* If function hasn't been checked then excute recursive algorithm */
+            if(flag == 0) {
+                rc = find_loop(current, current_adj_function->function);
+                if(rc == -1) return -1;
+            }
 
-			current_adj_function = current_adj_function->next;
-		}
+            current_adj_function = current_adj_function->next;
+        }
 
-		remove_adj_function_recent(current);
-	}
+        remove_adj_function_recent(current);
+    }
 
-	return 0;
+    return 0;
 }
 
 void find_previous_states(xmachine_function * current_function, xmachine_message * current_message)
 {
-	adj_function * current_adj_function;
+    adj_function * current_adj_function;
 
-	//printf("\t\tstate = %s (%s)\n", current_function->current_state, current_function->agent_name);
+    //printf("\t\tstate = %s (%s)\n", current_function->current_state, current_function->agent_name);
 
-	//addxstate(current_function->current_state, current_function->agent_name, &current_message->states);
+    //addxstate(current_function->current_state, current_function->agent_name, &current_message->states);
 
-	current_adj_function = current_function->dependson;
-	while (current_adj_function)
-	{
-		if(strcmp(current_function->agent_name, current_adj_function->function->agent_name) == 0)
-			find_previous_states(current_adj_function->function, current_message);
+    current_adj_function = current_function->dependson;
+    while (current_adj_function) {
+        if(strcmp(current_function->agent_name, current_adj_function->function->agent_name) == 0)
+            find_previous_states(current_adj_function->function, current_message);
 
-		current_adj_function = current_adj_function->next;
-	}
+        current_adj_function = current_adj_function->next;
+    }
 }
 
 /** \fn void calculate_filter_agent_states(model_data * modeldata)
@@ -1965,271 +1864,243 @@ void find_previous_states(xmachine_function * current_function, xmachine_message
  */
 void calculate_filter_agent_states(model_data * modeldata)
 {
-	/* Calculate the preceding states before an start sync that
-	 * could hold agents that use filter for message input    */
-/*	for(current_message = * modeldata->p_xmessages; current_message; current_message = current_message->next)
-	{
-			current_layer = * modeldata->p_layers;
-			while(current_layer)
-			{
-				current_function_pointer = current_layer->functions;
-				while(current_function_pointer)
-				{
-					current_function = current_function_pointer->function;
+    /* Calculate the preceding states before an start sync that
+     * could hold agents that use filter for message input    */
+    /*	for(current_message = * modeldata->p_xmessages; current_message; current_message = current_message->next)
+    	{
+    			current_layer = * modeldata->p_layers;
+    			while(current_layer)
+    			{
+    				current_function_pointer = current_layer->functions;
+    				while(current_function_pointer)
+    				{
+    					current_function = current_function_pointer->function;
 
-					printf("current_function->name = %s\n", current_function->name);
+    					printf("current_function->name = %s\n", current_function->name);
 
-					// Find last output of a messagetype
-					current_output = current_function->inputs;
-					while(current_output)
-					{
-						if( strcmp(current_message->name, current_output->messagetype) == 0 )
-						{
-							printf("\tfirst_inputs = %s\n", current_message->name);
-							// Find all preceding states of same agent
-							find_previous_states(current_function, current_message);
+    					// Find last output of a messagetype
+    					current_output = current_function->inputs;
+    					while(current_output)
+    					{
+    						if( strcmp(current_message->name, current_output->messagetype) == 0 )
+    						{
+    							printf("\tfirst_inputs = %s\n", current_message->name);
+    							// Find all preceding states of same agent
+    							find_previous_states(current_function, current_message);
 
-							//for(current_state = current_message->states; current_state; current_state = current_state->next)
-							//{
-							//	printf("\t\tstate: %s\n", current_state->name);
-							//}
+    							//for(current_state = current_message->states; current_state; current_state = current_state->next)
+    							//{
+    							//	printf("\t\tstate: %s\n", current_state->name);
+    							//}
 
-						}
+    						}
 
-						current_output = current_output->next;
-					}
+    						current_output = current_output->next;
+    					}
 
-					current_function_pointer = current_function_pointer->next;
-				}
+    					current_function_pointer = current_function_pointer->next;
+    				}
 
-				current_layer = current_layer->next;
-			}
-	}*/
+    				current_layer = current_layer->next;
+    			}
+    	}*/
 }
 
 /** \fn int find_agent_start_states(model_data * modeldata)
  * \brief Finds agent start states.
  * \param modeldata Data from the model.
  * \return Error code, 0 is success
- * 
+ *
  * This function searches each agent types functions for start and next states.
  */
 int find_agent_start_states(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine * current_xmachine2;
-	xmachine_function * current_function;
-	xmachine_state * current_state;
-	int k, m;
+    xmachine * current_xmachine;
+    xmachine * current_xmachine2;
+    xmachine_function * current_function;
+    xmachine_state * current_state;
+    int k, m;
 
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	current_xmachine2 = NULL;
-	while(current_xmachine)
-	{
-		current_state = current_xmachine->states;
-		while(current_state)
-		{
-			k = 0;
-			m = 0;
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				if(strcmp(current_function->next_state, current_state->name) == 0)
-					k = 1;
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    current_xmachine2 = NULL;
+    while(current_xmachine) {
+        current_state = current_xmachine->states;
+        while(current_state) {
+            k = 0;
+            m = 0;
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                if(strcmp(current_function->next_state, current_state->name) == 0)
+                    k = 1;
 
-				if(strcmp(current_function->current_state, current_state->name) == 0)
-					m++;
+                if(strcmp(current_function->current_state, current_state->name) == 0)
+                    m++;
 
-				current_function = current_function->next;
-			}
+                current_function = current_function->next;
+            }
 
-			if(k == 0)
-			{
-				/*printf("%s - %s\n", current_xmachine->name, current_state->name);*/
-				if(current_xmachine->start_state == NULL)
-				{
-					current_xmachine->start_state = current_state;
-				}
-				else
-				{
-					fprintf(stderr, "ERROR: multiple start states found in '%s' agent\n", current_xmachine->name);
-					fprintf(stderr, "\tincludes %s and %s states\n", current_xmachine->start_state->name, current_state->name);
-					return -1;
-				}
-			}
+            if(k == 0) {
+                /*printf("%s - %s\n", current_xmachine->name, current_state->name);*/
+                if(current_xmachine->start_state == NULL) {
+                    current_xmachine->start_state = current_state;
+                } else {
+                    fprintf(stderr, "ERROR: multiple start states found in '%s' agent\n", current_xmachine->name);
+                    fprintf(stderr, "\tincludes %s and %s states\n", current_xmachine->start_state->name, current_state->name);
+                    return -1;
+                }
+            }
 
-			if(m == 0)
-			{
-				/*printf("END STATE: %s - %s\n", current_xmachine->name, current_state->name);*/
-				addstateholder(current_state, &current_xmachine->end_states);
-			}
+            if(m == 0) {
+                /*printf("END STATE: %s - %s\n", current_xmachine->name, current_state->name);*/
+                addstateholder(current_state, &current_xmachine->end_states);
+            }
 
-			if(m > 1)
-			{
-				/*printf("More than one outgoing edge: %s - %s\n", current_xmachine->name, current_state->name);*/
-			}
+            if(m > 1) {
+                /*printf("More than one outgoing edge: %s - %s\n", current_xmachine->name, current_state->name);*/
+            }
 
-			current_state = current_state->next;
-		}
+            current_state = current_state->next;
+        }
 
-		/* if no start state then error */
-		if(current_xmachine->start_state == NULL)
-		{
-			/*fprintf(stderr, "ERROR: no start state found in '%s' agent\n", current_xmachine->name);
-			return -1;*/
-			fprintf(stderr, "!!! WARNING: no start state found in '%s' agent, agent removed from model\n", current_xmachine->name);
-			/* Remove agent from the agent list */
-			if(current_xmachine2 == NULL) * modeldata->p_xmachines = current_xmachine->next;
-			else current_xmachine2->next = current_xmachine->next;
+        /* if no start state then error */
+        if(current_xmachine->start_state == NULL) {
+            /*fprintf(stderr, "ERROR: no start state found in '%s' agent\n", current_xmachine->name);
+            return -1;*/
+            fprintf(stderr, "!!! WARNING: no start state found in '%s' agent, agent removed from model\n", current_xmachine->name);
+            /* Remove agent from the agent list */
+            if(current_xmachine2 == NULL) * modeldata->p_xmachines = current_xmachine->next;
+            else current_xmachine2->next = current_xmachine->next;
 
-			free(current_xmachine->name);
-			freevariables(&current_xmachine->variables);
-			freexstates(&current_xmachine->states);
-			freexfunctions(&current_xmachine->functions);
-			freestateholder(&current_xmachine->end_states);
-			free(current_xmachine);
+            free(current_xmachine->name);
+            freevariables(&current_xmachine->variables);
+            freexstates(&current_xmachine->states);
+            freexfunctions(&current_xmachine->functions);
+            freestateholder(&current_xmachine->end_states);
+            free(current_xmachine);
 
-			if(current_xmachine2 == NULL) current_xmachine = * modeldata->p_xmachines;
-			else current_xmachine = current_xmachine2->next;
-		}
-		else
-		{
-			current_xmachine2 = current_xmachine;
-			current_xmachine = current_xmachine->next;
-		}
-	}
+            if(current_xmachine2 == NULL) current_xmachine = * modeldata->p_xmachines;
+            else current_xmachine = current_xmachine2->next;
+        } else {
+            current_xmachine2 = current_xmachine;
+            current_xmachine = current_xmachine->next;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 /** \fn void catalogue_agent_communications(model_data * modeldata)
  * \brief Catalogues communication between every agent function.
  * \param modeldata Data from the model.
- * 
+ *
  * For every function pair of inputs and outputs a flame communication is added.
  * An adjacent function (outputting function) is added to the inputting function.
  */
 void catalogue_agent_communications(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine * current_xmachine2;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	xmachine_ioput * current_input;
-	xmachine_ioput * current_output;
+    xmachine * current_xmachine;
+    xmachine * current_xmachine2;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    xmachine_ioput * current_input;
+    xmachine_ioput * current_output;
 
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		/* For each function */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			/* For each input */
-			current_input = current_function->inputs;
-			while(current_input)
-			{
-				/* For each agent */
-				current_xmachine2 = * modeldata->p_xmachines;
-				while(current_xmachine2)
-				{
-					/* For each function */
-					current_function2 = current_xmachine2->functions;
-					while(current_function2)
-					{
-						/* For each output */
-						current_output = current_function2->outputs;
-						while(current_output)
-						{
-							/* If the message types are equal */
-							if(strcmp(current_input->messagetype, current_output->messagetype) == 0)
-							{
-								/* Add the communication to the communication list */
-								add_flame_communication(current_input->messagetype, current_input->filter_rule, current_function, current_function2, modeldata->p_communications);
-								/* Add the outputting function as an adjacent function to the inputting function */
-								add_adj_function(current_function2, current_function, current_input->messagetype);
-							}
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        /* For each function */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            /* For each input */
+            current_input = current_function->inputs;
+            while(current_input) {
+                /* For each agent */
+                current_xmachine2 = * modeldata->p_xmachines;
+                while(current_xmachine2) {
+                    /* For each function */
+                    current_function2 = current_xmachine2->functions;
+                    while(current_function2) {
+                        /* For each output */
+                        current_output = current_function2->outputs;
+                        while(current_output) {
+                            /* If the message types are equal */
+                            if(strcmp(current_input->messagetype, current_output->messagetype) == 0) {
+                                /* Add the communication to the communication list */
+                                add_flame_communication(current_input->messagetype, current_input->filter_rule, current_function, current_function2, modeldata->p_communications);
+                                /* Add the outputting function as an adjacent function to the inputting function */
+                                add_adj_function(current_function2, current_function, current_input->messagetype);
+                            }
 
-							current_output = current_output->next;
-						}
+                            current_output = current_output->next;
+                        }
 
-						current_function2 = current_function2->next;
-					}
+                        current_function2 = current_function2->next;
+                    }
 
-					current_xmachine2 = current_xmachine2->next;
-				}
+                    current_xmachine2 = current_xmachine2->next;
+                }
 
-				current_input = current_input->next;
-			}
+                current_input = current_input->next;
+            }
 
-			current_function = current_function->next;
-		}
+            current_function = current_function->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 }
 
 int check_message_consistancy(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	xmachine_message * current_message2;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_ioput * current_ioput;
-	int output_flag;
-	int input_flag;
-	
-	current_message = * modeldata->p_xmessages;
-	while(current_message != NULL)
-	{
-		output_flag = 0;
-		input_flag = 0;
-		
-		for(current_xmachine = * modeldata->p_xmachines;
-			current_xmachine != NULL;
-			current_xmachine = current_xmachine->next)
-		{
-			for(current_function = current_xmachine->functions;
-				current_function != NULL;
-				current_function = current_function->next)
-			{
-				for(current_ioput = current_function->outputs;
-					current_ioput != NULL;
-					current_ioput = current_ioput->next)
-				{
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						output_flag = 1;
-					}
-				}
-				
-				for(current_ioput = current_function->inputs;
-					current_ioput != NULL;
-					current_ioput = current_ioput->next)
-				{
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						input_flag = 1;
-					}
-				}
-			}
-		}
-		
-		if(input_flag == 0 && output_flag == 1) printf("!!! WARNING: %s message is not input by any agent function\n", current_message->name);
-		if(input_flag == 1 && output_flag == 0) printf("!!! WARNING: %s message is not output by any agent function\n", current_message->name);
-		if(input_flag == 0 && output_flag == 0)
-		{
-			printf("!!! WARNING: %s message is not input or output by any agent function, message removed from model\n", current_message->name);
-			current_message2 = current_message->next;
-			freexmessage(modeldata->p_xmessages, current_message);
-			current_message = current_message2;
-		}
-		else current_message = current_message->next;
-	}
-	
-	return 1;
+    xmachine_message * current_message;
+    xmachine_message * current_message2;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_ioput * current_ioput;
+    int output_flag;
+    int input_flag;
+
+    current_message = * modeldata->p_xmessages;
+    while(current_message != NULL) {
+        output_flag = 0;
+        input_flag = 0;
+
+        for(current_xmachine = * modeldata->p_xmachines;
+                current_xmachine != NULL;
+                current_xmachine = current_xmachine->next) {
+            for(current_function = current_xmachine->functions;
+                    current_function != NULL;
+                    current_function = current_function->next) {
+                for(current_ioput = current_function->outputs;
+                        current_ioput != NULL;
+                        current_ioput = current_ioput->next) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        output_flag = 1;
+                    }
+                }
+
+                for(current_ioput = current_function->inputs;
+                        current_ioput != NULL;
+                        current_ioput = current_ioput->next) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        input_flag = 1;
+                    }
+                }
+            }
+        }
+
+        if(input_flag == 0 && output_flag == 1) printf("!!! WARNING: %s message is not input by any agent function\n", current_message->name);
+        if(input_flag == 1 && output_flag == 0) printf("!!! WARNING: %s message is not output by any agent function\n", current_message->name);
+        if(input_flag == 0 && output_flag == 0) {
+            printf("!!! WARNING: %s message is not input or output by any agent function, message removed from model\n", current_message->name);
+            current_message2 = current_message->next;
+            freexmessage(modeldata->p_xmessages, current_message);
+            current_message = current_message2;
+        } else current_message = current_message->next;
+    }
+
+    return 1;
 }
 
 /** \fn void catalogue_agent_internal(model_data * modeldata)
@@ -2238,763 +2109,668 @@ int check_message_consistancy(model_data * modeldata)
  */
 void catalogue_agent_internal(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
 
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		/* For each function */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			/* For each function */
-			current_function2 = current_xmachine->functions;
-			while(current_function2)
-			{
-				/* If the first functions current state equals the second functions next state */
-				if(strcmp(current_function->current_state, current_function2->next_state) == 0)
-				{
-					/* Add the first function as a dependency of the second function
-					 * (with a type of being 'internal') because the second function
-					 * finishes in its next state which is the current state and start
-					 * of the first function */
-					add_adj_function(current_function2, current_function, "internal");
-				}
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        /* For each function */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            /* For each function */
+            current_function2 = current_xmachine->functions;
+            while(current_function2) {
+                /* If the first functions current state equals the second functions next state */
+                if(strcmp(current_function->current_state, current_function2->next_state) == 0) {
+                    /* Add the first function as a dependency of the second function
+                     * (with a type of being 'internal') because the second function
+                     * finishes in its next state which is the current state and start
+                     * of the first function */
+                    add_adj_function(current_function2, current_function, "internal");
+                }
 
-				current_function2 = current_function2->next;
-			}
+                current_function2 = current_function2->next;
+            }
 
-			current_function = current_function->next;
-		}
+            current_function = current_function->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 }
 
 /** \fn int check_dependency_loops(model_data * modeldata)
  * \brief Find loops within agent function dependencies.
  * \param modeldata Data from the model.
  * \return 0
- * 
+ *
  * Make sure that there are no cyclic loops of dependencies with agent functions
  */
 int check_dependency_loops(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	adj_function * current_adj_function;
-	int rc;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    adj_function * current_adj_function;
+    int rc;
 
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			current_adj_function = current_function->dependson;
-			while(current_adj_function)
-			{
-				rc = find_loop(current_function, current_adj_function->function);
-				if(rc == -1) return -1;
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            current_adj_function = current_function->dependson;
+            while(current_adj_function) {
+                rc = find_loop(current_function, current_adj_function->function);
+                if(rc == -1) return -1;
 
-				current_adj_function = current_adj_function->next;
-			}
+                current_adj_function = current_adj_function->next;
+            }
 
-			current_function = current_function->next;
-		}
+            current_function = current_function->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        current_xmachine = current_xmachine->next;
+    }
 
-	return 0;
+    return 0;
 }
 
 /* List for each state their incoming transition and outgoing transitions */
 void catalogue_states_edges(model_data * modeldata)
 {
-	xmachine_state * current_state;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	//function_pointer * current_function_pointer;
-	
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		/* For each state */
-		current_state = current_xmachine->states;
-		while(current_state)
-		{
-			/* For each function */
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				if(strcmp(current_function->current_state, current_state->name) == 0)
-				{
-					addfunction_pointer(&current_state->outgoing_functions, current_function);
-				}
-				if(strcmp(current_function->next_state, current_state->name) == 0)
-				{
-					addfunction_pointer(&current_state->incoming_functions, current_function);
-				}
-				
-				current_function = current_function->next;
-			}
-			
-			/* Print results */
-			/*printf("State: %s\nincoming:\n", current_state->name);
-			for(current_function_pointer = current_state->incoming_functions; current_function_pointer != NULL; current_function_pointer = current_function_pointer->next)
-			{
-				printf("\t%s\n", current_function_pointer->function->name);
-			}
-			printf("outgoing:\n");
-			for(current_function_pointer = current_state->outgoing_functions; current_function_pointer != NULL; current_function_pointer = current_function_pointer->next)
-			{
-				printf("\t%s\n", current_function_pointer->function->name);
-			}*/
-			
-			current_state = current_state->next;
-		}
-		
-		current_xmachine = current_xmachine->next;
-	}
+    xmachine_state * current_state;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    //function_pointer * current_function_pointer;
+
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        /* For each state */
+        current_state = current_xmachine->states;
+        while(current_state) {
+            /* For each function */
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                if(strcmp(current_function->current_state, current_state->name) == 0) {
+                    addfunction_pointer(&current_state->outgoing_functions, current_function);
+                }
+                if(strcmp(current_function->next_state, current_state->name) == 0) {
+                    addfunction_pointer(&current_state->incoming_functions, current_function);
+                }
+
+                current_function = current_function->next;
+            }
+
+            /* Print results */
+            /*printf("State: %s\nincoming:\n", current_state->name);
+            for(current_function_pointer = current_state->incoming_functions; current_function_pointer != NULL; current_function_pointer = current_function_pointer->next)
+            {
+            	printf("\t%s\n", current_function_pointer->function->name);
+            }
+            printf("outgoing:\n");
+            for(current_function_pointer = current_state->outgoing_functions; current_function_pointer != NULL; current_function_pointer = current_function_pointer->next)
+            {
+            	printf("\t%s\n", current_function_pointer->function->name);
+            }*/
+
+            current_state = current_state->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
 }
 
 void find_states_with_branches(xmachine_state_holder ** states, model_data * modeldata)
 {
-	xmachine_state_holder * current_state_holder;
-	xmachine_state * current_state;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	//function_pointer * current_function_pointer;
-	int found;
-	
-	/* For each agent */
-	current_xmachine = * modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		/* For each function */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			current_function2 = current_xmachine->functions;
-			while(current_function2)
-			{
-				if(strcmp(current_function->name, current_function2->name) != 0 &&
-						strcmp(current_function->current_state, current_function2->current_state) == 0)
-				{
-					current_state = current_xmachine->states;
-					while(current_state)
-					{
-						if(strcmp(current_state->name, current_function->current_state) == 0)
-						{
-							found = 0;
-							current_state_holder = *states;
-							while(current_state_holder)
-							{
-								if(current_state == current_state_holder->state)
-								{
-									found = 1;
-								}
-								
-								current_state_holder = current_state_holder->next;
-							}
-							if(found == 0)
-							{
-								addstateholder(current_state, states);
-							}
-						}
-							
-						current_state = current_state->next;
-					}
-					current_function2 = NULL;
-				}
-				else current_function2 = current_function2->next;
-			}
-			
-			current_function = current_function->next;
-		}
-		
-		current_xmachine = current_xmachine->next;
-	}
-	
-	/*current_state_holder = *states;
-	while(current_state_holder)
-	{
-		printf("**** %s - %s\n",
-				current_state_holder->state->agent_name,
-				current_state_holder->state->name);
-		current_function_pointer = current_state_holder->state->branching_functions;
-		while(current_function_pointer)
-		{
-			printf("\t%s\n", current_function_pointer->function->name);
-			
-			current_function_pointer = current_function_pointer->next;
-		}
-		
-		current_state_holder = current_state_holder->next;
-	}*/
+    xmachine_state_holder * current_state_holder;
+    xmachine_state * current_state;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    //function_pointer * current_function_pointer;
+    int found;
+
+    /* For each agent */
+    current_xmachine = * modeldata->p_xmachines;
+    while(current_xmachine) {
+        /* For each function */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            current_function2 = current_xmachine->functions;
+            while(current_function2) {
+                if(strcmp(current_function->name, current_function2->name) != 0 &&
+                        strcmp(current_function->current_state, current_function2->current_state) == 0) {
+                    current_state = current_xmachine->states;
+                    while(current_state) {
+                        if(strcmp(current_state->name, current_function->current_state) == 0) {
+                            found = 0;
+                            current_state_holder = *states;
+                            while(current_state_holder) {
+                                if(current_state == current_state_holder->state) {
+                                    found = 1;
+                                }
+
+                                current_state_holder = current_state_holder->next;
+                            }
+                            if(found == 0) {
+                                addstateholder(current_state, states);
+                            }
+                        }
+
+                        current_state = current_state->next;
+                    }
+                    current_function2 = NULL;
+                } else current_function2 = current_function2->next;
+            }
+
+            current_function = current_function->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+    /*current_state_holder = *states;
+    while(current_state_holder)
+    {
+    	printf("**** %s - %s\n",
+    			current_state_holder->state->agent_name,
+    			current_state_holder->state->name);
+    	current_function_pointer = current_state_holder->state->branching_functions;
+    	while(current_function_pointer)
+    	{
+    		printf("\t%s\n", current_function_pointer->function->name);
+
+    		current_function_pointer = current_function_pointer->next;
+    	}
+
+    	current_state_holder = current_state_holder->next;
+    }*/
 }
 
 /** \fn void calculate_dependency_graph(model_data * modeldata)
  * \brief Calculate function layers of dependencies.
  * \param modeldata Data from the model.
- * 
+ *
  * Create layers of dependencies where the top layer of functions have no
  * dependencies and each successive layer depends only on functions in the
  * layer(s) above.
  */
 void calculate_dependency_graph(model_data * modeldata)
 {
-	xmachine_state_holder * states = NULL;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	adj_function * current_adj_function;
-	xmachine_state_holder * current_state_holder;
-	xmachine_state_holder * current_state_holder2;
-	function_pointer * current_function_pointer;
-	layer * current_layer;
-	int k, m, newlayer;
+    xmachine_state_holder * states = NULL;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    adj_function * current_adj_function;
+    xmachine_state_holder * current_state_holder;
+    xmachine_state_holder * current_state_holder2;
+    function_pointer * current_function_pointer;
+    layer * current_layer;
+    int k, m, newlayer;
 
-	/* Calculate states with out going branches */
-	find_states_with_branches(&states, modeldata);
-	
-	/* Calculate layers of dgraph */
-	/* This is achieved by finding functions with no dependencies */
-	/* giving them a layer no, taking those functions away and doing the operation again */
+    /* Calculate states with out going branches */
+    find_states_with_branches(&states, modeldata);
 
-	current_layer = addlayer(modeldata->p_layers);
-	newlayer = 0;
-	m = 0;
-	while(m == 0)
-	{
-		/* For each agent */
-		current_xmachine = * modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			/* For each function */
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				/* If rank_in is unknown */
-				if(current_function->rank_in == -1)
-				{
-					k = 0;
-					/* Search dependencies on the current function */
-					current_adj_function = current_function->dependson;
-					while(current_adj_function)
-					{
-						/* Check if the function has a dependency on it (and not from itself) */
-						/* Check to see if the dependency is a function and not be assigned a layer in last layers */
-						if(current_adj_function->function->rank_in == -1 || current_adj_function->function->rank_in == newlayer)
-						{
-							/* Change flag to say there is a dependency */
-							k = 1;
-						}
+    /* Calculate layers of dgraph */
+    /* This is achieved by finding functions with no dependencies */
+    /* giving them a layer no, taking those functions away and doing the operation again */
 
-						current_adj_function = current_adj_function->next;
-					}
-					if(k == 0)
-					{
-						current_function->rank_in = newlayer;
+    current_layer = addlayer(modeldata->p_layers);
+    newlayer = 0;
+    m = 0;
+    while(m == 0) {
+        /* For each agent */
+        current_xmachine = * modeldata->p_xmachines;
+        while(current_xmachine) {
+            /* For each function */
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                /* If rank_in is unknown */
+                if(current_function->rank_in == -1) {
+                    k = 0;
+                    /* Search dependencies on the current function */
+                    current_adj_function = current_function->dependson;
+                    while(current_adj_function) {
+                        /* Check if the function has a dependency on it (and not from itself) */
+                        /* Check to see if the dependency is a function and not be assigned a layer in last layers */
+                        if(current_adj_function->function->rank_in == -1 || current_adj_function->function->rank_in == newlayer) {
+                            /* Change flag to say there is a dependency */
+                            k = 1;
+                        }
 
-						addfunction_pointer(&current_layer->functions, current_function);
-						
-						/* Find function in state branch functions and flag as found */
-						current_state_holder = states;
-						while(current_state_holder)
-						{
-							current_function_pointer = current_state_holder->state->incoming_functions;
-							while(current_function_pointer)
-							{
-								if(current_function == current_function_pointer->function)
-								{
-									//printf("** found %s\n", current_function_pointer->function->name);
-									current_function_pointer->found = 1;
-								}
-								
-								current_function_pointer = current_function_pointer->next;
-							}
-							
-							current_state_holder = current_state_holder->next;
-						}
-					}
-				}
+                        current_adj_function = current_adj_function->next;
+                    }
+                    if(k == 0) {
+                        current_function->rank_in = newlayer;
 
-				current_function = current_function->next;
-			}
+                        addfunction_pointer(&current_layer->functions, current_function);
 
-			current_xmachine = current_xmachine->next;
-		}
-		/* Increment layer */
-		newlayer++;
-		
-		/* If all the functions have layers then stop */
-		/* Set flag to all functions have a layer */
-		k = 0;
-		current_xmachine = * modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			/* For each function */
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				/* If a function does not have a layer yet */
-				if(current_function->rank_in == -1) k = 1;
+                        /* Find function in state branch functions and flag as found */
+                        current_state_holder = states;
+                        while(current_state_holder) {
+                            current_function_pointer = current_state_holder->state->incoming_functions;
+                            while(current_function_pointer) {
+                                if(current_function == current_function_pointer->function) {
+                                    //printf("** found %s\n", current_function_pointer->function->name);
+                                    current_function_pointer->found = 1;
+                                }
 
-				current_function = current_function->next;
-			}
+                                current_function_pointer = current_function_pointer->next;
+                            }
 
-			current_xmachine = current_xmachine->next;
-		}
-		/* If flag is still zero then stop */
-		if(k == 0) m = 1;
-		else
-		{
-			/* If a state with branch functions has no incoming functions
-			 * then add to the top layer and not the following one */
-			current_state_holder = states;
-			while(current_state_holder)
-			{
-				if(current_state_holder->state->incoming_functions == NULL)
-				{
-					//printf("state found\n");
-					/* remove from states and add to layer states */
-					addstateholder(current_state_holder->state, &current_layer->branching_states);
-					
-					if(states == current_state_holder)
-					{
-						states = current_state_holder->next;
-						free(current_state_holder);
-						current_state_holder = states;
-					}
-					else
-					{
-						current_state_holder2->next = current_state_holder->next;
-						free(current_state_holder);
-						current_state_holder = current_state_holder2->next;
-					}
-				}
-				else
-				{
-					current_state_holder2 = current_state_holder;
-					current_state_holder = current_state_holder->next;
-				}
-			}
-			
-			current_layer = addlayer(modeldata->p_layers);
-			
-			/* If all states have branch functions have been found... */
-			current_state_holder = states;
-			while(current_state_holder)
-			{
-				k = 0;
-				current_function_pointer = current_state_holder->state->incoming_functions;
-				while(current_function_pointer)
-				{
-					if(current_function_pointer->found == 0) k = 1;
-					
-					current_function_pointer = current_function_pointer->next;
-				}
-				
-				if(k == 0)
-				{
-					//printf("state found\n");
-					/* remove from states and add to layer states */
-					addstateholder(current_state_holder->state, &current_layer->branching_states);
-					
-					if(states == current_state_holder)
-					{
-						states = current_state_holder->next;
-						free(current_state_holder);
-						current_state_holder = states;
-					}
-					else
-					{
-						current_state_holder2->next = current_state_holder->next;
-						free(current_state_holder);
-						current_state_holder = current_state_holder2->next;
-					}
-				}
-				else
-				{
-					current_state_holder2 = current_state_holder;
-					current_state_holder = current_state_holder->next;
-				}
-			}
-		}
-	}
-	/* Make the layer value equal to the number of layers */
-	newlayer--;
+                            current_state_holder = current_state_holder->next;
+                        }
+                    }
+                }
 
-	modeldata->layer_total = newlayer;
-	
-	freestateholder(&states);
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+        /* Increment layer */
+        newlayer++;
+
+        /* If all the functions have layers then stop */
+        /* Set flag to all functions have a layer */
+        k = 0;
+        current_xmachine = * modeldata->p_xmachines;
+        while(current_xmachine) {
+            /* For each function */
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                /* If a function does not have a layer yet */
+                if(current_function->rank_in == -1) k = 1;
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+        /* If flag is still zero then stop */
+        if(k == 0) m = 1;
+        else {
+            /* If a state with branch functions has no incoming functions
+             * then add to the top layer and not the following one */
+            current_state_holder = states;
+            while(current_state_holder) {
+                if(current_state_holder->state->incoming_functions == NULL) {
+                    //printf("state found\n");
+                    /* remove from states and add to layer states */
+                    addstateholder(current_state_holder->state, &current_layer->branching_states);
+
+                    if(states == current_state_holder) {
+                        states = current_state_holder->next;
+                        free(current_state_holder);
+                        current_state_holder = states;
+                    } else {
+                        current_state_holder2->next = current_state_holder->next;
+                        free(current_state_holder);
+                        current_state_holder = current_state_holder2->next;
+                    }
+                } else {
+                    current_state_holder2 = current_state_holder;
+                    current_state_holder = current_state_holder->next;
+                }
+            }
+
+            current_layer = addlayer(modeldata->p_layers);
+
+            /* If all states have branch functions have been found... */
+            current_state_holder = states;
+            while(current_state_holder) {
+                k = 0;
+                current_function_pointer = current_state_holder->state->incoming_functions;
+                while(current_function_pointer) {
+                    if(current_function_pointer->found == 0) k = 1;
+
+                    current_function_pointer = current_function_pointer->next;
+                }
+
+                if(k == 0) {
+                    //printf("state found\n");
+                    /* remove from states and add to layer states */
+                    addstateholder(current_state_holder->state, &current_layer->branching_states);
+
+                    if(states == current_state_holder) {
+                        states = current_state_holder->next;
+                        free(current_state_holder);
+                        current_state_holder = states;
+                    } else {
+                        current_state_holder2->next = current_state_holder->next;
+                        free(current_state_holder);
+                        current_state_holder = current_state_holder2->next;
+                    }
+                } else {
+                    current_state_holder2 = current_state_holder;
+                    current_state_holder = current_state_holder->next;
+                }
+            }
+        }
+    }
+    /* Make the layer value equal to the number of layers */
+    newlayer--;
+
+    modeldata->layer_total = newlayer;
+
+    freestateholder(&states);
 }
 
 int handle_rule_value_for_agent_variable(char * value, variable * var, xmachine * current_xmachine, int flag)
 {
-	variable * current_variable, * current_variable2;
-	int found_flag = 0;
+    variable * current_variable, * current_variable2;
+    int found_flag = 0;
 
-	//printf("\tvalue = %s\n", value);
+    //printf("\tvalue = %s\n", value);
 
-	/* If value is an agent variable */
-	if(strncmp(value, "a->", 3) == 0)
-	{
-		/* Only check for agent vars */
-		if(flag == 0) return 1;
-		/* Only check for non-constant agent vars */
-		if(flag == 2)
-		{
-			if(var->constant == 0) return 1;
-			else return 0;
-		}
-		
-		/* 22/04/09 Simon (bug from Shawn)
-		 * Check not adding duplicate var */
-		for(current_variable2 = current_xmachine->variables; current_variable2 != NULL;
-			current_variable2 = current_variable2->next)
-		{
-			if( strcmp(var->name, current_variable2->name) == 0 ) found_flag = 1;
-		}
-		
-		if(found_flag == 0)
-		{
-			current_variable = addvariable(&current_xmachine->variables);
-			current_variable->name = copystr(var->name);
-			current_variable->type = copystr(var->type);
-			current_variable->constant = var->constant;
-			current_variable->agent = var->agent;
-			strcpy(current_variable->c_type, var->c_type);
-		}
-	}
-	
-	return 0;
+    /* If value is an agent variable */
+    if(strncmp(value, "a->", 3) == 0) {
+        /* Only check for agent vars */
+        if(flag == 0) return 1;
+        /* Only check for non-constant agent vars */
+        if(flag == 2) {
+            if(var->constant == 0) return 1;
+            else return 0;
+        }
+
+        /* 22/04/09 Simon (bug from Shawn)
+         * Check not adding duplicate var */
+        for(current_variable2 = current_xmachine->variables; current_variable2 != NULL;
+                current_variable2 = current_variable2->next) {
+            if( strcmp(var->name, current_variable2->name) == 0 ) found_flag = 1;
+        }
+
+        if(found_flag == 0) {
+            current_variable = addvariable(&current_xmachine->variables);
+            current_variable->name = copystr(var->name);
+            current_variable->type = copystr(var->type);
+            current_variable->constant = var->constant;
+            current_variable->agent = var->agent;
+            strcpy(current_variable->c_type, var->c_type);
+        }
+    }
+
+    return 0;
 }
 
 int handle_rule_for_agent_variable(rule_data * current_rule_data, xmachine * current_xmachine, int flag)
 {
-	int rc;
-	
-	/* Handle values */
-	if(current_rule_data->lhs == NULL) rc = handle_rule_for_agent_variable(current_rule_data->lhs_rule, current_xmachine, flag);
-	else rc = handle_rule_value_for_agent_variable(current_rule_data->lhs, current_rule_data->lhs_variable, current_xmachine, flag);
-	if((flag == 0 || flag == 2) && rc == 1) return 1;
-	
-	if(current_rule_data->rhs == NULL) rc = handle_rule_for_agent_variable(current_rule_data->rhs_rule, current_xmachine, flag);
-	else rc = handle_rule_value_for_agent_variable(current_rule_data->rhs, current_rule_data->rhs_variable, current_xmachine, flag);
-	if((flag == 0 || flag == 2) && rc == 1) return 1;
-	
-	return 0;
+    int rc;
+
+    /* Handle values */
+    if(current_rule_data->lhs == NULL) rc = handle_rule_for_agent_variable(current_rule_data->lhs_rule, current_xmachine, flag);
+    else rc = handle_rule_value_for_agent_variable(current_rule_data->lhs, current_rule_data->lhs_variable, current_xmachine, flag);
+    if((flag == 0 || flag == 2) && rc == 1) return 1;
+
+    if(current_rule_data->rhs == NULL) rc = handle_rule_for_agent_variable(current_rule_data->rhs_rule, current_xmachine, flag);
+    else rc = handle_rule_value_for_agent_variable(current_rule_data->rhs, current_rule_data->rhs_variable, current_xmachine, flag);
+    if((flag == 0 || flag == 2) && rc == 1) return 1;
+
+    return 0;
 }
 
 int handle_rule_for_message_variable(rule_data * current_rule_data)
 {
-	if(current_rule_data->lhs == NULL) { if(handle_rule_for_message_variable(current_rule_data->lhs_rule) == 1) return 1; }
-	else if(strncmp(current_rule_data->lhs, "m->", 3) == 0) return 1;
-	
-	if(current_rule_data->rhs == NULL) { if(handle_rule_for_message_variable(current_rule_data->rhs_rule) == 1) return 1; }
-	else if(strncmp(current_rule_data->rhs, "m->", 3) == 0) return 1; 
-	
-	return 0;
+    if(current_rule_data->lhs == NULL) {
+        if(handle_rule_for_message_variable(current_rule_data->lhs_rule) == 1) return 1;
+    } else if(strncmp(current_rule_data->lhs, "m->", 3) == 0) return 1;
+
+    if(current_rule_data->rhs == NULL) {
+        if(handle_rule_for_message_variable(current_rule_data->rhs_rule) == 1) return 1;
+    } else if(strncmp(current_rule_data->rhs, "m->", 3) == 0) return 1;
+
+    return 0;
 }
 
 void calculate_message_input_output_agents(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine * current_xmachine2;
-	//xmachine * current_xmachine3;
-	xmachine_function * current_function;
-	//xmachine_function * current_function3;
-	xmachine_message * current_message;
-	xmachine_ioput * current_ioput;
-	int flag;
-	
-	for(current_message = * modeldata->p_xmessages;
-		current_message != NULL;
-		current_message = current_message->next)
-	{
-		for(current_xmachine = * modeldata->p_xmachines;
-			current_xmachine != NULL;
-			current_xmachine = current_xmachine->next)
-		{
-			for(current_function = current_xmachine->functions;
-				current_function != NULL;
-				current_function = current_function->next)
-			{
-				/* Find inputting agents */
-				for(current_ioput = current_function->inputs;
-					current_ioput != NULL;
-					current_ioput = current_ioput->next)
-				{	
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						/* Add inputting agents to message type list */
-						flag = 0;
-						for(current_xmachine2 = current_message->inputting_agents;
-							current_xmachine2 != NULL;
-							current_xmachine2 = current_xmachine2->next)
-						{
-							if(strcmp(current_xmachine2->name, current_xmachine->name) == 0) flag = 1;
-						}
-						if(flag == 0)
-						{
-							current_xmachine2 = addxmachine(&current_message->inputting_agents, current_xmachine->name);
-							current_xmachine2->start_state = current_xmachine->start_state;
-						}
-					}
-				}
-				
-				/* Find outputting agents */
-				for(current_ioput = current_function->outputs;
-					current_ioput != NULL;
-					current_ioput = current_ioput->next)
-				{	
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						/* Add outputting agents to message type list */
-						flag = 0;
-						for(current_xmachine2 = current_message->outputting_agents;
-							current_xmachine2 != NULL;
-							current_xmachine2 = current_xmachine2->next)
-						{
-							if(strcmp(current_xmachine2->name, current_xmachine->name) == 0) flag = 1;
-						}
-						if(flag == 0)
-						{
-							current_xmachine2 = addxmachine(&current_message->outputting_agents, current_xmachine->name);
-							current_xmachine2->start_state = current_xmachine->start_state;
-						}
-					}
-				}
-			}
-		}
-	}
+    xmachine * current_xmachine;
+    xmachine * current_xmachine2;
+    //xmachine * current_xmachine3;
+    xmachine_function * current_function;
+    //xmachine_function * current_function3;
+    xmachine_message * current_message;
+    xmachine_ioput * current_ioput;
+    int flag;
+
+    for(current_message = * modeldata->p_xmessages;
+            current_message != NULL;
+            current_message = current_message->next) {
+        for(current_xmachine = * modeldata->p_xmachines;
+                current_xmachine != NULL;
+                current_xmachine = current_xmachine->next) {
+            for(current_function = current_xmachine->functions;
+                    current_function != NULL;
+                    current_function = current_function->next) {
+                /* Find inputting agents */
+                for(current_ioput = current_function->inputs;
+                        current_ioput != NULL;
+                        current_ioput = current_ioput->next) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        /* Add inputting agents to message type list */
+                        flag = 0;
+                        for(current_xmachine2 = current_message->inputting_agents;
+                                current_xmachine2 != NULL;
+                                current_xmachine2 = current_xmachine2->next) {
+                            if(strcmp(current_xmachine2->name, current_xmachine->name) == 0) flag = 1;
+                        }
+                        if(flag == 0) {
+                            current_xmachine2 = addxmachine(&current_message->inputting_agents, current_xmachine->name);
+                            current_xmachine2->start_state = current_xmachine->start_state;
+                        }
+                    }
+                }
+
+                /* Find outputting agents */
+                for(current_ioput = current_function->outputs;
+                        current_ioput != NULL;
+                        current_ioput = current_ioput->next) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        /* Add outputting agents to message type list */
+                        flag = 0;
+                        for(current_xmachine2 = current_message->outputting_agents;
+                                current_xmachine2 != NULL;
+                                current_xmachine2 = current_xmachine2->next) {
+                            if(strcmp(current_xmachine2->name, current_xmachine->name) == 0) flag = 1;
+                        }
+                        if(flag == 0) {
+                            current_xmachine2 = addxmachine(&current_message->outputting_agents, current_xmachine->name);
+                            current_xmachine2->start_state = current_xmachine->start_state;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 void calculate_communication_syncs(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	variable * current_variable;
-	variable * current_variable2;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	//xmachine_function * last_output_function;
-	function_pointer * current_function_pointer;
-	function_pointer * current_function_pointer2;
-	xmachine_message * current_message;
-	adj_function * current_adj_function;
-	xmachine_ioput * current_input;
-	xmachine_ioput * current_output;
-	layer * current_layer;
-	sync * current_sync = NULL;
-	sync * previous_sync = NULL;
-	function_pointer * temp_function_pointer = NULL;
-	char buffer[1000];
-	char buffer2[1000];
-	int flag;
+    xmachine * current_xmachine;
+    variable * current_variable;
+    variable * current_variable2;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    //xmachine_function * last_output_function;
+    function_pointer * current_function_pointer;
+    function_pointer * current_function_pointer2;
+    xmachine_message * current_message;
+    adj_function * current_adj_function;
+    xmachine_ioput * current_input;
+    xmachine_ioput * current_output;
+    layer * current_layer;
+    sync * current_sync = NULL;
+    sync * previous_sync = NULL;
+    function_pointer * temp_function_pointer = NULL;
+    char buffer[1000];
+    char buffer2[1000];
+    int flag;
 
-	/* For each message type find:
-	 * 1) outputting functions
-	 * 2) inputting functions */
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		//printf("**** message type: %s\n", current_message->name);
-		
-		temp_function_pointer = NULL;
+    /* For each message type find:
+     * 1) outputting functions
+     * 2) inputting functions */
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        //printf("**** message type: %s\n", current_message->name);
 
-		current_layer = * modeldata->p_layers;
-		while(current_layer)
-		{
-			current_function_pointer = current_layer->functions;
+        temp_function_pointer = NULL;
 
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+        current_layer = * modeldata->p_layers;
+        while(current_layer) {
+            current_function_pointer = current_layer->functions;
 
-				/* Find last output of a messagetype */
-				current_output = current_function->outputs;
-				while(current_output)
-				{
-						if( strcmp(current_message->name, current_output->messagetype) == 0 )
-						{
-							/* Create list of outputting functions of this message type */
-							addfunction_pointer(&temp_function_pointer, current_function);
-						}
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-					current_output = current_output->next;
-				}
+                /* Find last output of a messagetype */
+                current_output = current_function->outputs;
+                while(current_output) {
+                    if( strcmp(current_message->name, current_output->messagetype) == 0 ) {
+                        /* Create list of outputting functions of this message type */
+                        addfunction_pointer(&temp_function_pointer, current_function);
+                    }
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                    current_output = current_output->next;
+                }
 
-			current_layer = current_layer->next;
-		}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-		/* If there are no outputting functions then no syncs are needed */
-		if(temp_function_pointer != NULL)
-		{
-			//printf("******* sync needed ... ");
-			
-			current_layer = * modeldata->p_layers;
-			while(current_layer)
-			{
-				current_function_pointer = current_layer->functions;
+            current_layer = current_layer->next;
+        }
 
-				while(current_function_pointer)
-				{
-					current_function = current_function_pointer->function;
+        /* If there are no outputting functions then no syncs are needed */
+        if(temp_function_pointer != NULL) {
+            //printf("******* sync needed ... ");
 
-					current_input = current_function->inputs;
-					while(current_input)
-					{
-						if( strcmp(current_message->name, current_input->messagetype) == 0 )
-						{
-							/* If current function layer equals current start layer
-							 * then add function to current sync */
-							//if(current_start_layer == current_layer->number)
-							
-							/* If current_message has no sync then add sync */
-							if(current_message->syncs != NULL)
-							{
-								addfunction_pointer(&current_sync->inputting_functions, current_function);
-							}
-							/* else add a new sync */
-							else
-							{
-								//printf("added\n");
-								
-								/* Save current sync as previous sync */
-								previous_sync = current_sync;
-								/* Add new sync */
-								current_sync = addsync(&current_message->syncs);
-								/* If new sync is not the first sync then
-								 * make previous sync point to previous sync */
-								if(current_sync != current_message->syncs)
-								{
-									current_sync->previous_sync_inputting_functions = previous_sync->inputting_functions;
-								}
-								/* Copy message pointer */
-								current_sync->message = current_message;
-								/* Sync name = message_name _ layer_number */
-								strcpy(buffer, current_message->name);
-								strcat(buffer, "_");
-								sprintf(buffer2, "%d", current_layer->number);
-								strcat(buffer, buffer2);
-								current_sync->name = copystr(buffer);
-								/* Add current function to inputting functions */
-								addfunction_pointer(&current_sync->inputting_functions, current_function);
-								/* Next function pointers are place holders */
-								addfunction_pointer(&current_sync->firstdependent, NULL); //current_function);
-								addfunction_pointer(&current_sync->lastdepend, NULL); //last_output_function);
+            current_layer = * modeldata->p_layers;
+            while(current_layer) {
+                current_function_pointer = current_layer->functions;
 
-								/* Copy list of outputting functions to this sync */
-								current_function_pointer2 = temp_function_pointer;
-								while(current_function_pointer2)
-								{
-									addfunction_pointer(&current_sync->outputting_functions, current_function_pointer2->function);
-									current_function_pointer2 = current_function_pointer2->next;
-								}
-							}
-							
-							//printf("****     function: %s\n", current_function->name);
-						}
+                while(current_function_pointer) {
+                    current_function = current_function_pointer->function;
 
-						current_input = current_input->next;
-					}
+                    current_input = current_function->inputs;
+                    while(current_input) {
+                        if( strcmp(current_message->name, current_input->messagetype) == 0 ) {
+                            /* If current function layer equals current start layer
+                             * then add function to current sync */
+                            //if(current_start_layer == current_layer->number)
 
-					current_function_pointer = current_function_pointer->next;
-				}
+                            /* If current_message has no sync then add sync */
+                            if(current_message->syncs != NULL) {
+                                addfunction_pointer(&current_sync->inputting_functions, current_function);
+                            }
+                            /* else add a new sync */
+                            else {
+                                //printf("added\n");
 
-				current_layer = current_layer->next;
-			}
+                                /* Save current sync as previous sync */
+                                previous_sync = current_sync;
+                                /* Add new sync */
+                                current_sync = addsync(&current_message->syncs);
+                                /* If new sync is not the first sync then
+                                 * make previous sync point to previous sync */
+                                if(current_sync != current_message->syncs) {
+                                    current_sync->previous_sync_inputting_functions = previous_sync->inputting_functions;
+                                }
+                                /* Copy message pointer */
+                                current_sync->message = current_message;
+                                /* Sync name = message_name _ layer_number */
+                                strcpy(buffer, current_message->name);
+                                strcat(buffer, "_");
+                                sprintf(buffer2, "%d", current_layer->number);
+                                strcat(buffer, buffer2);
+                                current_sync->name = copystr(buffer);
+                                /* Add current function to inputting functions */
+                                addfunction_pointer(&current_sync->inputting_functions, current_function);
+                                /* Next function pointers are place holders */
+                                addfunction_pointer(&current_sync->firstdependent, NULL); //current_function);
+                                addfunction_pointer(&current_sync->lastdepend, NULL); //last_output_function);
 
-			/* Check if any inputs do not use a filter */
-			flag = 0;
-			current_sync = current_message->syncs;
-			if(current_sync != NULL)
-			{
-				current_function_pointer = current_sync->inputting_functions;
-				while(current_function_pointer)
-				{
-					current_function = current_function_pointer->function;
-	
-					/* If function has a filter for the message type */
-					current_input = current_function->inputs;
-					while(current_input)
-					{
-						if( current_sync->message == current_input->message )
-						{
-							/* If input message has a filter */
-							if(current_input->filter_rule == NULL)
-							{
-								flag = 1;
-							}
-						}
-						
-						current_input = current_input->next;
-					}
-	
-					current_function_pointer = current_function_pointer->next;
-				}
-			}
-			
-			/* For each sync with associated filter add filter
-			 * variable changing functions and
-			 * the agent including agent filter variables */
-			if(flag == 0)
-			{
-				current_sync = current_message->syncs;
-				while(current_sync)
-				{
-					/* For each inputting function find the previous function (if any)
-					 * with the highest layer number */
-					current_function_pointer = current_sync->inputting_functions;
-					while(current_function_pointer)
-					{
-						current_function = current_function_pointer->function;
-	
-						/* If function has a filter for the message type */
-						current_input = current_function->inputs;
-						while(current_input)
-						{
-							if( current_sync->message == current_input->message )
-							{
-								/* If input message has a filter */
-								if(current_input->filter_rule != NULL)
-								{
-								    /* If interaction radius */
-								    if(current_input->filter_rule->box > 0)
-								    {
+                                /* Copy list of outputting functions to this sync */
+                                current_function_pointer2 = temp_function_pointer;
+                                while(current_function_pointer2) {
+                                    addfunction_pointer(&current_sync->outputting_functions, current_function_pointer2->function);
+                                    current_function_pointer2 = current_function_pointer2->next;
+                                }
+                            }
 
-								    }
-								    else
-								    {
+                            //printf("****     function: %s\n", current_function->name);
+                        }
+
+                        current_input = current_input->next;
+                    }
+
+                    current_function_pointer = current_function_pointer->next;
+                }
+
+                current_layer = current_layer->next;
+            }
+
+            /* Check if any inputs do not use a filter */
+            flag = 0;
+            current_sync = current_message->syncs;
+            if(current_sync != NULL) {
+                current_function_pointer = current_sync->inputting_functions;
+                while(current_function_pointer) {
+                    current_function = current_function_pointer->function;
+
+                    /* If function has a filter for the message type */
+                    current_input = current_function->inputs;
+                    while(current_input) {
+                        if( current_sync->message == current_input->message ) {
+                            /* If input message has a filter */
+                            if(current_input->filter_rule == NULL) {
+                                flag = 1;
+                            }
+                        }
+
+                        current_input = current_input->next;
+                    }
+
+                    current_function_pointer = current_function_pointer->next;
+                }
+            }
+
+            /* For each sync with associated filter add filter
+             * variable changing functions and
+             * the agent including agent filter variables */
+            if(flag == 0) {
+                current_sync = current_message->syncs;
+                while(current_sync) {
+                    /* For each inputting function find the previous function (if any)
+                     * with the highest layer number */
+                    current_function_pointer = current_sync->inputting_functions;
+                    while(current_function_pointer) {
+                        current_function = current_function_pointer->function;
+
+                        /* If function has a filter for the message type */
+                        current_input = current_function->inputs;
+                        while(current_input) {
+                            if( current_sync->message == current_input->message ) {
+                                /* If input message has a filter */
+                                if(current_input->filter_rule != NULL) {
+                                    /* If interaction radius */
+                                    if(current_input->filter_rule->box > 0) {
+
+                                    } else {
                                         /* If agent variables exist */
                                         //if(handle_rule_for_agent_variable(current_input->filter_rule, current_xmachine, 0))
                                         /* If filter has the form a.var == m.var/# */
-                                        if(strcmp(current_input->filter_rule->op, "==") == 0)
-                                        {
+                                        if(strcmp(current_input->filter_rule->op, "==") == 0) {
                                             flag = 0;
-                                            if(current_input->filter_rule->lhs_variable != NULL)
-                                            {
+                                            if(current_input->filter_rule->lhs_variable != NULL) {
                                                 if(current_input->filter_rule->lhs_variable->agent != NULL &&
-                                                    current_input->filter_rule->lhs_variable->constant == 1) flag = 1;
+                                                        current_input->filter_rule->lhs_variable->constant == 1) flag = 1;
                                             }
-                                            if(current_input->filter_rule->rhs_variable != NULL)
-                                            {
+                                            if(current_input->filter_rule->rhs_variable != NULL) {
                                                 if(current_input->filter_rule->rhs_variable->agent != NULL &&
-                                                    current_input->filter_rule->rhs_variable->constant == 1) flag = 1;
+                                                        current_input->filter_rule->rhs_variable->constant == 1) flag = 1;
                                             }
-                                            if(flag == 1)
-                                            {
+                                            if(flag == 1) {
                                                 /* Add agent and agent variables to the sync */
                                                 current_xmachine = addxmachine(&current_sync->inputting_agents, current_function->agent_name);
                                                 current_sync->filter_agent_count++;
@@ -3017,13 +2793,10 @@ void calculate_communication_syncs(model_data * modeldata)
 
                                                 /* Find functions that can change the filter variables */
                                                 /* If filter variables are constant no functions can change them */
-                                                if(handle_rule_for_agent_variable(current_input->filter_rule, current_xmachine, 2))
-                                                {
+                                                if(handle_rule_for_agent_variable(current_input->filter_rule, current_xmachine, 2)) {
                                                     current_adj_function = current_function_pointer->function->dependson;
-                                                    while(current_adj_function)
-                                                    {
-                                                        if(strcmp(current_function_pointer->function->agent_name, current_adj_function->function->agent_name) == 0)
-                                                        {
+                                                    while(current_adj_function) {
+                                                        if(strcmp(current_function_pointer->function->agent_name, current_adj_function->function->agent_name) == 0) {
                                                             /* Add functions that can change the filter variables */
                                                             addfunction_pointer(&current_sync->filter_variable_changing_functions, current_adj_function->function);
 
@@ -3036,667 +2809,606 @@ void calculate_communication_syncs(model_data * modeldata)
 
                                                         current_adj_function = current_adj_function->next;
                                                     }
-                                                }
-                                                else
-                                                {
+                                                } else {
                                                     current_input->non_constant_vars = 0;
                                                     /*printf("*** constant vars %s\n", current_input->filter_function);*/
                                                 }
                                             }
                                         }
-								    }
-								}
-							}
-	
-							current_input = current_input->next;
-						}
-	
-						current_function_pointer = current_function_pointer->next;
-					}
-	
-					/* For each agent filter var add to sync vars */
-					current_xmachine = current_sync->inputting_agents;
-					while(current_xmachine)
-					{
-						current_variable = current_xmachine->variables;
-						while(current_variable)
-						{
-							flag = 0;
-							current_variable2 = current_sync->vars;
-							while(current_variable2)
-							{
-								if(strcmp(current_variable->type, current_variable2->type) == 0) flag = 1;
-	
-								current_variable2 = current_variable2->next;
-							}
-							if(flag == 0)
-							{
-								current_variable2 = addvariable(&current_sync->vars);
-								current_variable2->name = copystr(current_variable->name);
-								current_variable2->type = copystr(current_variable->type);
-								current_variable2->constant = current_variable->constant;
-								current_variable2->agent = current_variable->agent;
-								
-								/*printf("agent sync var to sync vars: %s-%s -> %s-%s\n",
-																	current_variable->agent->name, current_variable->name,
-																	current_variable2->agent->name, current_variable2->name);*/
-							}
-	
-							current_variable = current_variable->next;
-						}
-	
-						current_xmachine = current_xmachine->next;
-					}
-					
-					current_sync = current_sync->next;
-				}
-			}
-		}
+                                    }
+                                }
+                            }
 
-		/* free temp_function_pointer */
-		freefunction_pointers(&temp_function_pointer);
-		temp_function_pointer = NULL;
+                            current_input = current_input->next;
+                        }
 
-		current_message = current_message->next;
-	}
+                        current_function_pointer = current_function_pointer->next;
+                    }
+
+                    /* For each agent filter var add to sync vars */
+                    current_xmachine = current_sync->inputting_agents;
+                    while(current_xmachine) {
+                        current_variable = current_xmachine->variables;
+                        while(current_variable) {
+                            flag = 0;
+                            current_variable2 = current_sync->vars;
+                            while(current_variable2) {
+                                if(strcmp(current_variable->type, current_variable2->type) == 0) flag = 1;
+
+                                current_variable2 = current_variable2->next;
+                            }
+                            if(flag == 0) {
+                                current_variable2 = addvariable(&current_sync->vars);
+                                current_variable2->name = copystr(current_variable->name);
+                                current_variable2->type = copystr(current_variable->type);
+                                current_variable2->constant = current_variable->constant;
+                                current_variable2->agent = current_variable->agent;
+
+                                /*printf("agent sync var to sync vars: %s-%s -> %s-%s\n",
+                                									current_variable->agent->name, current_variable->name,
+                                									current_variable2->agent->name, current_variable2->name);*/
+                            }
+
+                            current_variable = current_variable->next;
+                        }
+
+                        current_xmachine = current_xmachine->next;
+                    }
+
+                    current_sync = current_sync->next;
+                }
+            }
+        }
+
+        /* free temp_function_pointer */
+        freefunction_pointers(&temp_function_pointer);
+        temp_function_pointer = NULL;
+
+        current_message = current_message->next;
+    }
 }
 
 int calculate_sync_lengths(model_data * modeldata)
 {
-	/*
-	 * This is not calculated totally correctly.
-	 * Sync lengths should be between start and end syncs.
-	 * But some start syncs depend upon functions before inputting
-	 * functions that are not linked to the sync.
-	 */
+    /*
+     * This is not calculated totally correctly.
+     * Sync lengths should be between start and end syncs.
+     * But some start syncs depend upon functions before inputting
+     * functions that are not linked to the sync.
+     */
 
-	xmachine_message * current_message;
-	sync * current_sync;
-	int total = 0;
+    xmachine_message * current_message;
+    sync * current_sync;
+    int total = 0;
 
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			total += ( current_sync->firstdependent->function->index - current_sync->lastdepend->function->index );
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            total += ( current_sync->firstdependent->function->index - current_sync->lastdepend->function->index );
 
-			current_sync = current_sync->next;
-		}
+            current_sync = current_sync->next;
+        }
 
-		current_message = current_message->next;
-	}
+        current_message = current_message->next;
+    }
 
-	return total;
+    return total;
 }
 
 void order_functions_in_process_layers(model_data * modeldata)
 {
-	/* Place outputting functions first and start their sync afterwards if any.
-	 * Outputting functions with shortest syncs first.
-	 * Place inputting functions last with complete syncs just before if any.
-	 * Inputting functions with shortest syncs last. */
+    /* Place outputting functions first and start their sync afterwards if any.
+     * Outputting functions with shortest syncs first.
+     * Place inputting functions last with complete syncs just before if any.
+     * Inputting functions with shortest syncs last. */
 
-	/* Add check for messages that don't have a first or last */
+    /* Add check for messages that don't have a first or last */
 
-	layer * current_layer;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	function_pointer * current_function_pointer;
-	function_pointer * current_function_pointer2;
-	function_pointer * temp_function_pointer;
-	function_pointer * next_function_pointer;
-	function_pointer * previous_function_pointer;
-	//xmachine_ioput * current_input;
-	//xmachine_ioput * current_output;
-	xmachine_message * current_message;
-	sync * current_sync;
-	int input_score;
-	int output_score;
+    layer * current_layer;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    function_pointer * current_function_pointer;
+    function_pointer * current_function_pointer2;
+    function_pointer * temp_function_pointer;
+    function_pointer * next_function_pointer;
+    function_pointer * previous_function_pointer;
+    //xmachine_ioput * current_input;
+    //xmachine_ioput * current_output;
+    xmachine_message * current_message;
+    sync * current_sync;
+    int input_score;
+    int output_score;
 
-	current_layer = * modeldata->p_layers;
-	while(current_layer)
-	{
-		temp_function_pointer = current_layer->functions;
-		current_layer->functions = NULL;
-		current_function_pointer = temp_function_pointer;
-		while(current_function_pointer)
-		{
-			input_score = 0;
-			output_score = 0;
+    current_layer = * modeldata->p_layers;
+    while(current_layer) {
+        temp_function_pointer = current_layer->functions;
+        current_layer->functions = NULL;
+        current_function_pointer = temp_function_pointer;
+        while(current_function_pointer) {
+            input_score = 0;
+            output_score = 0;
 
-			current_function = current_function_pointer->function;
+            current_function = current_function_pointer->function;
 
-			/* Search syncs for depends and dependent functions */
-			current_message = * modeldata->p_xmessages;
-			while(current_message)
-			{
-				current_sync = current_message->syncs;
-				while(current_sync)
-				{
-					/*if(current_sync->outputting_functions->function == current_function)
-					{
-						output_score += ( current_sync->firstdependent->function->index - current_function->index);
-					}*/
+            /* Search syncs for depends and dependent functions */
+            current_message = * modeldata->p_xmessages;
+            while(current_message) {
+                current_sync = current_message->syncs;
+                while(current_sync) {
+                    /*if(current_sync->outputting_functions->function == current_function)
+                    {
+                    	output_score += ( current_sync->firstdependent->function->index - current_function->index);
+                    }*/
 
-					current_function_pointer2 = current_sync->outputting_functions;
-					while(current_function_pointer2)
-					{
-						current_function2 = current_function_pointer2->function;
+                    current_function_pointer2 = current_sync->outputting_functions;
+                    while(current_function_pointer2) {
+                        current_function2 = current_function_pointer2->function;
 
-						if(current_function2 == current_function)
-						{
-							output_score += ( current_sync->firstdependent->function->index - current_function->index );
-						}
+                        if(current_function2 == current_function) {
+                            output_score += ( current_sync->firstdependent->function->index - current_function->index );
+                        }
 
-						current_function_pointer2 = current_function_pointer2->next;
-					}
+                        current_function_pointer2 = current_function_pointer2->next;
+                    }
 
-					current_function_pointer2 = current_sync->inputting_functions;
-					while(current_function_pointer2)
-					{
-						current_function2 = current_function_pointer2->function;
+                    current_function_pointer2 = current_sync->inputting_functions;
+                    while(current_function_pointer2) {
+                        current_function2 = current_function_pointer2->function;
 
-						if(current_function2 == current_function)
-						{
-							input_score += ( current_function->index - current_sync->lastdepend->function->index);
-						}
+                        if(current_function2 == current_function) {
+                            input_score += ( current_function->index - current_sync->lastdepend->function->index);
+                        }
 
-						current_function_pointer2 = current_function_pointer2->next;
-					}
+                        current_function_pointer2 = current_function_pointer2->next;
+                    }
 
-					//total += ( current_sync->depends->function->index - current_sync->outputting_functions->function->index );
+                    //total += ( current_sync->depends->function->index - current_sync->outputting_functions->function->index );
 
-					current_sync = current_sync->next;
-				}
+                    current_sync = current_sync->next;
+                }
 
-				current_message = current_message->next;
-			}
+                current_message = current_message->next;
+            }
 
-			/*current_input = current_function->inputs;
-			while(current_input)
-			{
-				//printf("\tinput = %s\n", current_input->messagetype);
+            /*current_input = current_function->inputs;
+            while(current_input)
+            {
+            	//printf("\tinput = %s\n", current_input->messagetype);
 
-				current_message = * modeldata->p_xmessages;
-				while(current_message)
-				{
-					if( strcmp(current_input->messagetype, current_message->name) == 0 )
-					{
-						//printf("\t\tlast out on execution layer %d\n", current_message->last);
-						input_score += ( current_function->index - current_message->depends->function->index);
-					}
+            	current_message = * modeldata->p_xmessages;
+            	while(current_message)
+            	{
+            		if( strcmp(current_input->messagetype, current_message->name) == 0 )
+            		{
+            			//printf("\t\tlast out on execution layer %d\n", current_message->last);
+            			input_score += ( current_function->index - current_message->depends->function->index);
+            		}
 
-					current_message = current_message->next;
-				}
+            		current_message = current_message->next;
+            	}
 
-				current_input = current_input->next;
-			}
+            	current_input = current_input->next;
+            }
 
-			current_output = current_function->outputs;
-			while(current_output)
-			{
-				//printf("\toutput = %s\n", current_output->messagetype);
+            current_output = current_function->outputs;
+            while(current_output)
+            {
+            	//printf("\toutput = %s\n", current_output->messagetype);
 
-				current_message = * modeldata->p_xmessages;
-				while(current_message)
-				{
-					if( strcmp(current_output->messagetype, current_message->name) == 0 )
-					{
-						//printf("\t\tfirst input on execution layer %d\n", current_message->first);
-						output_score += ( current_message->dependents->function->index - current_function->index);
-					}
+            	current_message = * modeldata->p_xmessages;
+            	while(current_message)
+            	{
+            		if( strcmp(current_output->messagetype, current_message->name) == 0 )
+            		{
+            			//printf("\t\tfirst input on execution layer %d\n", current_message->first);
+            			output_score += ( current_message->dependents->function->index - current_function->index);
+            		}
 
-					current_message = current_message->next;
-				}
+            		current_message = current_message->next;
+            	}
 
-				current_output = current_output->next;
-			}*/
+            	current_output = current_output->next;
+            }*/
 
-			//printf("input_score = %d;\noutput_score = %d\n", input_score, output_score);
-			if(input_score > output_score) current_function->score = input_score;
-			else if (input_score < output_score) current_function->score = -output_score;
-			else current_function->score = 0;
+            //printf("input_score = %d;\noutput_score = %d\n", input_score, output_score);
+            if(input_score > output_score) current_function->score = input_score;
+            else if (input_score < output_score) current_function->score = -output_score;
+            else current_function->score = 0;
 
-			//printf("current_function->name = %s - score = %d\n", current_function->name, current_function->score);
+            //printf("current_function->name = %s - score = %d\n", current_function->name, current_function->score);
 
-			next_function_pointer = current_function_pointer->next;
+            next_function_pointer = current_function_pointer->next;
 
-			if(current_layer->functions == NULL)
-			{
-				current_layer->functions = current_function_pointer;
-				current_function_pointer->next = NULL;
-			}
-			else
-			{
-				current_function_pointer2 = current_layer->functions;
-				previous_function_pointer = NULL;
-				while(current_function_pointer2)
-				{
-					/* Order functions with least distance outputting functions first
-					 * going to
-					 * least distance inputting functions last */
-					if(		(current_function->score > 0 &&
-							current_function_pointer2->function->score > 0 &&
-							current_function->score > current_function_pointer2->function->score)
-							||
-							(current_function->score < 0 &&
-							current_function_pointer2->function->score < 0 &&
-							current_function->score > current_function_pointer2->function->score)
-							||
-							(((current_function->score <= 0 &&
-								current_function_pointer2->function->score >= 0)
-								||
-								(current_function->score >= 0 &&
-								current_function_pointer2->function->score <= 0)) &&
-							current_function->score < current_function_pointer2->function->score)
-						)
-					{
-						current_function_pointer2 = NULL;
-					}
-					else
-					{
-						previous_function_pointer = current_function_pointer2;
-						current_function_pointer2 = current_function_pointer2->next;
-					}
-				}
+            if(current_layer->functions == NULL) {
+                current_layer->functions = current_function_pointer;
+                current_function_pointer->next = NULL;
+            } else {
+                current_function_pointer2 = current_layer->functions;
+                previous_function_pointer = NULL;
+                while(current_function_pointer2) {
+                    /* Order functions with least distance outputting functions first
+                     * going to
+                     * least distance inputting functions last */
+                    if(		(current_function->score > 0 &&
+                             current_function_pointer2->function->score > 0 &&
+                             current_function->score > current_function_pointer2->function->score)
+                            ||
+                            (current_function->score < 0 &&
+                             current_function_pointer2->function->score < 0 &&
+                             current_function->score > current_function_pointer2->function->score)
+                            ||
+                            (((current_function->score <= 0 &&
+                               current_function_pointer2->function->score >= 0)
+                              ||
+                              (current_function->score >= 0 &&
+                               current_function_pointer2->function->score <= 0)) &&
+                             current_function->score < current_function_pointer2->function->score)
+                      ) {
+                        current_function_pointer2 = NULL;
+                    } else {
+                        previous_function_pointer = current_function_pointer2;
+                        current_function_pointer2 = current_function_pointer2->next;
+                    }
+                }
 
-				if(previous_function_pointer == NULL)
-				{
-					current_function_pointer->next = current_layer->functions;
-					current_layer->functions = current_function_pointer;
-				}
-				else
-				{
-					current_function_pointer->next = previous_function_pointer->next;
-					previous_function_pointer->next = current_function_pointer;
-				}
+                if(previous_function_pointer == NULL) {
+                    current_function_pointer->next = current_layer->functions;
+                    current_layer->functions = current_function_pointer;
+                } else {
+                    current_function_pointer->next = previous_function_pointer->next;
+                    previous_function_pointer->next = current_function_pointer;
+                }
 
-			}
+            }
 
-			current_function_pointer = next_function_pointer;
-		}
+            current_function_pointer = next_function_pointer;
+        }
 
-		current_layer = current_layer->next;
-	}
+        current_layer = current_layer->next;
+    }
 }
 
 void assign_function_order_index_and_sync_dependency_functions(model_data * modeldata)
 {
-	layer * current_layer;
-	xmachine_function * current_function;
-	xmachine_function * first_input_function;
-	xmachine_function * last_dependent_function;
-	function_pointer * current_function_pointer;
-	xmachine_message * current_message;
-	sync * current_sync;
-	int i = 0;
+    layer * current_layer;
+    xmachine_function * current_function;
+    xmachine_function * first_input_function;
+    xmachine_function * last_dependent_function;
+    function_pointer * current_function_pointer;
+    xmachine_message * current_message;
+    sync * current_sync;
+    int i = 0;
 
-	current_layer = * modeldata->p_layers;
-	while(current_layer)
-	{
-		current_function_pointer = current_layer->functions;
-		while(current_function_pointer)
-		{
-			current_function = current_function_pointer->function;
+    current_layer = * modeldata->p_layers;
+    while(current_layer) {
+        current_function_pointer = current_layer->functions;
+        while(current_function_pointer) {
+            current_function = current_function_pointer->function;
 
-			current_function->index = i;
-			i++;
+            current_function->index = i;
+            i++;
 
-			current_function_pointer = current_function_pointer->next;
-		}
+            current_function_pointer = current_function_pointer->next;
+        }
 
-		current_layer = current_layer->next;
-	}
+        current_layer = current_layer->next;
+    }
 
 
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			/* Calculate first input function in index for syncs */
-			first_input_function = NULL;
-			current_function_pointer = current_sync->inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            /* Calculate first input function in index for syncs */
+            first_input_function = NULL;
+            current_function_pointer = current_sync->inputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				if(first_input_function == NULL)
-				{
-					first_input_function = current_function;
-				}
-				else if(current_function->index < first_input_function->index)
-				{
-					first_input_function = current_function;
-				}
+                if(first_input_function == NULL) {
+                    first_input_function = current_function;
+                } else if(current_function->index < first_input_function->index) {
+                    first_input_function = current_function;
+                }
 
-				current_function_pointer = current_function_pointer->next;
-			}
-			current_sync->firstdependent->function = first_input_function;
+                current_function_pointer = current_function_pointer->next;
+            }
+            current_sync->firstdependent->function = first_input_function;
 
-			/* Calculate last sync start dependent function */
-			last_dependent_function = NULL;
-			current_function_pointer = current_sync->outputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+            /* Calculate last sync start dependent function */
+            last_dependent_function = NULL;
+            current_function_pointer = current_sync->outputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				if(last_dependent_function == NULL)
-				{
-					last_dependent_function = current_function;
-				}
-				else if(current_function->index > last_dependent_function->index)
-				{
-					last_dependent_function = current_function;
-				}
+                if(last_dependent_function == NULL) {
+                    last_dependent_function = current_function;
+                } else if(current_function->index > last_dependent_function->index) {
+                    last_dependent_function = current_function;
+                }
 
-				current_function_pointer = current_function_pointer->next;
-			}
-			current_function_pointer = current_sync->filter_variable_changing_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+                current_function_pointer = current_function_pointer->next;
+            }
+            current_function_pointer = current_sync->filter_variable_changing_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				if(last_dependent_function == NULL)
-				{
-					last_dependent_function = current_function;
-				}
-				else if(current_function->index > last_dependent_function->index)
-				{
-					last_dependent_function = current_function;
-				}
+                if(last_dependent_function == NULL) {
+                    last_dependent_function = current_function;
+                } else if(current_function->index > last_dependent_function->index) {
+                    last_dependent_function = current_function;
+                }
 
-				current_function_pointer = current_function_pointer->next;
-			}
-			/* If the sync has a previous sync */
-			current_function_pointer = current_sync->previous_sync_inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+                current_function_pointer = current_function_pointer->next;
+            }
+            /* If the sync has a previous sync */
+            current_function_pointer = current_sync->previous_sync_inputting_functions;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				if(last_dependent_function == NULL)
-				{
-					last_dependent_function = current_function;
-				}
-				else if(current_function->index > last_dependent_function->index)
-				{
-					last_dependent_function = current_function;
-				}
+                if(last_dependent_function == NULL) {
+                    last_dependent_function = current_function;
+                } else if(current_function->index > last_dependent_function->index) {
+                    last_dependent_function = current_function;
+                }
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-			current_sync->lastdepend->function = last_dependent_function;
+            current_sync->lastdepend->function = last_dependent_function;
 
-			current_sync = current_sync->next;
-		}
+            current_sync = current_sync->next;
+        }
 
-		current_message = current_message->next;
-	}
+        current_message = current_message->next;
+    }
 }
 
 void calculate_message_start_end_syncs(model_data * modeldata)
 {
-	/*	xmachine_message * current_message;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	xmachine_ioput * current_input;
-	xmachine_ioput * current_output;
-	xmachine_ioput * current_ioput;
-	layer * current_layer;
-	function_pointer * current_function_pointer;
+    /*	xmachine_message * current_message;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    xmachine_ioput * current_input;
+    xmachine_ioput * current_output;
+    xmachine_ioput * current_ioput;
+    layer * current_layer;
+    function_pointer * current_function_pointer;
 
-	// Calculate points to start sync and end sync communication
-	// and points where states have more than one leading edge
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		// Points to the last function that outs a message type
-		current_function2 = NULL;
+    // Calculate points to start sync and end sync communication
+    // and points where states have more than one leading edge
+    current_message = * modeldata->p_xmessages;
+    while(current_message)
+    {
+    	// Points to the last function that outs a message type
+    	current_function2 = NULL;
 
-		current_layer = * modeldata->p_layers;
-		while(current_layer)
-		{
-			current_function_pointer = current_layer->functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+    	current_layer = * modeldata->p_layers;
+    	while(current_layer)
+    	{
+    		current_function_pointer = current_layer->functions;
+    		while(current_function_pointer)
+    		{
+    			current_function = current_function_pointer->function;
 
-				// Find first input of a messagetype
-				current_input = current_function->inputs;
-				while(current_input)
-				{
-					if(current_message->first == NULL)
-					{
-						if( strcmp(current_message->name, current_input->messagetype) == 0 )
-						{
-							current_ioput = addioput(&current_function->first_inputs);
-							current_ioput->messagetype = copystr(current_message->name);
-						}
-					}
+    			// Find first input of a messagetype
+    			current_input = current_function->inputs;
+    			while(current_input)
+    			{
+    				if(current_message->first == NULL)
+    				{
+    					if( strcmp(current_message->name, current_input->messagetype) == 0 )
+    					{
+    						current_ioput = addioput(&current_function->first_inputs);
+    						current_ioput->messagetype = copystr(current_message->name);
+    					}
+    				}
 
-					current_input = current_input->next;
-				}
+    				current_input = current_input->next;
+    			}
 
-				// Find last output of a messagetype
-				current_output = current_function->outputs;
-				while(current_output)
-				{
-						if( strcmp(current_message->name, current_output->messagetype) == 0 )
-						{
-							current_function2 = current_function;
-						}
+    			// Find last output of a messagetype
+    			current_output = current_function->outputs;
+    			while(current_output)
+    			{
+    					if( strcmp(current_message->name, current_output->messagetype) == 0 )
+    					{
+    						current_function2 = current_function;
+    					}
 
-					current_output = current_output->next;
-				}
+    				current_output = current_output->next;
+    			}
 
-				current_function_pointer = current_function_pointer->next;
-			}
+    			current_function_pointer = current_function_pointer->next;
+    		}
 
-			current_layer = current_layer->next;
-		}
+    		current_layer = current_layer->next;
+    	}
 
-		if(current_function2 != NULL)
-		{
-			current_ioput = addioput(&current_function2->last_outputs);
-			current_ioput->messagetype = copystr(current_message->name);
-			current_ioput->message = current_message;
-		}
+    	if(current_function2 != NULL)
+    	{
+    		current_ioput = addioput(&current_function2->last_outputs);
+    		current_ioput->messagetype = copystr(current_message->name);
+    		current_ioput->message = current_message;
+    	}
 
-		current_message = current_message->next;
-	}*/
+    	current_message = current_message->next;
+    }*/
 }
 
 void apply_sync_data_to_functions(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	sync * current_sync;
-	function_pointer * current_function_pointer;
-	xmachine_function * current_function;
-	//xmachine_ioput * current_ioput;
+    xmachine_message * current_message;
+    sync * current_sync;
+    function_pointer * current_function_pointer;
+    xmachine_function * current_function;
+    //xmachine_ioput * current_ioput;
 
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			/* For the depends */
-			current_function_pointer = current_sync->lastdepend;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            /* For the depends */
+            current_function_pointer = current_sync->lastdepend;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				//printf("**** %s last_outputs %s\n", current_function->name, current_message->name);
+                //printf("**** %s last_outputs %s\n", current_function->name, current_message->name);
 
-				/*current_ioput = addioput(&current_function->last_outputs);
-				current_ioput->messagetype = copystr(current_message->name);
-				current_ioput->message = current_message;*/
-				/* Need to add filters */
-				add_sync_pointer(&current_function->start_syncs, current_sync);
-				/*printf("Function: %s start_sync: %s\n", current_function->name, current_sync->name);*/
+                /*current_ioput = addioput(&current_function->last_outputs);
+                current_ioput->messagetype = copystr(current_message->name);
+                current_ioput->message = current_message;*/
+                /* Need to add filters */
+                add_sync_pointer(&current_function->start_syncs, current_sync);
+                /*printf("Function: %s start_sync: %s\n", current_function->name, current_sync->name);*/
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-			/* For the first input */
-			current_function_pointer = current_sync->firstdependent;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
+            /* For the first input */
+            current_function_pointer = current_sync->firstdependent;
+            while(current_function_pointer) {
+                current_function = current_function_pointer->function;
 
-				//printf("**** %s first_inputs %s\n", current_function->name, current_message->name);
+                //printf("**** %s first_inputs %s\n", current_function->name, current_message->name);
 
-				/*current_ioput = addioput(&current_function->first_inputs);
-				current_ioput->messagetype = copystr(current_message->name);
-				current_ioput->message = current_message;*/
-				add_sync_pointer(&current_function->complete_syncs, current_sync);
-				/*printf("Function: %s complete_sync: %s\n", current_function->name, current_sync->name);*/
+                /*current_ioput = addioput(&current_function->first_inputs);
+                current_ioput->messagetype = copystr(current_message->name);
+                current_ioput->message = current_message;*/
+                add_sync_pointer(&current_function->complete_syncs, current_sync);
+                /*printf("Function: %s complete_sync: %s\n", current_function->name, current_sync->name);*/
 
-				current_function_pointer = current_function_pointer->next;
-			}
+                current_function_pointer = current_function_pointer->next;
+            }
 
-			current_sync = current_sync->next;
-		}
+            current_sync = current_sync->next;
+        }
 
-		current_message = current_message->next;
-	}
+        current_message = current_message->next;
+    }
 }
 
 void calculate_partition_data(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	xmachine_ioput * current_ioput;
+    xmachine_message * current_message;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    xmachine_ioput * current_ioput;
 
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		/* For each agent */
-		current_xmachine = * modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			/* For each function */
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				current_ioput = current_function->outputs;
-				while(current_ioput)
-				{
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						printf("Agent: %s outputs message: %s\n", current_xmachine->name, current_message->name);
-					}
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        /* For each agent */
+        current_xmachine = * modeldata->p_xmachines;
+        while(current_xmachine) {
+            /* For each function */
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                current_ioput = current_function->outputs;
+                while(current_ioput) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        printf("Agent: %s outputs message: %s\n", current_xmachine->name, current_message->name);
+                    }
 
-					current_ioput = current_ioput->next;
-				}
-				
-				current_ioput = current_function->inputs;
-				while(current_ioput)
-				{
-					if( strcmp(current_message->name, current_ioput->messagetype) == 0 )
-					{
-						printf("Agent: %s inputs message: %s\n", current_xmachine->name, current_message->name);
-					}
+                    current_ioput = current_ioput->next;
+                }
 
-					current_ioput = current_ioput->next;
-				}
-				
-				current_function = current_function->next;
-			}
+                current_ioput = current_function->inputs;
+                while(current_ioput) {
+                    if( strcmp(current_message->name, current_ioput->messagetype) == 0 ) {
+                        printf("Agent: %s inputs message: %s\n", current_xmachine->name, current_message->name);
+                    }
 
-			current_xmachine = current_xmachine->next;
-		}
-		
-		current_message = current_message->next;
-	}
+                    current_ioput = current_ioput->next;
+                }
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+
+        current_message = current_message->next;
+    }
 }
 
 void print_sync_data(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	sync * current_sync;
-	xmachine * current_xmachine;
-	xmachine_function * current_function;
-	/*xmachine_ioput * current_ioput;
-	function_pointer * current_function_pointer;
-	xmachine_function * current_function;*/
+    xmachine_message * current_message;
+    sync * current_sync;
+    xmachine * current_xmachine;
+    xmachine_function * current_function;
+    /*xmachine_ioput * current_ioput;
+    function_pointer * current_function_pointer;
+    xmachine_function * current_function;*/
 
-	printf("\n");
-	
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		printf("%s\n", current_message->name);
-		
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			printf("\t%s\n", current_sync->name);
-			if(current_sync->filter_rule != NULL)
-			printf("\trule: %s %s %s\n",
-					current_sync->filter_rule->lhs_print,
-					current_sync->filter_rule->op_print,
-					current_sync->filter_rule->rhs_print);
-			current_xmachine = current_sync->inputting_agents;
-			while(current_xmachine)
-			{
-				printf("\t\t%s\n", current_xmachine->name);
-				current_function = current_xmachine->functions;
-				while(current_function)
-				{
-					printf("\t\t\tf: %s\n", current_function->name);
-					
-					printf("\t\t\trule: %s %s %s\n",
-						current_function->filter_rule->lhs,
-						current_function->filter_rule->op,
-						current_function->filter_rule->rhs);
-					
-					current_function = current_function->next;
-				}
-				
-				current_xmachine = current_xmachine->next;
-			}
-			
-			/*if(current_sync->has_agent_and_message_vars)
-			{
-				printf("\t%s\n", current_sync->name);
-				
-			}*/
-			//printf("\thas_agent_and_message_vars == %d\n", current_sync->has_agent_and_message_vars);
-			
-			/*current_function_pointer = current_sync->inputting_functions;
-			while(current_function_pointer)
-			{
-				current_function = current_function_pointer->function;
-				printf("\t\t%s", current_function->name);
-				current_ioput = current_function->inputs;
-				while(current_ioput)
-				{
-					if( strcmp(current_ioput->messagetype, current_message->name) == 0 &&
-						current_ioput->filter_rule != NULL)
-					{
-						printf("\tfilter");
-					}
-					
-					current_ioput = current_ioput->next;
-				}
-				printf("\n");
-				
-				current_function_pointer = current_function_pointer->next;
-			}*/
+    printf("\n");
 
-			current_sync = current_sync->next;
-		}
-		
-		current_message = current_message->next;
-	}
-	
-	printf("\n");
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        printf("%s\n", current_message->name);
+
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            printf("\t%s\n", current_sync->name);
+            if(current_sync->filter_rule != NULL)
+                printf("\trule: %s %s %s\n",
+                       current_sync->filter_rule->lhs_print,
+                       current_sync->filter_rule->op_print,
+                       current_sync->filter_rule->rhs_print);
+            current_xmachine = current_sync->inputting_agents;
+            while(current_xmachine) {
+                printf("\t\t%s\n", current_xmachine->name);
+                current_function = current_xmachine->functions;
+                while(current_function) {
+                    printf("\t\t\tf: %s\n", current_function->name);
+
+                    printf("\t\t\trule: %s %s %s\n",
+                           current_function->filter_rule->lhs,
+                           current_function->filter_rule->op,
+                           current_function->filter_rule->rhs);
+
+                    current_function = current_function->next;
+                }
+
+                current_xmachine = current_xmachine->next;
+            }
+
+            /*if(current_sync->has_agent_and_message_vars)
+            {
+            	printf("\t%s\n", current_sync->name);
+
+            }*/
+            //printf("\thas_agent_and_message_vars == %d\n", current_sync->has_agent_and_message_vars);
+
+            /*current_function_pointer = current_sync->inputting_functions;
+            while(current_function_pointer)
+            {
+            	current_function = current_function_pointer->function;
+            	printf("\t\t%s", current_function->name);
+            	current_ioput = current_function->inputs;
+            	while(current_ioput)
+            	{
+            		if( strcmp(current_ioput->messagetype, current_message->name) == 0 &&
+            			current_ioput->filter_rule != NULL)
+            		{
+            			printf("\tfilter");
+            		}
+
+            		current_ioput = current_ioput->next;
+            	}
+            	printf("\n");
+
+            	current_function_pointer = current_function_pointer->next;
+            }*/
+
+            current_sync = current_sync->next;
+        }
+
+        current_message = current_message->next;
+    }
+
+    printf("\n");
 }
 
 /** \fn void find_constant_filter_vars(model_data * modeldata)
@@ -3705,123 +3417,111 @@ void print_sync_data(model_data * modeldata)
  */
 void find_constant_filter_vars(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	sync * current_sync;
-	variable * current_variable;
-	variable * current_variable2;
-	xmachine * current_xmachine;
-	int flag;
-		
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		current_sync = current_message->syncs;
-		while(current_sync)
-		{
-			current_xmachine = current_sync->inputting_agents;
-			while(current_xmachine)
-			{
-				current_variable = current_xmachine->variables;
-				while(current_variable)
-				{
-					if(current_variable->constant == 1)
-					{
-						/* check for duplicates */
-						flag = 0;
-						current_variable2 = *modeldata->p_constant_filter_vars;
-						while(current_variable2)
-						{
-							if(current_variable->agent == current_variable2->agent &&
-								strcmp(current_variable->name, current_variable2->name) == 0) flag = 1;
-							
-							current_variable2 = current_variable2->next;
-						}
-						if(flag == 0)
-						{
-							current_variable2 = addvariable(modeldata->p_constant_filter_vars);
-							current_variable2->name = copystr(current_variable->name);
-							current_variable2->type = copystr(current_variable->type);
-							current_variable2->agent = current_variable->agent;
-						}
-					}
-					
-					current_variable = current_variable->next;
-				}
-				
-				current_xmachine = current_xmachine->next;
-			}
-			
-			current_sync = current_sync->next;
-		}
-					
-		current_message = current_message->next;
-	}
+    xmachine_message * current_message;
+    sync * current_sync;
+    variable * current_variable;
+    variable * current_variable2;
+    xmachine * current_xmachine;
+    int flag;
+
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        current_sync = current_message->syncs;
+        while(current_sync) {
+            current_xmachine = current_sync->inputting_agents;
+            while(current_xmachine) {
+                current_variable = current_xmachine->variables;
+                while(current_variable) {
+                    if(current_variable->constant == 1) {
+                        /* check for duplicates */
+                        flag = 0;
+                        current_variable2 = *modeldata->p_constant_filter_vars;
+                        while(current_variable2) {
+                            if(current_variable->agent == current_variable2->agent &&
+                                    strcmp(current_variable->name, current_variable2->name) == 0) flag = 1;
+
+                            current_variable2 = current_variable2->next;
+                        }
+                        if(flag == 0) {
+                            current_variable2 = addvariable(modeldata->p_constant_filter_vars);
+                            current_variable2->name = copystr(current_variable->name);
+                            current_variable2->type = copystr(current_variable->type);
+                            current_variable2->agent = current_variable->agent;
+                        }
+                    }
+
+                    current_variable = current_variable->next;
+                }
+
+                current_xmachine = current_xmachine->next;
+            }
+
+            current_sync = current_sync->next;
+        }
+
+        current_message = current_message->next;
+    }
 }
 
 void calculate_last_read_layer_of_message_types(model_data * modeldata)
 {
-	xmachine_message * current_message;
-	xmachine_message * new_message;
-	layer * current_layer;
-	layer * saved_layer;
-	function_pointer * current_function_pointer;
-	xmachine_function * current_function;
-	xmachine_ioput * current_input;
-	
-	/* For each message type */
-	for(current_message = * modeldata->p_xmessages;
-		current_message != NULL;
-		current_message = current_message->next)
-	{
-		saved_layer = NULL;
-		
-		/* For each layer */
-		for(current_layer = * modeldata->p_layers;
-			current_layer != NULL;
-			current_layer = current_layer->next)
-		{
-			/* For each function */
-			for(current_function_pointer = current_layer->functions;
-				current_function_pointer != NULL;
-				current_function_pointer = current_function_pointer->next)
-			{
-				current_function = current_function_pointer->function;
+    xmachine_message * current_message;
+    xmachine_message * new_message;
+    layer * current_layer;
+    layer * saved_layer;
+    function_pointer * current_function_pointer;
+    xmachine_function * current_function;
+    xmachine_ioput * current_input;
 
-				/* Find last input of a messagetype */
-				for(current_input = current_function->inputs;
-					current_input != NULL;
-					current_input = current_input->next)
-				{
-						if( strcmp(current_message->name, current_input->messagetype) == 0 )
-						{
-							saved_layer = current_layer;
-						}
-				}
-				
-				// Find first input of a messagetype
-				/*current_input = current_function->inputs;
-				while(current_input)
-				{
-					if(current_message->first == NULL)
-					{
-						if( strcmp(current_message->name, current_input->messagetype) == 0 )
-						{
-							current_ioput = addioput(&current_function->first_inputs);
-							current_ioput->messagetype = copystr(current_message->name);
-						}
-					}
+    /* For each message type */
+    for(current_message = * modeldata->p_xmessages;
+            current_message != NULL;
+            current_message = current_message->next) {
+        saved_layer = NULL;
 
-					current_input = current_input->next;
-				}*/
-			}
-		}
-		
-		new_message = addxmessage(&saved_layer->finished_messages);
-		new_message->name = copystr(current_message->name);
-		new_message->has_box2d = current_message->has_box2d;
-		new_message->has_box3d = current_message->has_box3d;
-		//printf("Last layer read of %s - %d\n", current_message->name, saved_layer->number);
-	}
+        /* For each layer */
+        for(current_layer = * modeldata->p_layers;
+                current_layer != NULL;
+                current_layer = current_layer->next) {
+            /* For each function */
+            for(current_function_pointer = current_layer->functions;
+                    current_function_pointer != NULL;
+                    current_function_pointer = current_function_pointer->next) {
+                current_function = current_function_pointer->function;
+
+                /* Find last input of a messagetype */
+                for(current_input = current_function->inputs;
+                        current_input != NULL;
+                        current_input = current_input->next) {
+                    if( strcmp(current_message->name, current_input->messagetype) == 0 ) {
+                        saved_layer = current_layer;
+                    }
+                }
+
+                // Find first input of a messagetype
+                /*current_input = current_function->inputs;
+                while(current_input)
+                {
+                	if(current_message->first == NULL)
+                	{
+                		if( strcmp(current_message->name, current_input->messagetype) == 0 )
+                		{
+                			current_ioput = addioput(&current_function->first_inputs);
+                			current_ioput->messagetype = copystr(current_message->name);
+                		}
+                	}
+
+                	current_input = current_input->next;
+                }*/
+            }
+        }
+
+        new_message = addxmessage(&saved_layer->finished_messages);
+        new_message->name = copystr(current_message->name);
+        new_message->has_box2d = current_message->has_box2d;
+        new_message->has_box3d = current_message->has_box3d;
+        //printf("Last layer read of %s - %d\n", current_message->name, saved_layer->number);
+    }
 }
 
 /** \fn void create_dependency_graph(char * filepath, model_data * modeldata)
@@ -3831,74 +3531,74 @@ void calculate_last_read_layer_of_message_types(model_data * modeldata)
  */
 int create_dependency_graph(char * filepath, model_data * modeldata)
 {
-	int rc;
+    int rc;
 
-	/* Find start state of agents, find error if more than one? */
-	rc = find_agent_start_states(modeldata);
-	if(rc != 0) return -1;
+    /* Find start state of agents, find error if more than one? */
+    rc = find_agent_start_states(modeldata);
+    if(rc != 0) return -1;
 
-	printf("Creating dependency graph\n");
-	/* Gather information */
-	catalogue_agent_communications(modeldata);
-	/* Look for internal dependencies */
-	catalogue_agent_internal(modeldata);
-	
-	rc = check_message_consistancy(modeldata);
-	//if(rc != 0) return -1;
+    printf("Creating dependency graph\n");
+    /* Gather information */
+    catalogue_agent_communications(modeldata);
+    /* Look for internal dependencies */
+    catalogue_agent_internal(modeldata);
 
-	/* check loops in dependencies */
-	rc = check_dependency_loops(modeldata);
-	if(rc != 0) return -1;
-	printf("Finished dependency loop check\n");
+    rc = check_message_consistancy(modeldata);
+    //if(rc != 0) return -1;
 
-	catalogue_states_edges(modeldata);
-	calculate_dependency_graph(modeldata);
+    /* check loops in dependencies */
+    rc = check_dependency_loops(modeldata);
+    if(rc != 0) return -1;
+    printf("Finished dependency loop check\n");
 
-	calculate_message_input_output_agents(modeldata);
-	
-	calculate_communication_syncs(modeldata);
+    catalogue_states_edges(modeldata);
+    calculate_dependency_graph(modeldata);
 
-	assign_function_order_index_and_sync_dependency_functions(modeldata);
-	printf("Total communication sync lengths = %d\n", calculate_sync_lengths(modeldata));
-	printf("Ordering functions in process layers\n");
-	//output_process_order_graph("process_order_graph_pre.dot", filepath, modeldata);
-	order_functions_in_process_layers(modeldata);
-	assign_function_order_index_and_sync_dependency_functions(modeldata);
-	printf("New communication sync lengths = %d\n", calculate_sync_lengths(modeldata));
+    calculate_message_input_output_agents(modeldata);
+
+    calculate_communication_syncs(modeldata);
+
+    assign_function_order_index_and_sync_dependency_functions(modeldata);
+    printf("Total communication sync lengths = %d\n", calculate_sync_lengths(modeldata));
+    printf("Ordering functions in process layers\n");
+    //output_process_order_graph("process_order_graph_pre.dot", filepath, modeldata);
+    order_functions_in_process_layers(modeldata);
+    assign_function_order_index_and_sync_dependency_functions(modeldata);
+    printf("New communication sync lengths = %d\n", calculate_sync_lengths(modeldata));
     printf("\n");
-    
-	/*if(modeldata->depends_style == 0)*/
-	output_stategraph("stategraph.dot", filepath, modeldata, 1);
-	output_stategraph_colour("stategraph_colour.dot", filepath, modeldata, 1);
-	/*if(modeldata->depends_style == 1) output_dgraph("dgraph.dot", filepath, modeldata);*/
-	//output_communication_graph("communication_graph.dot", filepath, modeldata);
-	output_process_order_graph("process_order_graph.dot", filepath, modeldata);
-	
-	output_latex("latex.tex", filepath, modeldata);
 
-	/*calculate_message_start_end_syncs(modeldata);
-	 * replaced with:
-	 */
-	apply_sync_data_to_functions(modeldata);
+    /*if(modeldata->depends_style == 0)*/
+    output_stategraph("stategraph.dot", filepath, modeldata, 1);
+    output_stategraph_colour("stategraph_colour.dot", filepath, modeldata, 1);
+    /*if(modeldata->depends_style == 1) output_dgraph("dgraph.dot", filepath, modeldata);*/
+    //output_communication_graph("communication_graph.dot", filepath, modeldata);
+    output_process_order_graph("process_order_graph.dot", filepath, modeldata);
 
-	calculate_filter_agent_states(modeldata);
-	
-	calculate_last_read_layer_of_message_types(modeldata);
-	
-	/* Calculate data for possible partitioning scheme */
-	/*calculate_partition_data(modeldata);*/
-	/*print_sync_data(modeldata);*/
+    output_latex("latex.tex", filepath, modeldata);
 
-	find_constant_filter_vars(modeldata);
+    /*calculate_message_start_end_syncs(modeldata);
+     * replaced with:
+     */
+    apply_sync_data_to_functions(modeldata);
+
+    calculate_filter_agent_states(modeldata);
+
+    calculate_last_read_layer_of_message_types(modeldata);
+
+    /* Calculate data for possible partitioning scheme */
+    /*calculate_partition_data(modeldata);*/
+    /*print_sync_data(modeldata);*/
+
+    find_constant_filter_vars(modeldata);
     printf("\n");
-	
-	return 0;
+
+    return 0;
 }
 
 /** \defgroup dependencygraph Dependency Graph
  *
  * The dependency graph
- * 
+ *
  * \dot
  * digraph finite_state_machine
  * {
@@ -3922,5 +3622,5 @@ int create_dependency_graph(char * filepath, model_data * modeldata)
  *	LR_8 -> LR_5 [ label = "S(a)" ];
  * }
  * \enddot
- * 
+ *
  */

--- a/header.h
+++ b/header.h
@@ -2,6 +2,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*****************************************************************
+ * 
+ * Change FLAME_XPARSER_DIR here if required
+ * 
+ *****************************************************************/
+ /** \def FLAME_XPARSER_DIR
+* \brief FLAME_XPARSER_DIR - the location of the xparser templates
+*/
+#define FLAME_XPARSER_DIR "."
+
 /** \def NAME
  * \brief Release name. */
 #define NAME "FLAME X-machine agent parser"
@@ -13,7 +23,7 @@
 #define VERSIONMINOR 17
 /** \def VERSIONMICRO
  * \brief Bug fixes. */
-#define VERSIONMICRO 0
+#define VERSIONMICRO 1
 /** \def DEBUG
  * \brief Debug output. */
 #define DEBUG 0
@@ -260,8 +270,8 @@ struct xmachine_function
 	struct xmachine_ioput * outputs;
 
 	/* Holds first inputs and last outputs of specific message types */
-	//struct xmachine_ioput * first_inputs;
-	//struct xmachine_ioput * last_outputs;
+	/*struct xmachine_ioput * first_inputs;*/
+	/*struct xmachine_ioput * last_outputs;*/
 	struct sync_pointer * start_syncs;
 	struct sync_pointer * complete_syncs;
 
@@ -395,6 +405,7 @@ struct xmachine
 	char yvar[50];							/**< Variable name for position in y-axis. */
 	char zvar[50];							/**< Variable name for position in z-axis. */
 	int var_number;							/**< Number of variables in memory. */
+	int gsl_lib;							/** bool to indicate the GSL_RND_SEED is present - thus gsl_lib being used */
 
 	struct xmachine * next;				/**< Pointer next X-machine in list. */
 };
@@ -542,6 +553,7 @@ struct model_data
 	int depends_style;
 	input_file ** p_files;
 	int debug_mode;
+	int gsl_lib;
 };
 
 /* explicit define datatypes so dont need to use struct anymore */
@@ -672,7 +684,7 @@ void remove_adj_function_recent(xmachine_function * function1);
 void add_adj_function(xmachine_function * function1, xmachine_function * function2, char * type);
 void free_adj_function(adj_function *adj_functions);
 
-//functions for output_colour
+/*functions for output_colour*/
 void addagent_colour(agent_colour **p_agent_colours, char * name, int colour_value);
 void freeagent_colours(agent_colour **p_agent_colours);
 int displayagent_colour(agent_colour **p_agent_colours, char * name);

--- a/header.tmpl
+++ b/header.tmpl
@@ -23,6 +23,16 @@
 #define FLAME_TEST_PRINT_START_AND_END_OF_LIBMBOARD_CALLS 0
 #define FLAME_USE_FILTERS_IN_SYNC 1
 
+/*#define PAUSE printf("PAUSE - type anything to continue");i=getc(stdin);*/
+#define PAUSE
+
+#ifdef START_END
+int start_simulation(void);
+int end_simulation(void);
+int start_iteration(void);
+int end_iteration(void);
+#endif
+
 <?if parallel?>#include <mpi.h>
 <?end if?>
 /* Checking macros */
@@ -31,6 +41,24 @@
 #else
 #define CHECK_POINTER(PT)
 #endif
+
+<?foreach xagent?>
+<?foreach state?>
+<?if last?>
+#define START_LOOP_OVER_$agent_name_AGENTS  \
+    current_xmachine_$agent_name_holder = $agent_name_$name_state->agents;\
+    while (current_xmachine_$agent_name_holder) {\
+	temp_xmachine_$agent_name_holder = current_xmachine_$agent_name_holder->next;\
+	current_xmachine_$agent_name = current_xmachine_$agent_name_holder->agent;\
+	current_xmachine->xmachine_$agent_name = current_xmachine_$agent_name;
+#define END_LOOP_OVER_$agent_name_AGENTS \
+	current_xmachine_$agent_name = NULL;\
+	current_xmachine->xmachine_$agent_name = NULL;\
+	current_xmachine_$agent_name_holder = temp_xmachine_$agent_name_holder;\
+    }
+<?end if?>
+<?end foreach?>
+<?end foreach?>
 
 <?foreach envvar?>
 /** \def $uc_name
@@ -254,6 +282,7 @@ struct node_information
 {
 	int node_id;	/**< Node ID. */
 	double partition_data[6];	/**< Defines bounding box. */
+	int neighbours[10]; /**< Defines the neighbours to this node - -99 if no neighbour */
 	int agents_in_halo;	/**< Number of agents in the halo region. */
 	int agent_total;	/**< Total number of agents on the node. */
 	struct xmachine * agents;	/**< Pointer to list of X-machines. */
@@ -348,6 +377,13 @@ node_information ** p_node_info;
 /** \var node_information * current_node
 * \brief Pointer to current node */
 node_information * current_node;
+
+<?if serial?>
+/** \var int node_number\n
+ *  \brief Node number (not needed for serial codes) */
+int node_number;
+<?end if?>
+
 <?if parallel?>
 /** \var MPI_Status status
 * \brief MPI status */

--- a/main.tmpl
+++ b/main.tmpl
@@ -2,8 +2,20 @@
  * \file  main.c
  * \brief Holds main function of the program.
  */
-
 #include "header.h"
+#include <time.h>
+
+<?if gsl_lib?>
+#ifdef GSL_LIB
+#include <gsl/gsl_rng.h>
+
+//Global GSL RNG: global constant variable: continues to exist for whole duration of main
+gsl_rng * FLAME_GSL_RNG;  /* global GSL random generator */
+const gsl_rng_type * T;
+unsigned long int gsl_seed;
+#endif
+<?end if?>
+
 #define COMPACT_PRINTOUT_P_THRESHOLD 8
 
 /** \fn int main(int argc, char * argv[])
@@ -36,7 +48,8 @@ int main(int argc, char * argv[])
 	/* Particle cloud data */
 	double cloud_data[6] = {0.0,0.0,0.0,0.0,0.0,0.0};
 <?if debug?>	/* Count to debug function branches */
-	int FLAME_debug_count;<?end if?>
+	int FLAME_debug_count;
+<?end if?>
 
 /* For partition method. Makes geometric (-g flag) the default but may be overridden with -r for round-robin */
 	int partition_method=1;
@@ -57,8 +70,12 @@ int main(int argc, char * argv[])
 
 	/* Output frequency is 1 as default */
 	output_frequency = 1;
+
 	/* Set random seed */
-/*	srand(time(NULL)); */
+	srand((unsigned int) time(NULL));
+<?if debug?>
+	srand(0);
+<?end if?>
 
 	<?if parallel?>
 	/* MPI initialisation routine */
@@ -282,6 +299,40 @@ if(argc < 2)
     }
 <?end if?>
 
+<?if gsl_lib?>
+#ifdef GSL_LIB
+/******* GSL INIT */
+/* Use GSL Random Number Generator
+*
+* Has two environment variables:
+*	GSL_RNG_TYPE - generator type
+*	GSL_RNG_SEED - initial seed values
+* read and set through gsl_rng_env_setup()
+*/
+
+/* Read environment variables if set - returned as gsl_rng_default and gsl_rng_default_seed */
+	gsl_rng_env_setup();
+
+	//returns a pointer to a newly-created instance of gsl_rng
+	T = gsl_rng_default;
+	FLAME_GSL_RNG = gsl_rng_alloc (T);
+
+	gsl_seed = gsl_rng_default_seed;
+	<?if debug?>	
+	gsl_seed = (unsigned long int) FLAME_environment_variable_GSL_RNG_SEED;
+	if(gsl_seed == 0) gsl_seed = gsl_rng_default_seed;
+	<?end if?>
+	if(gsl_seed == 0) gsl_seed = (unsigned long int)time(NULL);
+
+	gsl_rng_set(FLAME_GSL_RNG, gsl_seed);
+
+	printf ("[GSL Random Number Generator] generator type: %s\n", gsl_rng_name (FLAME_GSL_RNG));
+	printf ("[GSL Random Number Generator] seed = %lu\n", gsl_seed);
+	printf ("[GSL Random Number Generator] first value = %lu\n", gsl_rng_get (FLAME_GSL_RNG));
+/******* END GSL INIT */
+#endif
+<?end if?>
+
 /* Use MB_IndexMap routines from libmboard v0.2 */
 /* For each agent constant (that is used in a filter(?))
  * declare an index map handle */
@@ -394,11 +445,70 @@ if(argc < 2)
 
 	(void)fclose(file);
 <?if parallel?>	}<?end if?>
-	/* Start timing */
+
+	/* For each message check if their exists agents that input/output the message */
+	<?foreach message?>FLAME_$name_message_board_write = 0;
+	FLAME_$name_message_board_read = 0;
+	/* Sending agents */
+	<?foreach sendingxagent?>if($name_$start_state_state->agents != NULL) FLAME_$message_name_message_board_write = 1;
+	<?end foreach?>
+	/* Reading agents */
+	<?foreach readingxagent?>if($name_$start_state_state->agents != NULL) FLAME_$message_name_message_board_read = 1;
+	<?end foreach?>
+	/* Call message board library with details */
+	if(FLAME_$name_message_board_write == 0 &&
+		FLAME_$name_message_board_read == 0)
+			rc = MB_SetAccessMode(b_$name, MB_MODE_IDLE);
+	if(FLAME_$name_message_board_write == 1 &&
+		FLAME_$name_message_board_read == 0)
+			rc = MB_SetAccessMode(b_$name, MB_MODE_WRITEONLY);
+	if(FLAME_$name_message_board_write == 0 &&
+		FLAME_$name_message_board_read == 1)
+			rc = MB_SetAccessMode(b_$name, MB_MODE_READONLY);
+	if(FLAME_$name_message_board_write == 1 &&
+		FLAME_$name_message_board_read == 1)
+			rc = MB_SetAccessMode(b_$name, MB_MODE_READWRITE);
+	#ifdef ERRCHECK
+	if (rc != MB_SUCCESS)
+	{
+	   fprintf(stderr, "ERROR: Could not set access mode of '$name' board\n");
+	   switch(rc) {
+		   case MB_ERR_INVALID:
+			   fprintf(stderr, "\t reason: '$name' board is invalid\n");
+			   break;
+		   case MB_ERR_LOCKED:
+			   fprintf(stderr, "\t reason: '$name' board is locked\n");
+			   break;
+		   case MB_ERR_MEMALLOC:
+			   fprintf(stderr, "\t reason: out of memory\n");
+			   break;
+		   case MB_ERR_INTERNAL:
+			   fprintf(stderr, "\t reason: internal error. Recompile libmoard in debug mode for more info \n");
+			   break;
+		   default:
+			   fprintf(stderr, "\t MB_SyncStart returned error code: %d (see libmboard docs for details)\n", rc);
+			   break;
+	   }
+		   <?if parallel?>MPI_Abort(MPI_COMM_WORLD, rc);<?end if?>
+		   exit(rc);
+	}
+	#endif
+	<?end foreach?>
+
+#ifdef START_END	
+/* Call initialisation function */
+	start_simulation();
+#endif
+
+/* Start timing */
 	start = get_time();
 
 	for(iteration_loop=iteration_number+1; iteration_loop < iteration_number+iteration_total+1; iteration_loop++)
 	{
+#ifdef START_END
+/* Start iteration function */
+	start_iteration();
+#endif
 		interval = get_time();
 
 		/* Print out iteration number */
@@ -513,7 +623,9 @@ if(argc < 2)
 		current_xmachine_$agent_name_holder = $agent_name_$name_state->agents;
 		while(current_xmachine_$agent_name_holder)
 		{
+<?if debug?>
 			FLAME_debug_count = 0;
+<?end if?>
 	<?foreach function?>		/* Function: $name */
 			<?if condition?>if($condition(current_xmachine_$agent_name_holder->agent)==1)
 			{ FLAME_debug_count++; }<?end if?>
@@ -826,6 +938,10 @@ if(FLAME_$name_message_board_read == 0)
     #endif
 <?end foreach?>
 <?end foreach?>
+	if(iteration_loop%output_frequency == output_offset)
+	{
+		saveiterationdata(iteration_loop);
+	}
 <?foreach xagent?><?foreach state?>
 	/*printf("$agent_name_$name_state->count = %d\n", $agent_name_$name_state->count);*/
 	$agent_name_$name_state->count = 0;
@@ -867,12 +983,29 @@ if(FLAME_$name_message_board_read == 0)
 		(void)fputs("</time></iteration>\n", file);
 		(void)fclose(file);
 <?if parallel?>		}<?end if?>
+
+#ifdef START_END
+/* End iteration function */
+	end_iteration();
+#endif
 	}
+
+#ifdef START_END
+/* End simualtion function */
+	end_simulation();
+#endif
 
 <?if parallel?>
     /* Wait till all procs are done */
     MPI_Barrier(MPI_COMM_WORLD);
 <?end if?>    
+
+<?if gsl_lib?>
+#ifdef GSL_LIB
+	/* Free pointer GSL RNG */
+	gsl_rng_free(FLAME_GSL_RNG);
+#endif
+<?end if?>
 
 	/* Stop timing and print total time */
 	stop = get_time();

--- a/memory.c
+++ b/memory.c
@@ -2,69 +2,66 @@
 
 void free_modeldata(model_data * modeldata)
 {
-	freexmachines(modeldata->p_xmachines);
-	freexmessages(modeldata->p_xmessages);
-	freeenvfunc(modeldata->p_envfuncs);
-	freevariables(modeldata->p_envvars);
-	freevariables(modeldata->p_envdefines);
-	freevariables(modeldata->p_allvars);
-	freevariables(modeldata->p_constant_filter_vars);
-	freelayers(modeldata->p_layers);
-	freedatatypes(modeldata->p_datatypes);
-	free_flame_communications(modeldata->p_communications);
-	free_time_units(modeldata->p_time_units);
-	free_input_files(modeldata->p_files);
-	free(modeldata->name);
-	free(modeldata);
+    freexmachines(modeldata->p_xmachines);
+    freexmessages(modeldata->p_xmessages);
+    freeenvfunc(modeldata->p_envfuncs);
+    freevariables(modeldata->p_envvars);
+    freevariables(modeldata->p_envdefines);
+    freevariables(modeldata->p_allvars);
+    freevariables(modeldata->p_constant_filter_vars);
+    freelayers(modeldata->p_layers);
+    freedatatypes(modeldata->p_datatypes);
+    free_flame_communications(modeldata->p_communications);
+    free_time_units(modeldata->p_time_units);
+    free_input_files(modeldata->p_files);
+    free(modeldata->name);
+    free(modeldata);
 }
 
 input_file * add_input_file(input_file ** p_files)
 {
-	input_file * current, * tmp = NULL;
-	current = *p_files;
-	
-	while(current)
-	{
-		tmp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	current = (input_file *)malloc(sizeof(input_file));
-	/* Make tmp->next point to current if tmp exists */
-	if(tmp) tmp->next = current;
-	else
-	{
-		*p_files = current;
-	}
-	/* Make current->next point to NULL */
-	current->next = NULL;
-	current->file = NULL;
-	current->fullfilepath = NULL;
-	current->fulldirectory = NULL;
-	current->localdirectory = NULL;
-	current->enabled = 1;
-	
-	/* Return new element */
-	return current;
+    input_file * current, * tmp = NULL;
+    current = *p_files;
+
+    while(current) {
+        tmp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    current = (input_file *)malloc(sizeof(input_file));
+    /* Make tmp->next point to current if tmp exists */
+    if(tmp) tmp->next = current;
+    else {
+        *p_files = current;
+    }
+    /* Make current->next point to NULL */
+    current->next = NULL;
+    current->file = NULL;
+    current->fullfilepath = NULL;
+    current->fulldirectory = NULL;
+    current->localdirectory = NULL;
+    current->enabled = 1;
+
+    /* Return new element */
+    return current;
 }
 
 void free_input_files(input_file ** p_files)
 {
-	input_file * temp, * head;
-	head = *p_files;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head->file);
-		free(head->fullfilepath);
-		free(head->fulldirectory);
-		free(head->localdirectory);
-		free(head);
-		head = temp;
-	}
-	
-	*p_files = NULL;
+    input_file * temp, * head;
+    head = *p_files;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head->file);
+        free(head->fullfilepath);
+        free(head->fulldirectory);
+        free(head->localdirectory);
+        free(head);
+        head = temp;
+    }
+
+    *p_files = NULL;
 }
 
 /** \fn sync * addfcode(sync ** p_code)
@@ -74,154 +71,146 @@ void free_input_files(input_file ** p_files)
  */
 sync * addsync(sync ** p_sync)
 {
-	sync * current, * tmp = NULL;
-	current = *p_sync;
+    sync * current, * tmp = NULL;
+    current = *p_sync;
 
-	while(current)
-	{
-		tmp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	current = (sync *)malloc(sizeof(sync));
-	/* Make tmp->next point to current if tmp exists */
-	if(tmp) tmp->next = current;
-	else
-	{
-		*p_sync = current;
-	}
-	/* Make current->next point to NULL */
-	current->message = NULL;
-	current->name = NULL;
-	current->filter_rule = NULL;
-	current->vars = NULL;
-	current->inputting_agents = NULL;
-	current->filter_agent_count = 0;
-	current->has_agent_and_message_vars = 0;
-	current->lastdepend = NULL;
-	current->firstdependent = NULL;
-	current->outputting_functions = NULL;
-	current->filter_variable_changing_functions = NULL;
-	current->previous_sync_inputting_functions = NULL;
-	current->inputting_functions = NULL;
-	current->filters = NULL;
-	current->next = NULL;
+    while(current) {
+        tmp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    current = (sync *)malloc(sizeof(sync));
+    /* Make tmp->next point to current if tmp exists */
+    if(tmp) tmp->next = current;
+    else {
+        *p_sync = current;
+    }
+    /* Make current->next point to NULL */
+    current->message = NULL;
+    current->name = NULL;
+    current->filter_rule = NULL;
+    current->vars = NULL;
+    current->inputting_agents = NULL;
+    current->filter_agent_count = 0;
+    current->has_agent_and_message_vars = 0;
+    current->lastdepend = NULL;
+    current->firstdependent = NULL;
+    current->outputting_functions = NULL;
+    current->filter_variable_changing_functions = NULL;
+    current->previous_sync_inputting_functions = NULL;
+    current->inputting_functions = NULL;
+    current->filters = NULL;
+    current->next = NULL;
 
-	/* Return new element */
-	return current;
+    /* Return new element */
+    return current;
 }
 
 void freesync(sync ** p_sync)
 {
-	sync * temp, * head;
-	head = *p_sync;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head->name);
-		free_rule_data(&head->filter_rule);
-		freevariables(&head->vars);
-		freexmachines(&head->inputting_agents);
-		freefunction_pointers(&head->outputting_functions);
-		freefunction_pointers(&head->filter_variable_changing_functions);
-		//freesync(&head->previous_sync);
-		freefunction_pointers(&head->inputting_functions);
-		freefunction_pointers(&head->lastdepend);
-		freefunction_pointers(&head->firstdependent);
-		free_ioput(&head->filters);
-		free(head);
-		head = temp;
-	}
+    sync * temp, * head;
+    head = *p_sync;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head->name);
+        free_rule_data(&head->filter_rule);
+        freevariables(&head->vars);
+        freexmachines(&head->inputting_agents);
+        freefunction_pointers(&head->outputting_functions);
+        freefunction_pointers(&head->filter_variable_changing_functions);
+        //freesync(&head->previous_sync);
+        freefunction_pointers(&head->inputting_functions);
+        freefunction_pointers(&head->lastdepend);
+        freefunction_pointers(&head->firstdependent);
+        free_ioput(&head->filters);
+        free(head);
+        head = temp;
+    }
 
-	*p_sync = NULL;
+    *p_sync = NULL;
 }
 
 void add_sync_pointer(sync_pointer ** p_sync_pointers, sync * current_sync)
 {
-	sync_pointer * current;
+    sync_pointer * current;
 
-	/* And current is the new element */
-	if((current = (sync_pointer *)malloc(sizeof(sync_pointer))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make current->next point to NULL */
-	current->current_sync = current_sync;
-	current->next = *p_sync_pointers;
-	*p_sync_pointers = current;
+    /* And current is the new element */
+    if((current = (sync_pointer *)malloc(sizeof(sync_pointer))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make current->next point to NULL */
+    current->current_sync = current_sync;
+    current->next = *p_sync_pointers;
+    *p_sync_pointers = current;
 }
 
 void free_sync_pointers(sync_pointer ** p_sync_pointers)
 {
-	sync_pointer * temp, * head;
-	head = *p_sync_pointers;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head);
-		head = temp;
-	}
+    sync_pointer * temp, * head;
+    head = *p_sync_pointers;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head);
+        head = temp;
+    }
 
-	*p_sync_pointers = NULL;
+    *p_sync_pointers = NULL;
 }
 
 xmachine_ioput * addioput(xmachine_ioput ** p_ioput)
 {
-	xmachine_ioput * current, * tmp = NULL;
-	current = *p_ioput;
-	
-	while(current)
-	{
-		tmp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	current = (xmachine_ioput *)malloc(sizeof(xmachine_ioput));
-	/* Make tmp->next point to current if tmp exists */
-	if(tmp) tmp->next = current;
-	else
-	{
-		*p_ioput = current;
-	}
-	/* Make current->next point to NULL */
-	current->next = NULL;
-	current->filter_function = NULL;
-	current->filter_rule = NULL;
-	current->function = NULL;
-	current->message = NULL;
-	current->sort_function = NULL;
-	current->sort_key = NULL;
-	current->sort_order = NULL;
-	current->non_constant_vars = 1;
-	current->box_apothem = NULL;
+    xmachine_ioput * current, * tmp = NULL;
+    current = *p_ioput;
 
-	/* Return new element */
-	return current;
+    while(current) {
+        tmp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    current = (xmachine_ioput *)malloc(sizeof(xmachine_ioput));
+    /* Make tmp->next point to current if tmp exists */
+    if(tmp) tmp->next = current;
+    else {
+        *p_ioput = current;
+    }
+    /* Make current->next point to NULL */
+    current->next = NULL;
+    current->filter_function = NULL;
+    current->filter_rule = NULL;
+    current->function = NULL;
+    current->message = NULL;
+    current->sort_function = NULL;
+    current->sort_key = NULL;
+    current->sort_order = NULL;
+    current->non_constant_vars = 1;
+    current->box_apothem = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 void free_ioput(xmachine_ioput ** p_ioput)
 {
-	xmachine_ioput * temp, * head;
-	head = *p_ioput;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head->filter_function);
-		free_rule_data(&head->filter_rule);
-		free(head->messagetype);
-		free(head->sort_function);
-		free(head->sort_key);
-		free(head->sort_order);
-		free(head->box_apothem);
-		free(head);
-		head = temp;
-	}
-	
-	*p_ioput = NULL;
+    xmachine_ioput * temp, * head;
+    head = *p_ioput;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head->filter_function);
+        free_rule_data(&head->filter_rule);
+        free(head->messagetype);
+        free(head->sort_function);
+        free(head->sort_key);
+        free(head->sort_order);
+        free(head->box_apothem);
+        free(head);
+        head = temp;
+    }
+
+    *p_ioput = NULL;
 }
 
 /** \fn f_code * addfcode(f_code ** p_code)
@@ -231,28 +220,26 @@ void free_ioput(xmachine_ioput ** p_ioput)
  */
 f_code * addfcode(f_code ** p_code)
 {
-	f_code * current, * tmp = NULL;
-	current = *p_code;
-	
-	while(current)
-	{
-		tmp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	current = (f_code *)malloc(sizeof(f_code));
-	/* Make tmp->next point to current if tmp exists */
-	if(tmp) tmp->next = current;
-	else
-	{
-		*p_code = current;
-	}
-	/* Make current->next point to NULL */
-	current->code = NULL;
-	current->next = NULL;
-	
-	/* Return new element */
-	return current;
+    f_code * current, * tmp = NULL;
+    current = *p_code;
+
+    while(current) {
+        tmp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    current = (f_code *)malloc(sizeof(f_code));
+    /* Make tmp->next point to current if tmp exists */
+    if(tmp) tmp->next = current;
+    else {
+        *p_code = current;
+    }
+    /* Make current->next point to NULL */
+    current->code = NULL;
+    current->next = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freefcode(f_code ** p_code)
@@ -261,19 +248,18 @@ f_code * addfcode(f_code ** p_code)
  */
 void freefcode(f_code ** p_code)
 {
-	f_code * temp, * head;
-	head = *p_code;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		/*freechars(&head->code);*/
-		free(head);
-		head = temp;
-	}
-	
-	*p_code = NULL;
+    f_code * temp, * head;
+    head = *p_code;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        /*freechars(&head->code);*/
+        free(head);
+        head = temp;
+    }
+
+    *p_code = NULL;
 }
 
 /** \fn variable * addvariable(variable ** p_vars)
@@ -283,37 +269,35 @@ void freefcode(f_code ** p_code)
  */
 variable * addvariable(variable ** p_vars)
 {
-	variable * current, * tmp = NULL;
-	current = *p_vars;
-	
-	while(current)
-	{
-		tmp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	current = (variable *)malloc(sizeof(variable));
-	/* Make tmp->next point to current if tmp exists */
-	if(tmp) tmp->next = current;
-	else
-	{
-		*p_vars = current;
-	}
-	/* Make current->next point to NULL */
-	current->type = NULL;
-	current->name = NULL;
-	current->value = NULL;
-	current->datatype = NULL;
-	current->file = NULL;
-	current->next = NULL;
-	current->typenotarray = NULL;
-	current->message = NULL;
-	current->agent = NULL;
-	current->constant = 0;
-	current->description = NULL;
+    variable * current, * tmp = NULL;
+    current = *p_vars;
 
-	/* Return new element */
-	return current;
+    while(current) {
+        tmp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    current = (variable *)malloc(sizeof(variable));
+    /* Make tmp->next point to current if tmp exists */
+    if(tmp) tmp->next = current;
+    else {
+        *p_vars = current;
+    }
+    /* Make current->next point to NULL */
+    current->type = NULL;
+    current->name = NULL;
+    current->value = NULL;
+    current->datatype = NULL;
+    current->file = NULL;
+    current->next = NULL;
+    current->typenotarray = NULL;
+    current->message = NULL;
+    current->agent = NULL;
+    current->constant = 0;
+    current->description = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freevariables(variable ** p_vars)
@@ -322,28 +306,27 @@ variable * addvariable(variable ** p_vars)
  */
 void freevariables(variable ** p_vars)
 {
-	variable * temp, * head;
-	head = *p_vars;
-	
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		/*freechars(&head->name);*/
-		/*freechars(&head->type);*/
-		/*freechars(&head->value);*/
-		free(head->type);
-		free(head->name);
-		free(head->value);
-		free(head->typenotarray);
-		free(head->file);
-		free(head->description);
-		free(head);
-		head = temp;
-	}
-	
-	*p_vars = NULL;
+    variable * temp, * head;
+    head = *p_vars;
+
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        /*freechars(&head->name);*/
+        /*freechars(&head->type);*/
+        /*freechars(&head->value);*/
+        free(head->type);
+        free(head->name);
+        free(head->value);
+        free(head->typenotarray);
+        free(head->file);
+        free(head->description);
+        free(head);
+        head = temp;
+    }
+
+    *p_vars = NULL;
 }
 
 /** \fn env_func * addenvfunc(env_func ** p_env_funcs)
@@ -353,33 +336,30 @@ void freevariables(variable ** p_vars)
  */
 env_func * addenvfunc(env_func ** p_env_funcs)
 {
-	env_func * current, * temp = NULL;
-	current = *p_env_funcs;
-	
-	while(current)
-	{
-		temp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	if((current = (env_func *)malloc(sizeof(env_func))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_env_funcs = current;
-	}
-	/* Make current->next point to NULL */
-	current->code = NULL;
-	current->filepath = NULL;
-	current->next = NULL;
+    env_func * current, * temp = NULL;
+    current = *p_env_funcs;
 
-	/* Return new element */
-	return current;
+    while(current) {
+        temp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    if((current = (env_func *)malloc(sizeof(env_func))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_env_funcs = current;
+    }
+    /* Make current->next point to NULL */
+    current->code = NULL;
+    current->filepath = NULL;
+    current->next = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freeenvfunc(env_func ** p_env_funcs)
@@ -388,21 +368,20 @@ env_func * addenvfunc(env_func ** p_env_funcs)
  */
 void freeenvfunc(env_func ** p_env_funcs)
 {
-	env_func * temp, * head;
-	head = *p_env_funcs;
-	
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		/*freechars(&head->code);*/
-		free(head->filepath);
-		free(head);
-		head = temp;
-	}
-	
-	*p_env_funcs = NULL;
+    env_func * temp, * head;
+    head = *p_env_funcs;
+
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        /*freechars(&head->code);*/
+        free(head->filepath);
+        free(head);
+        head = temp;
+    }
+
+    *p_env_funcs = NULL;
 }
 
 /** \fn xmachine_message * addxmessage(xmachine_message ** p_xmessage)
@@ -412,88 +391,81 @@ void freeenvfunc(env_func ** p_env_funcs)
  */
 xmachine_message * addxmessage(xmachine_message ** p_xmessage)
 {
-	xmachine_message * current, * temp = NULL;
-	current = *p_xmessage;
-	
-	while(current)
-	{
-		temp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	if((current = (xmachine_message *)malloc(sizeof(xmachine_message))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_xmessage = current;
-	}
-	/* Make current->next point to NULL */
-	current->name = NULL;
-	current->vars = NULL;
-	//current->filters = NULL;
-	//current->agents = NULL;
-	//current->states = NULL;
-	current->syncs = NULL;
-	current->outputting_agents = NULL;
-	current->inputting_agents = NULL;
-	current->next = NULL;
-	//current->first = NULL;
-	//current->last = NULL;
-	current->file = NULL;
-	current->description = NULL;
-	current->has_box2d = 0;
+    xmachine_message * current, * temp = NULL;
+    current = *p_xmessage;
+
+    while(current) {
+        temp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    if((current = (xmachine_message *)malloc(sizeof(xmachine_message))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_xmessage = current;
+    }
+    /* Make current->next point to NULL */
+    current->name = NULL;
+    current->vars = NULL;
+    //current->filters = NULL;
+    //current->agents = NULL;
+    //current->states = NULL;
+    current->syncs = NULL;
+    current->outputting_agents = NULL;
+    current->inputting_agents = NULL;
+    current->next = NULL;
+    //current->first = NULL;
+    //current->last = NULL;
+    current->file = NULL;
+    current->description = NULL;
+    current->has_box2d = 0;
     current->has_box3d = 0;
     current->make_x_function = 0;
     current->make_y_function = 0;
     current->make_z_function = 0;
 
-	/* Return new element */
-	return current;
+    /* Return new element */
+    return current;
 }
 
 void freexmessage(xmachine_message ** p_xmessage, xmachine_message * message)
 {
-	xmachine_message * next, * prev, * head;
-	head = *p_xmessage;
-	prev = NULL;
-	if(head != NULL) next = head->next;
-	else next = NULL;
-	
-	/* Loop until message */
-	while(head)
-	{
-		if(head == message)
-		{
-			/* Free the cell memory */
-			free(head->name);
-			free(head->description);
-			freevariables(&head->vars);
-			//free_ioput(&head->filters);
-			//freexmachines(&head->agents);
-			//freexstates(&head->states);
-			freesync(&head->syncs);
-			freexmachines(&head->outputting_agents);
-			freexmachines(&head->inputting_agents);
-			free(head->file);
-			free(head);
-			head = NULL;
-			
-			if(message == *p_xmessage) *p_xmessage = next;
-			else prev->next = next;
-		}
-		else
-		{
-			prev = head;
-			head = head->next;
-			if(head != NULL) next = head->next;
-			else next = NULL;
-		}
-	}
+    xmachine_message * next, * prev, * head;
+    head = *p_xmessage;
+    prev = NULL;
+    if(head != NULL) next = head->next;
+    else next = NULL;
+
+    /* Loop until message */
+    while(head) {
+        if(head == message) {
+            /* Free the cell memory */
+            free(head->name);
+            free(head->description);
+            freevariables(&head->vars);
+            //free_ioput(&head->filters);
+            //freexmachines(&head->agents);
+            //freexstates(&head->states);
+            freesync(&head->syncs);
+            freexmachines(&head->outputting_agents);
+            freexmachines(&head->inputting_agents);
+            free(head->file);
+            free(head);
+            head = NULL;
+
+            if(message == *p_xmessage) *p_xmessage = next;
+            else prev->next = next;
+        } else {
+            prev = head;
+            head = head->next;
+            if(head != NULL) next = head->next;
+            else next = NULL;
+        }
+    }
 }
 
 /** \fn void freexmessages(xmachine_message ** p_xmessage)
@@ -502,60 +474,57 @@ void freexmessage(xmachine_message ** p_xmessage, xmachine_message * message)
  */
 void freexmessages(xmachine_message ** p_xmessage)
 {
-	xmachine_message * temp, * head;
-	head = *p_xmessage;
-	
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		free(head->name);
-		freevariables(&head->vars);
-		//free_ioput(&head->filters);
-		//freexmachines(&head->agents);
-		//freexstates(&head->states);
-		freesync(&head->syncs);
-		freexmachines(&head->inputting_agents);
-		freexmachines(&head->outputting_agents);
-		free(head->file);
-		free(head->description);
-		free(head);
-		head = temp;
-	}
-	
-	*p_xmessage = NULL;
+    xmachine_message * temp, * head;
+    head = *p_xmessage;
+
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        free(head->name);
+        freevariables(&head->vars);
+        //free_ioput(&head->filters);
+        //freexmachines(&head->agents);
+        //freexstates(&head->states);
+        freesync(&head->syncs);
+        freexmachines(&head->inputting_agents);
+        freexmachines(&head->outputting_agents);
+        free(head->file);
+        free(head->description);
+        free(head);
+        head = temp;
+    }
+
+    *p_xmessage = NULL;
 }
 
 void addstateholder(xmachine_state * state, xmachine_state_holder ** p_list)
 {
-	xmachine_state_holder * current;
-	
-	if((current = (xmachine_state_holder *)malloc(sizeof(xmachine_state_holder))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	
-	current->state = state;
-	current->next = *p_list;
-	*p_list = current;
+    xmachine_state_holder * current;
+
+    if((current = (xmachine_state_holder *)malloc(sizeof(xmachine_state_holder))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+
+    current->state = state;
+    current->next = *p_list;
+    *p_list = current;
 }
 
 void freestateholder(xmachine_state_holder ** p_list)
 {
-	xmachine_state_holder * temp, * head;
-	head = *p_list;
-	
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head);
-		head = temp;
-	}
-	
-	*p_list = NULL;
+    xmachine_state_holder * temp, * head;
+    head = *p_list;
+
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head);
+        head = temp;
+    }
+
+    *p_list = NULL;
 }
 
 /** \fn xmachine_state * addxstate(xmachine_state ** p_xstates)
@@ -565,37 +534,34 @@ void freestateholder(xmachine_state_holder ** p_list)
  */
 void addxstate(char * name, char * agent_name, xmachine_state ** p_xstates)
 {
-	xmachine_state * current, * temp;
-	int flag = 0;
-	
-	current = *p_xstates;
-	temp = *p_xstates;
-	
-	while(current && flag == 0)
-	{
-		if(strcmp(current->name, name) == 0 && strcmp(current->agent_name, agent_name) == 0) flag = 1;
+    xmachine_state * current, * temp;
+    int flag = 0;
 
-		current = current->next;
-	}
-	
-	if(flag == 0)
-	{
-		/* And current is the new element */
-		if((current = (xmachine_state *)malloc(sizeof(xmachine_state))) == NULL)
-		{
-			printf("Error: Cannot allocate memory\n");
-			exit(0);
-		}
-		/* Make tmp->next point to current if tmp exists */
-		current->next = temp;
-		*p_xstates = current;
-		
-		/* Make current->next point to NULL */
-		current->name = copystr(name);
-		current->agent_name = copystr(agent_name);
-		current->incoming_functions = NULL;
-		current->outgoing_functions = NULL;
-	}
+    current = *p_xstates;
+    temp = *p_xstates;
+
+    while(current && flag == 0) {
+        if(strcmp(current->name, name) == 0 && strcmp(current->agent_name, agent_name) == 0) flag = 1;
+
+        current = current->next;
+    }
+
+    if(flag == 0) {
+        /* And current is the new element */
+        if((current = (xmachine_state *)malloc(sizeof(xmachine_state))) == NULL) {
+            printf("Error: Cannot allocate memory\n");
+            exit(0);
+        }
+        /* Make tmp->next point to current if tmp exists */
+        current->next = temp;
+        *p_xstates = current;
+
+        /* Make current->next point to NULL */
+        current->name = copystr(name);
+        current->agent_name = copystr(agent_name);
+        current->incoming_functions = NULL;
+        current->outgoing_functions = NULL;
+    }
 }
 
 /** \fn void freexstates(xmachine_state ** p_xstates)
@@ -604,130 +570,118 @@ void addxstate(char * name, char * agent_name, xmachine_state ** p_xstates)
  */
 void freexstates(xmachine_state ** p_xstates)
 {
-	xmachine_state * temp, * head;
-	head = *p_xstates;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		free(head->name);
-		free(head->agent_name);
-		freefunction_pointers(&head->incoming_functions);
-		freefunction_pointers(&head->outgoing_functions);
-		free(head);
-		head = temp;
-	}
-	
-	*p_xstates = NULL;
+    xmachine_state * temp, * head;
+    head = *p_xstates;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        free(head->name);
+        free(head->agent_name);
+        freefunction_pointers(&head->incoming_functions);
+        freefunction_pointers(&head->outgoing_functions);
+        free(head);
+        head = temp;
+    }
+
+    *p_xstates = NULL;
 }
 
 void add_flame_communication(char * messagetype, rule_data * filter_rule, xmachine_function * function1, xmachine_function * function2, flame_communication ** communications)
 {
-	flame_communication * current, * tmp = * communications;
-	
-	/* And current is the new element */
-	current = (flame_communication *)malloc(sizeof(flame_communication));
-	/* Make tmp->next point to current if tmp exists */
-	current->next = tmp;
-	* communications = current;
-	
-	current->input_function = function1;
-	current->output_function = function2;
-	current->filter_rule = filter_rule;
+    flame_communication * current, * tmp = * communications;
 
-	current->messagetype = copystr(messagetype);
+    /* And current is the new element */
+    current = (flame_communication *)malloc(sizeof(flame_communication));
+    /* Make tmp->next point to current if tmp exists */
+    current->next = tmp;
+    * communications = current;
+
+    current->input_function = function1;
+    current->output_function = function2;
+    current->filter_rule = filter_rule;
+
+    current->messagetype = copystr(messagetype);
 }
 
 void free_flame_communications(flame_communication ** communications)
 {
-	flame_communication * temp, * head;
-	head = * communications;
-	
-	while(head)
-	{
-		temp = head->next;
-		free(head->messagetype);
-		free(head);
-		
-		head = temp;
-	}
-	
-	* communications = NULL;
+    flame_communication * temp, * head;
+    head = * communications;
+
+    while(head) {
+        temp = head->next;
+        free(head->messagetype);
+        free(head);
+
+        head = temp;
+    }
+
+    * communications = NULL;
 }
 
 void add_time_unit(char * name, char * unit_name, int period, time_data ** p_time_units)
 {
-	time_data * current, * temp = NULL;
-	
-	current = *p_time_units;
-	while(current)
-	{
-		temp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	if((current = (time_data *)malloc(sizeof(time_data))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_time_units = current;
-	}
-	
-	current->name = copystr(name);
-	current->unit = NULL;
-	current->period = period;
-	current->next = NULL;
-	current->iterations = 0;
-	
-	/*printf("time: name: %s unit: %s period: %d\n", name, unit_name, period);*/
-	
-	/* Find unit name struct */
-	if(strcmp(unit_name, "ITERATION") == 0 || strcmp(unit_name, "iteration") == 0)
-	{
-		current->iterations = current->period;
-	}
-	else
-	{
-		temp = * p_time_units;
-		while(temp)
-		{
-			if(strcmp(unit_name, temp->name) == 0)
-			{
-				current->unit = temp;
-				current->iterations = temp->iterations * current->period;
-			}
-			
-			temp = temp->next;
-		}
-		if(current->unit == NULL)
-		{
-			printf("ERROR: time unit '%s' not found in time name '%s'\n", unit_name, name);
-			exit(0); // todo
-		}
-	}
+    time_data * current, * temp = NULL;
+
+    current = *p_time_units;
+    while(current) {
+        temp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    if((current = (time_data *)malloc(sizeof(time_data))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_time_units = current;
+    }
+
+    current->name = copystr(name);
+    current->unit = NULL;
+    current->period = period;
+    current->next = NULL;
+    current->iterations = 0;
+
+    /*printf("time: name: %s unit: %s period: %d\n", name, unit_name, period);*/
+
+    /* Find unit name struct */
+    if(strcmp(unit_name, "ITERATION") == 0 || strcmp(unit_name, "iteration") == 0) {
+        current->iterations = current->period;
+    } else {
+        temp = * p_time_units;
+        while(temp) {
+            if(strcmp(unit_name, temp->name) == 0) {
+                current->unit = temp;
+                current->iterations = temp->iterations * current->period;
+            }
+
+            temp = temp->next;
+        }
+        if(current->unit == NULL) {
+            printf("ERROR: time unit '%s' not found in time name '%s'\n", unit_name, name);
+            exit(0); // todo
+        }
+    }
 }
 
 void free_time_units(time_data ** p_time_units)
 {
-	time_data * temp, * head;
-	head = * p_time_units;
-	
-	while(head)
-	{
-		temp = head->next;
-		free(head->name);
-		free(head);
-		
-		head = temp;
-	}
-	
-	* p_time_units = NULL;
+    time_data * temp, * head;
+    head = * p_time_units;
+
+    while(head) {
+        temp = head->next;
+        free(head->name);
+        free(head);
+
+        head = temp;
+    }
+
+    * p_time_units = NULL;
 }
 
 /** \fn char * copystr(char * string)
@@ -737,210 +691,199 @@ void free_time_units(time_data ** p_time_units)
  */
 char * copystr(char * string)
 {
-	char * new_string = (char *)malloc( (strlen(string) + 1) * sizeof(char));
-	strcpy(new_string, string);
-	return new_string;
+    char * new_string = (char *)malloc( (strlen(string) + 1) * sizeof(char));
+    strcpy(new_string, string);
+    return new_string;
 }
 
 adj_function * add_depends_adj_function(xmachine_function * current_function)
 {
-	adj_function * current;
-	
-	current = (adj_function *)malloc(sizeof(adj_function));
-	current->next = current_function->depends;
-	current_function->depends = current;
-	
-	current->function = NULL;
-	current->name = NULL;
-	current->type = NULL;
-	
-	return current;
+    adj_function * current;
+
+    current = (adj_function *)malloc(sizeof(adj_function));
+    current->next = current_function->depends;
+    current_function->depends = current;
+
+    current->function = NULL;
+    current->name = NULL;
+    current->type = NULL;
+
+    return current;
 }
 
 void add_adj_function_simple(xmachine_function * function1, xmachine_function * function2)
 {
-	adj_function * current;
-	
-	current = (adj_function *)malloc(sizeof(adj_function));
-	current->function = function2;
-	current->next = function1->alldepends;
-	function1->alldepends = current;
-	current->name = NULL;
-	current->type = NULL;
+    adj_function * current;
+
+    current = (adj_function *)malloc(sizeof(adj_function));
+    current->function = function2;
+    current->next = function1->alldepends;
+    function1->alldepends = current;
+    current->name = NULL;
+    current->type = NULL;
 }
 
 void remove_adj_function_simple(xmachine_function * function1)
 {
-	adj_function * current;
-	
-	if(function1->alldepends != NULL)
-	{
-		current = function1->alldepends->next;
-		free(function1->alldepends);
-		function1->alldepends = current;
-	}
+    adj_function * current;
+
+    if(function1->alldepends != NULL) {
+        current = function1->alldepends->next;
+        free(function1->alldepends);
+        function1->alldepends = current;
+    }
 }
 
 void add_adj_function_recent(xmachine_function * function1, xmachine_function * function2)
 {
-	adj_function * current;
-	
-	current = (adj_function *)malloc(sizeof(adj_function));
-	current->function = function2;
-	current->next = function1->recentdepends;
-	function1->recentdepends = current;
-	current->name = NULL;
-	current->type = NULL;
+    adj_function * current;
+
+    current = (adj_function *)malloc(sizeof(adj_function));
+    current->function = function2;
+    current->next = function1->recentdepends;
+    function1->recentdepends = current;
+    current->name = NULL;
+    current->type = NULL;
 }
 
 void remove_adj_function_recent(xmachine_function * function1)
 {
-	adj_function * current;
-	
-	if(function1->recentdepends != NULL)
-	{
-		current = function1->recentdepends->next;
-		free(function1->recentdepends->name);
-		free(function1->recentdepends->type);
-		free(function1->recentdepends);
-		function1->recentdepends = current;
-	}
+    adj_function * current;
+
+    if(function1->recentdepends != NULL) {
+        current = function1->recentdepends->next;
+        free(function1->recentdepends->name);
+        free(function1->recentdepends->type);
+        free(function1->recentdepends);
+        function1->recentdepends = current;
+    }
 }
 
 void add_adj_function(xmachine_function * function1, xmachine_function * function2, char * type)
 {
-	adj_function * current;
-	
-	current = (adj_function *)malloc(sizeof(adj_function));
-	current->function = function1;
-	current->type = copystr(type);
-	current->next = function2->dependson;
-	current->name = NULL;
-	function2->dependson = current;
-	
-	current = (adj_function *)malloc(sizeof(adj_function));
-	current->function = function2;
-	current->type = copystr(type);
-	current->next = function1->dependants;
-	current->name = NULL;
-	function1->dependants = current;
+    adj_function * current;
+
+    current = (adj_function *)malloc(sizeof(adj_function));
+    current->function = function1;
+    current->type = copystr(type);
+    current->next = function2->dependson;
+    current->name = NULL;
+    function2->dependson = current;
+
+    current = (adj_function *)malloc(sizeof(adj_function));
+    current->function = function2;
+    current->type = copystr(type);
+    current->next = function1->dependants;
+    current->name = NULL;
+    function1->dependants = current;
 }
 
 void free_adj_function(adj_function * adj_functions)
 {
-	adj_function * temp, * head;
-	head = adj_functions;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		
-		free(head->type);
-		free(head->name);
-		
-		free(head);
-		head = temp;
-	}
+    adj_function * temp, * head;
+    head = adj_functions;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+
+        free(head->type);
+        free(head->name);
+
+        free(head);
+        head = temp;
+    }
 }
 
 rule_data * add_rule_data(rule_data ** p_data)
 {
-	rule_data * current, * temp = NULL;
-	current = *p_data;
-	
-	while(current)
-	{
-		temp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	if((current = (rule_data *)malloc(sizeof(rule_data))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_data = current;
-	}
-	/* Make current->next point to NULL */
-	current->lhs = NULL;
-	current->rhs = NULL;
-	current->op = NULL;
-	current->lhs_print = NULL;
-	current->rhs_print = NULL;
-	current->op_print = NULL;
-	current->lhs_variable = NULL;
-	current->rhs_variable = NULL;
-	current->lhs_rule = NULL;
-	current->rhs_rule = NULL;
-	current->next = NULL;
-	current->time_rule = 0;
-	current->box = 0;
-	current->not = 0;
-	current->has_agent_var = 0;
-	current->has_message_var = 0;
-	current->parent_rule = NULL;
+    rule_data * current, * temp = NULL;
+    current = *p_data;
 
-	/* Return new element */
-	return current;
+    while(current) {
+        temp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    if((current = (rule_data *)malloc(sizeof(rule_data))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_data = current;
+    }
+    /* Make current->next point to NULL */
+    current->lhs = NULL;
+    current->rhs = NULL;
+    current->op = NULL;
+    current->lhs_print = NULL;
+    current->rhs_print = NULL;
+    current->op_print = NULL;
+    current->lhs_variable = NULL;
+    current->rhs_variable = NULL;
+    current->lhs_rule = NULL;
+    current->rhs_rule = NULL;
+    current->next = NULL;
+    current->time_rule = 0;
+    current->box = 0;
+    current->not = 0;
+    current->has_agent_var = 0;
+    current->has_message_var = 0;
+    current->parent_rule = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 void free_rule_data(rule_data ** p_data)
 {
-	rule_data * temp, * head;
-	head = *p_data;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		
-		free(head->lhs);
-		free(head->rhs);
-		free(head->op);
-		free(head->lhs_print);
-		free(head->rhs_print);
-		free(head->op_print);
-		free_rule_data(&head->lhs_rule);
-		free_rule_data(&head->rhs_rule);
-		free(head);
-		head = temp;
-	}
-	
-	*p_data = NULL;
+    rule_data * temp, * head;
+    head = *p_data;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+
+        free(head->lhs);
+        free(head->rhs);
+        free(head->op);
+        free(head->lhs_print);
+        free(head->rhs_print);
+        free(head->op_print);
+        free_rule_data(&head->lhs_rule);
+        free_rule_data(&head->rhs_rule);
+        free(head);
+        head = temp;
+    }
+
+    *p_data = NULL;
 }
 
 void copy_rule_data(rule_data * to, rule_data * from)
 {
-	to->time_rule = from->time_rule;
-	to->not = from->not;
-	to->has_agent_var = from->has_agent_var;
-	to->has_message_var = from->has_message_var;
-	if(from->lhs != NULL)
-	{
-		to->lhs = copystr(from->lhs);
-		to->lhs_print = copystr(from->lhs_print);
-		to->lhs_variable = from->lhs_variable;
-	}
-	if(from->rhs != NULL)
-	{
-		to->rhs = copystr(from->rhs);
-		to->rhs_print = copystr(from->rhs_print);
-		to->rhs_variable = from->rhs_variable;
-	}
-	to->op  = copystr(from->op);
-	if(from->lhs_rule != NULL)
-	{
-		(void) add_rule_data(&to->lhs_rule);
-		copy_rule_data(to->lhs_rule, from->lhs_rule);
-	}
-	if(from->rhs_rule != NULL)
-	{
-		(void) add_rule_data(&to->rhs_rule);
-		copy_rule_data(to->rhs_rule, from->rhs_rule);
-	}
+    to->time_rule = from->time_rule;
+    to->not = from->not;
+    to->has_agent_var = from->has_agent_var;
+    to->has_message_var = from->has_message_var;
+    if(from->lhs != NULL) {
+        to->lhs = copystr(from->lhs);
+        to->lhs_print = copystr(from->lhs_print);
+        to->lhs_variable = from->lhs_variable;
+    }
+    if(from->rhs != NULL) {
+        to->rhs = copystr(from->rhs);
+        to->rhs_print = copystr(from->rhs_print);
+        to->rhs_variable = from->rhs_variable;
+    }
+    to->op  = copystr(from->op);
+    if(from->lhs_rule != NULL) {
+        (void) add_rule_data(&to->lhs_rule);
+        copy_rule_data(to->lhs_rule, from->lhs_rule);
+    }
+    if(from->rhs_rule != NULL) {
+        (void) add_rule_data(&to->rhs_rule);
+        copy_rule_data(to->rhs_rule, from->rhs_rule);
+    }
 }
 
 /** \fn xmachine_function * addxfunction(xmachine_function ** p_xfunctions)
@@ -950,60 +893,57 @@ void copy_rule_data(rule_data * to, rule_data * from)
  */
 xmachine_function * addxfunction(xmachine_function ** p_xfunctions)
 {
-	xmachine_function * current, * temp = NULL;
-	current = *p_xfunctions;
-	
-	while(current)
-	{
-		temp = current;
-		current = current->next;
-	}
-	/* And current is the new element */
-	if((current = (xmachine_function *)malloc(sizeof(xmachine_function))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_xfunctions = current;
-	}
-	/* Make current->next point to NULL */
-	current->name = NULL;
-	current->note = NULL;
-	current->file = NULL;
-	current->code = NULL;
-	current->inputs = NULL;
-	current->outputs = NULL;
-	current->current_state = NULL;
-	current->next_state = NULL;
-	//current->first_inputs = NULL;
-	//current->last_outputs = NULL;
-	current->start_syncs = NULL;
-	current->complete_syncs = NULL;
-	current->dependson = NULL;
-	current->dependants = NULL;
-	current->alldepends = NULL;
-	current->depends = NULL;
-	current->recentdepends = NULL;
-	current->agent_name = NULL;
-	current->next = NULL;
-	current->x = 0.0;
-	current->y = 0.0;
-	current->rank_in = -1;
-	current->index = -1;
-	current->score = 0;
-	current->condition_rule = NULL;
-	current->condition_function = NULL;
-	current->filter_rule = NULL;
-	current->has_message_var = 0;
-	current->has_agent_var = 0;
-	current->description = NULL;
+    xmachine_function * current, * temp = NULL;
+    current = *p_xfunctions;
 
-	/* Return new element */
-	return current;
+    while(current) {
+        temp = current;
+        current = current->next;
+    }
+    /* And current is the new element */
+    if((current = (xmachine_function *)malloc(sizeof(xmachine_function))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_xfunctions = current;
+    }
+    /* Make current->next point to NULL */
+    current->name = NULL;
+    current->note = NULL;
+    current->file = NULL;
+    current->code = NULL;
+    current->inputs = NULL;
+    current->outputs = NULL;
+    current->current_state = NULL;
+    current->next_state = NULL;
+    //current->first_inputs = NULL;
+    //current->last_outputs = NULL;
+    current->start_syncs = NULL;
+    current->complete_syncs = NULL;
+    current->dependson = NULL;
+    current->dependants = NULL;
+    current->alldepends = NULL;
+    current->depends = NULL;
+    current->recentdepends = NULL;
+    current->agent_name = NULL;
+    current->next = NULL;
+    current->x = 0.0;
+    current->y = 0.0;
+    current->rank_in = -1;
+    current->index = -1;
+    current->score = 0;
+    current->condition_rule = NULL;
+    current->condition_function = NULL;
+    current->filter_rule = NULL;
+    current->has_message_var = 0;
+    current->has_agent_var = 0;
+    current->description = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freexfunctions(xmachine_function ** p_xfunctions)
@@ -1012,40 +952,39 @@ xmachine_function * addxfunction(xmachine_function ** p_xfunctions)
  */
 void freexfunctions(xmachine_function ** p_xfunctions)
 {
-	xmachine_function * temp, * head;
-	head = *p_xfunctions;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		free(head->name);
-		free(head->note);
-		free(head->file);
-		free(head->current_state);
-		free(head->next_state);
-		free(head->agent_name);
-		free(head->condition_function);
-		freefcode(&head->code);
-		free_ioput(&head->inputs);
-		free_ioput(&head->outputs);
-		//free_ioput(&head->first_inputs);
-		//free_ioput(&head->last_outputs);
-		free_sync_pointers(&head->start_syncs);
-		free_sync_pointers(&head->complete_syncs);
-		free_adj_function(head->dependson);
-		free_adj_function(head->dependants);
-		free_adj_function(head->alldepends);
-		free_adj_function(head->depends);
-		free_adj_function(head->recentdepends);
-		free_rule_data(&head->condition_rule);
-		free_rule_data(&head->filter_rule);
-		free(head->description);
-		free(head);
-		head = temp;
-	}
-	
-	*p_xfunctions = NULL;
+    xmachine_function * temp, * head;
+    head = *p_xfunctions;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        free(head->name);
+        free(head->note);
+        free(head->file);
+        free(head->current_state);
+        free(head->next_state);
+        free(head->agent_name);
+        free(head->condition_function);
+        freefcode(&head->code);
+        free_ioput(&head->inputs);
+        free_ioput(&head->outputs);
+        //free_ioput(&head->first_inputs);
+        //free_ioput(&head->last_outputs);
+        free_sync_pointers(&head->start_syncs);
+        free_sync_pointers(&head->complete_syncs);
+        free_adj_function(head->dependson);
+        free_adj_function(head->dependants);
+        free_adj_function(head->alldepends);
+        free_adj_function(head->depends);
+        free_adj_function(head->recentdepends);
+        free_rule_data(&head->condition_rule);
+        free_rule_data(&head->filter_rule);
+        free(head->description);
+        free(head);
+        head = temp;
+    }
+
+    *p_xfunctions = NULL;
 }
 
 /** \fn xmachine * addxmachine(xmachine ** p_xmachines)
@@ -1055,53 +994,50 @@ void freexfunctions(xmachine_function ** p_xfunctions)
  */
 xmachine * addxmachine(xmachine ** p_xmachines, char * name)
 {
-	int number = 0;
-	xmachine * current = *p_xmachines;
-	xmachine * temp = NULL;
-	
-	while(current)
-	{
-		/* If agent name already exists */
-		if(strcmp(current->name, name) == 0) return current;
-		
-		temp = current;
-		current = current->next;
-		number++;
-	}
-	/* And current is the new element */
-	if((current = (xmachine *)malloc(sizeof(xmachine))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make tmp->next point to current if tmp exists */
-	if(temp) temp->next = current;
-	else
-	{
-		*p_xmachines = current;
-	}
-	/* Make current->next point to NULL */
-	current->number = number;
-	current->name = copystr(name);
-	current->variables = NULL;
-	current->states = NULL;
-	current->functions = NULL;
-	
-	current->start_state = NULL;
-	current->end_states = NULL;
-	
-	current->idvar[0] = 0;
-	current->xvar[0] = 0;
-	current->yvar[0] = 0;
-	current->zvar[0] = 0;
+    int number = 0;
+    xmachine * current = *p_xmachines;
+    xmachine * temp = NULL;
 
-	current->rangevar[0] = 0;
-	current->idvar[0] = 0;
+    while(current) {
+        /* If agent name already exists */
+        if(strcmp(current->name, name) == 0) return current;
 
-	current->next = NULL;
+        temp = current;
+        current = current->next;
+        number++;
+    }
+    /* And current is the new element */
+    if((current = (xmachine *)malloc(sizeof(xmachine))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make tmp->next point to current if tmp exists */
+    if(temp) temp->next = current;
+    else {
+        *p_xmachines = current;
+    }
+    /* Make current->next point to NULL */
+    current->number = number;
+    current->name = copystr(name);
+    current->variables = NULL;
+    current->states = NULL;
+    current->functions = NULL;
 
-	/* Return new element */
-	return current;
+    current->start_state = NULL;
+    current->end_states = NULL;
+
+    current->idvar[0] = 0;
+    current->xvar[0] = 0;
+    current->yvar[0] = 0;
+    current->zvar[0] = 0;
+
+    current->rangevar[0] = 0;
+    current->idvar[0] = 0;
+
+    current->next = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freexmachines(xmachine ** p_xmachines)
@@ -1110,23 +1046,22 @@ xmachine * addxmachine(xmachine ** p_xmachines, char * name)
  */
 void freexmachines(xmachine ** p_xmachines)
 {
-	xmachine * temp, * head;
-	head = *p_xmachines;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		free(head->name);
-		freevariables(&head->variables);
-		freexstates(&head->states);
-		freexfunctions(&head->functions);
-		freestateholder(&head->end_states);
-		free(head);
-		head = temp;
-	}
-	
-	*p_xmachines = NULL;
+    xmachine * temp, * head;
+    head = *p_xmachines;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        free(head->name);
+        freevariables(&head->variables);
+        freexstates(&head->states);
+        freexfunctions(&head->functions);
+        freestateholder(&head->end_states);
+        free(head);
+        head = temp;
+    }
+
+    *p_xmachines = NULL;
 }
 
 /** \fn layer * addlayer(communication_layer * com_layer)
@@ -1136,41 +1071,36 @@ void freexmachines(xmachine ** p_xmachines)
  */
 layer * addlayer(layer ** p_layer)
 {
-	layer * current, * temp;
-	
-	/* And current is the new element */
-	if((current = (layer *)malloc(sizeof(layer))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	current->functions = NULL;
-	
-	temp = * p_layer;
-	if(temp == NULL)
-	{
-		current->next = * p_layer;
-		current->number = 0;
-		*p_layer = current;
-	}
-	else
-	{
-		while(temp->next)
-		{
-			temp = temp->next;
-		}
-		temp->next = current;
-		current->next = NULL;
-		current->number = temp->number + 1;
-	}
+    layer * current, * temp;
 
-	current->start_syncs = NULL;
-	current->complete_syncs = NULL;
-	current->branching_states = NULL;
-	current->finished_messages = NULL;
+    /* And current is the new element */
+    if((current = (layer *)malloc(sizeof(layer))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    current->functions = NULL;
 
-	/* Return new element */
-	return current;
+    temp = * p_layer;
+    if(temp == NULL) {
+        current->next = * p_layer;
+        current->number = 0;
+        *p_layer = current;
+    } else {
+        while(temp->next) {
+            temp = temp->next;
+        }
+        temp->next = current;
+        current->next = NULL;
+        current->number = temp->number + 1;
+    }
+
+    current->start_syncs = NULL;
+    current->complete_syncs = NULL;
+    current->branching_states = NULL;
+    current->finished_messages = NULL;
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freelayers(layer * layers)
@@ -1179,23 +1109,22 @@ layer * addlayer(layer ** p_layer)
  */
 void freelayers(layer ** p_layers)
 {
-	layer * temp, * head;
-	head = * p_layers;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		freefunction_pointers(&head->functions);
-		freesync(&head->start_syncs);
-		freesync(&head->complete_syncs);
-		freestateholder(&head->branching_states);
-		freexmessages(&head->finished_messages);
-		free(head);
-		head = temp;
-	}
-	
-	* p_layers = NULL;
+    layer * temp, * head;
+    head = * p_layers;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        freefunction_pointers(&head->functions);
+        freesync(&head->start_syncs);
+        freesync(&head->complete_syncs);
+        freestateholder(&head->branching_states);
+        freexmessages(&head->finished_messages);
+        free(head);
+        head = temp;
+    }
+
+    * p_layers = NULL;
 }
 
 /** \fn communication_layer * addcommunication_layer(communication_layer ** p_com_layers)
@@ -1205,19 +1134,18 @@ void freelayers(layer ** p_layers)
  */
 void addfunction_pointer(function_pointer ** p_function_pointers, xmachine_function * function)
 {
-	function_pointer * current;
-	
-	/* And current is the new element */
-	if((current = (function_pointer *)malloc(sizeof(function_pointer))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	/* Make current->next point to NULL */
-	current->function = function;
-	current->found = 0;
-	current->next = *p_function_pointers;
-	*p_function_pointers = current;
+    function_pointer * current;
+
+    /* And current is the new element */
+    if((current = (function_pointer *)malloc(sizeof(function_pointer))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    /* Make current->next point to NULL */
+    current->function = function;
+    current->found = 0;
+    current->next = *p_function_pointers;
+    *p_function_pointers = current;
 }
 
 /** \fn void freefunction_pointers(function_pointer ** p_function_pointers)
@@ -1226,18 +1154,17 @@ void addfunction_pointer(function_pointer ** p_function_pointers, xmachine_funct
  */
 void freefunction_pointers(function_pointer ** p_function_pointers)
 {
-	function_pointer * temp, * head;
-	head = *p_function_pointers;
-	
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		free(head);
-		head = temp;
-	}
-	
-	*p_function_pointers = NULL;
+    function_pointer * temp, * head;
+    head = *p_function_pointers;
+
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        free(head);
+        head = temp;
+    }
+
+    *p_function_pointers = NULL;
 }
 
 /** \fn layer * adddatatype(model_datatype ** p_datatypes)
@@ -1247,37 +1174,32 @@ void freefunction_pointers(function_pointer ** p_function_pointers)
  */
 model_datatype * adddatatype(model_datatype ** p_datatypes)
 {
-	model_datatype * current, * head, * temp;
-	head = * p_datatypes;
-	temp = head;
-	
-	/* And current is the new element */
-	if((current = (model_datatype *)malloc(sizeof(model_datatype))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}
-	current->vars = NULL;
-	current->next = NULL;
-	current->desc = NULL;
-	current->name = NULL;
-	/* Find end of list */
-	if(* p_datatypes == NULL)
-	{
-		* p_datatypes = current;
-	}
-	else
-	{
-		while(head)
-		{
-			temp = head;
-			head = temp->next;
-		}
-		temp->next = current;
-	}
-	
-	/* Return new element */
-	return current;
+    model_datatype * current, * head, * temp;
+    head = * p_datatypes;
+    temp = head;
+
+    /* And current is the new element */
+    if((current = (model_datatype *)malloc(sizeof(model_datatype))) == NULL) {
+        printf("Error: Cannot allocate memory\n");
+        exit(0);
+    }
+    current->vars = NULL;
+    current->next = NULL;
+    current->desc = NULL;
+    current->name = NULL;
+    /* Find end of list */
+    if(* p_datatypes == NULL) {
+        * p_datatypes = current;
+    } else {
+        while(head) {
+            temp = head;
+            head = temp->next;
+        }
+        temp->next = current;
+    }
+
+    /* Return new element */
+    return current;
 }
 
 /** \fn void freedatatypes(model_datatype ** p_datatypes)
@@ -1286,21 +1208,20 @@ model_datatype * adddatatype(model_datatype ** p_datatypes)
  */
 void freedatatypes(model_datatype ** p_datatypes)
 {
-	model_datatype * temp, * head;
-	head = * p_datatypes;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		freevariables(&head->vars);
-		free(head->name);
-		free(head->desc);
-		free(head);
-		head = temp;
-	}
-	
-	* p_datatypes = NULL;
+    model_datatype * temp, * head;
+    head = * p_datatypes;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        freevariables(&head->vars);
+        free(head->name);
+        free(head->desc);
+        free(head);
+        head = temp;
+    }
+
+    * p_datatypes = NULL;
 }
 
 /** \fn int_array * init_int_array()
@@ -1309,12 +1230,12 @@ void freedatatypes(model_datatype ** p_datatypes)
  */
 int_array * init_int_array(void)
 {
-	int_array * new_array = (int_array *)malloc(sizeof(int_array));
-	new_array->size = 0;
-	new_array->total_size = ARRAY_BLOCK_SIZE;
-	new_array->array = (int *)malloc(ARRAY_BLOCK_SIZE * sizeof(int));
-	
-	return new_array;
+    int_array * new_array = (int_array *)malloc(sizeof(int_array));
+    new_array->size = 0;
+    new_array->total_size = ARRAY_BLOCK_SIZE;
+    new_array->array = (int *)malloc(ARRAY_BLOCK_SIZE * sizeof(int));
+
+    return new_array;
 }
 
 /** \fn void free_int_array(int_array * array)
@@ -1323,8 +1244,8 @@ int_array * init_int_array(void)
  */
 void free_int_array(int_array * array)
 {
-	free(array->array);
-	free(array);
+    free(array->array);
+    free(array);
 }
 
 /** \fn void sort_int_array(int_array * array)
@@ -1333,23 +1254,20 @@ void free_int_array(int_array * array)
  */
 void sort_int_array(int_array * array)
 {
-	int i, j, temp;
-	
-	/* Using bubble sorts nested loops */
-	for(i=0; i<(array->size-1); i++)
-	{
-		for(j=0; j<(array->size-1)-i; j++)
-		{
-			/* Comparing the values between neighbours */
-			if(*(array->array+j+1) < *(array->array+j))
-			{
-				/* Swap neighbours */
-				temp = *(array->array+j);
-				*(array->array+j) = *(array->array+j+1);
-				*(array->array+j+1) = temp;
-			}
-		}
-	}
+    int i, j, temp;
+
+    /* Using bubble sorts nested loops */
+    for(i=0; i<(array->size-1); i++) {
+        for(j=0; j<(array->size-1)-i; j++) {
+            /* Comparing the values between neighbours */
+            if(*(array->array+j+1) < *(array->array+j)) {
+                /* Swap neighbours */
+                temp = *(array->array+j);
+                *(array->array+j) = *(array->array+j+1);
+                *(array->array+j+1) = temp;
+            }
+        }
+    }
 }
 
 /** \fn int quicksort_int(int *array, int elements)
@@ -1360,33 +1278,31 @@ void sort_int_array(int_array * array)
  */
 int quicksort_int(int * array, int elements)
 {
-	#define  LEVEL  1000
-	int  pivot, begin[LEVEL], end[LEVEL], i=0, left, right ;
-	begin[0]=0; end[0]=elements;
-	while (i>=0)
-	{
-		left=begin[i]; right=end[i]-1;
-		if (left<right)
-		{
-			pivot=array[left]; if (i==LEVEL-1) return 1;
-			while (left<right)
-			{
-				while (array[right]>=pivot && left<right) right--;
-				if (left<right) array[left++]=array[right];
-				while (array[left]<=pivot && left<right) left++;
-				if (left<right) array[right--]=array[left];
-			}
-			array[left]=pivot;
-			begin[i+1]=left+1;
-			end[i+1]=end[i];
-			end[i++]=left;
-		}
-	    else 
-	    {
-	      i--;
-	    }
-	}
-	return 0;
+#define  LEVEL  1000
+    int  pivot, begin[LEVEL], end[LEVEL], i=0, left, right ;
+    begin[0]=0;
+    end[0]=elements;
+    while (i>=0) {
+        left=begin[i];
+        right=end[i]-1;
+        if (left<right) {
+            pivot=array[left];
+            if (i==LEVEL-1) return 1;
+            while (left<right) {
+                while (array[right]>=pivot && left<right) right--;
+                if (left<right) array[left++]=array[right];
+                while (array[left]<=pivot && left<right) left++;
+                if (left<right) array[right--]=array[left];
+            }
+            array[left]=pivot;
+            begin[i+1]=left+1;
+            end[i+1]=end[i];
+            end[i++]=left;
+        } else {
+            i--;
+        }
+    }
+    return 0;
 }
 
 /** \fn void add_int(int_array * array, int new_int)
@@ -1396,14 +1312,13 @@ int quicksort_int(int * array, int elements)
  */
 void add_int(int_array * array, int new_int)
 {
-	if(array->size == array->total_size)
-	{
-		array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
-		array->array = (int *)realloc(array->array, (array->total_size * sizeof(int)));
-	}
-	
-	array->array[array->size] = new_int;
-	array->size++;
+    if(array->size == array->total_size) {
+        array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
+        array->array = (int *)realloc(array->array, (array->total_size * sizeof(int)));
+    }
+
+    array->array[array->size] = new_int;
+    array->size++;
 }
 
 /** \fn void remove_int(int_array * array, int index)
@@ -1413,18 +1328,16 @@ void add_int(int_array * array, int new_int)
  */
 void remove_int(int_array * array, int index)
 {
-	int i;
-	
-	if(index <= array->size)
-	{
-		/* memcopy??*/
-		for(i = index; i < array->size; i++)
-		{
-			array->array[i] = array->array[i+1];
-		}
-		
-		array->size--;
-	}
+    int i;
+
+    if(index <= array->size) {
+        /* memcopy??*/
+        for(i = index; i < array->size; i++) {
+            array->array[i] = array->array[i+1];
+        }
+
+        array->size--;
+    }
 }
 
 /** \fn void print_int_array(int_array * array)
@@ -1433,12 +1346,11 @@ void remove_int(int_array * array, int index)
  */
 void print_int_array(int_array * array)
 {
-	int i;
-	printf("\n");
-	for(i=0; i<array->size; i++)
-	{
-		printf("%d> %d\n", i, array->array[i]);
-	}
+    int i;
+    printf("\n");
+    for(i=0; i<array->size; i++) {
+        printf("%d> %d\n", i, array->array[i]);
+    }
 }
 
 /** \fn double_array * init_double_array()
@@ -1447,12 +1359,12 @@ void print_int_array(int_array * array)
  */
 double_array * init_double_array()
 {
-	double_array * new_array = (double_array *)malloc(sizeof(double_array));
-	new_array->size = 0;
-	new_array->total_size = ARRAY_BLOCK_SIZE;
-	new_array->array = (double *)malloc(ARRAY_BLOCK_SIZE * sizeof(double));
-	
-	return new_array;
+    double_array * new_array = (double_array *)malloc(sizeof(double_array));
+    new_array->size = 0;
+    new_array->total_size = ARRAY_BLOCK_SIZE;
+    new_array->array = (double *)malloc(ARRAY_BLOCK_SIZE * sizeof(double));
+
+    return new_array;
 }
 
 /** \fn void free_double_array(double_array * array)
@@ -1461,8 +1373,8 @@ double_array * init_double_array()
  */
 void free_double_array(double_array * array)
 {
-	free(array->array);
-	free(array);
+    free(array->array);
+    free(array);
 }
 
 /** \fn void sort_double_array(double_array * array)
@@ -1471,24 +1383,21 @@ void free_double_array(double_array * array)
  */
 void sort_double_array(double_array * array)
 {
-	int i, j;
-	double temp;
-	
-	/* Using bubble sorts nested loops */
-	for(i=0; i<(array->size-1); i++)
-	{
-		for(j=0; j<(array->size-1)-i; j++) 
-		{
-			/* Comparing the values between neighbours */
-			if(*(array->array+j+1) < *(array->array+j))
-			{
-				/* Swap neighbours */
-				temp = *(array->array+j); 
-				*(array->array+j) = *(array->array+j+1);
-				*(array->array+j+1) = temp;
-			}
-		}
-	}
+    int i, j;
+    double temp;
+
+    /* Using bubble sorts nested loops */
+    for(i=0; i<(array->size-1); i++) {
+        for(j=0; j<(array->size-1)-i; j++) {
+            /* Comparing the values between neighbours */
+            if(*(array->array+j+1) < *(array->array+j)) {
+                /* Swap neighbours */
+                temp = *(array->array+j);
+                *(array->array+j) = *(array->array+j+1);
+                *(array->array+j+1) = temp;
+            }
+        }
+    }
 }
 
 /** \fn void add_double(double_array * array, double new_double)
@@ -1498,14 +1407,13 @@ void sort_double_array(double_array * array)
  */
 void add_double(double_array * array, double new_double)
 {
-	if(array->size == array->total_size)
-	{
-		array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
-		array->array = (double *)realloc(array->array, (array->total_size * sizeof(double)));
-	}
-	
-	array->array[array->size] = new_double;
-	array->size++;
+    if(array->size == array->total_size) {
+        array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
+        array->array = (double *)realloc(array->array, (array->total_size * sizeof(double)));
+    }
+
+    array->array[array->size] = new_double;
+    array->size++;
 }
 
 /** \fn void remove_double(double_array * array, int index)
@@ -1515,18 +1423,16 @@ void add_double(double_array * array, double new_double)
  */
 void remove_double(double_array * array, int index)
 {
-	int i;
-	
-	if(index <= array->size)
-	{
-		/* memcopy??*/
-		for(i = index; i < array->size; i++)
-		{
-			array->array[i] = array->array[i+1];
-		}
-		
-		array->size--;
-	}
+    int i;
+
+    if(index <= array->size) {
+        /* memcopy??*/
+        for(i = index; i < array->size; i++) {
+            array->array[i] = array->array[i+1];
+        }
+
+        array->size--;
+    }
 }
 
 /** \fn void print_double_array(double_array * array)
@@ -1535,12 +1441,11 @@ void remove_double(double_array * array, int index)
  */
 void print_double_array(double_array * array)
 {
-	int i;
-	printf("\n");
-	for(i=0; i<array->size; i++)
-	{
-		printf("%d> %f\n", i, array->array[i]);
-	}
+    int i;
+    printf("\n");
+    for(i=0; i<array->size; i++) {
+        printf("%d> %f\n", i, array->array[i]);
+    }
 }
 
 /** \fn char_array * init_char_array()
@@ -1549,19 +1454,19 @@ void print_double_array(double_array * array)
  */
 char_array * init_char_array()
 {
-	char_array * new_array = (char_array *)malloc(sizeof(char_array));
-	new_array->size = 0;
-	new_array->total_size = ARRAY_BLOCK_SIZE;
-	new_array->array = (char *)malloc(ARRAY_BLOCK_SIZE * sizeof(char));
-	new_array->array[0] = '\0';
-	
-	return new_array;
+    char_array * new_array = (char_array *)malloc(sizeof(char_array));
+    new_array->size = 0;
+    new_array->total_size = ARRAY_BLOCK_SIZE;
+    new_array->array = (char *)malloc(ARRAY_BLOCK_SIZE * sizeof(char));
+    new_array->array[0] = '\0';
+
+    return new_array;
 }
 
 void reset_char_array(char_array * array)
 {
-	array->size = 0;
-	array->array[0] = '\0';
+    array->size = 0;
+    array->array[0] = '\0';
 }
 
 /** \fn void free_char_array(char_array * array)
@@ -1570,8 +1475,8 @@ void reset_char_array(char_array * array)
  */
 void free_char_array(char_array * array)
 {
-	free(array->array);
-	free(array);
+    free(array->array);
+    free(array);
 }
 
 /** \fn void add_char(char_array * array, char new_char)
@@ -1581,15 +1486,14 @@ void free_char_array(char_array * array)
  */
 void add_char(char_array * array, char new_char)
 {
-	if(array->size + 1 == array->total_size)
-	{
-		array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
-		array->array = (char *)realloc(array->array, (array->total_size * sizeof(char)));
-	}
-	
-	array->array[array->size] = new_char;
-	array->array[array->size + 1] = '\0';
-	array->size++;
+    if(array->size + 1 == array->total_size) {
+        array->total_size = (int)(array->total_size * ARRAY_GROWTH_RATE);
+        array->array = (char *)realloc(array->array, (array->total_size * sizeof(char)));
+    }
+
+    array->array[array->size] = new_char;
+    array->array[array->size + 1] = '\0';
+    array->size++;
 }
 
 /** \fn char * copy_array_to_str(char_array * array)
@@ -1599,8 +1503,8 @@ void add_char(char_array * array, char new_char)
  */
 char * copy_array_to_str(char_array * array)
 {
-	char * new_string = (char *)malloc( (array->size + 1) * sizeof(char));
-	return strcpy(new_string, array->array);
+    char * new_string = (char *)malloc( (array->size + 1) * sizeof(char));
+    return strcpy(new_string, array->array);
 }
 
 /** \fn void remove_char(char_array * array, int index)
@@ -1610,18 +1514,16 @@ char * copy_array_to_str(char_array * array)
  */
 void remove_char(char_array * array, int index)
 {
-	int i;
-	
-	if(index <= array->size)
-	{
-		/* memcopy??*/
-		for(i = index; i < array->size + 1; i++)
-		{
-			array->array[i] = array->array[i+1];
-		}
-		
-		array->size--;
-	}
+    int i;
+
+    if(index <= array->size) {
+        /* memcopy??*/
+        for(i = index; i < array->size + 1; i++) {
+            array->array[i] = array->array[i+1];
+        }
+
+        array->size--;
+    }
 }
 
 /** \fn void print_char_array(char_array * array)
@@ -1630,56 +1532,56 @@ void remove_char(char_array * array, int index)
  */
 void print_char_array(char_array * array)
 {
-	printf("%s\n", array->array);
+    printf("%s\n", array->array);
 }
 
 
 /**
  * functions for creating linked list of colours for agents and models
- * 
+ *
  */
 
 void addagent_colour(agent_colour **p_agent_colours, char * name, int colour_value)
 {
 //	int number = 0;
-	agent_colour * temp = *p_agent_colours;
-	agent_colour * current = NULL;
-	
-	/*while(current)
-	{
-		 If agent name already exists 
-		//if(strcmp(current->name, name) != 0) 
-			//return current;
-		
-		temp = current;
-		current = current->next;
-		number++;
-		
-	}*/
-	
-	/* And current is the new element */
-	current = (agent_colour *)malloc(sizeof(agent_colour));
-	/*if((temp = (agent_colour *)malloc(sizeof(agent_colour))) == NULL)
-	{
-		printf("Error: Cannot allocate memory\n");
-		exit(0);
-	}*/
-	current->next=temp;
-	*p_agent_colours = current;
-	/* Make tmp->next point to current if tmp exists */
-	/*if(temp) 
-		temp->next = current;
-	else
-	{
-		*p_agent_colours = current;
-	}*/
-	/* Make current->next point to NULL */
-	
-	current->name = copystr(name);
-	current->colour = colour_value;
-	//printf("****************** %s, %d",current->name,current->colour);
-	/* Return new element */
-	//return current;
+    agent_colour * temp = *p_agent_colours;
+    agent_colour * current = NULL;
+
+    /*while(current)
+    {
+    	 If agent name already exists
+    	//if(strcmp(current->name, name) != 0)
+    		//return current;
+
+    	temp = current;
+    	current = current->next;
+    	number++;
+
+    }*/
+
+    /* And current is the new element */
+    current = (agent_colour *)malloc(sizeof(agent_colour));
+    /*if((temp = (agent_colour *)malloc(sizeof(agent_colour))) == NULL)
+    {
+    	printf("Error: Cannot allocate memory\n");
+    	exit(0);
+    }*/
+    current->next=temp;
+    *p_agent_colours = current;
+    /* Make tmp->next point to current if tmp exists */
+    /*if(temp)
+    	temp->next = current;
+    else
+    {
+    	*p_agent_colours = current;
+    }*/
+    /* Make current->next point to NULL */
+
+    current->name = copystr(name);
+    current->colour = colour_value;
+    //printf("****************** %s, %d",current->name,current->colour);
+    /* Return new element */
+    //return current;
 }
 
 /** \fn void freexmachines(xmachine ** p_xmachines)
@@ -1688,138 +1590,129 @@ void addagent_colour(agent_colour **p_agent_colours, char * name, int colour_val
  */
 void freeagent_colours(agent_colour ** p_agent_colours)
 {
-	agent_colour * temp, * head;
-	head = *p_agent_colours;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-	//	printf("MK: freeing %s\n",head->name);
-		free(head->name);
-		
-		//free(head->colour);
-		free(head);
-		head = temp;
-	}
-	
-	*p_agent_colours = NULL;
+    agent_colour * temp, * head;
+    head = *p_agent_colours;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        //	printf("MK: freeing %s\n",head->name);
+        free(head->name);
+
+        //free(head->colour);
+        free(head);
+        head = temp;
+    }
+
+    *p_agent_colours = NULL;
 }
 
 int displayagent_colour(agent_colour **p_agent_colours, char * name)
 {
-	agent_colour * current = *p_agent_colours;
-	//agent_colour * temp = NULL;
-	int colour=0;
-	while(current)
-	{
-		//printf("&&&&&&&&&&&Comparing %s with %s ", current->name,name);
-		if(strcmp(current->name, name) == 0) 
-			colour=current->colour;
-		
-			
-		current = current->next;
-	}
-	
-	return colour;
+    agent_colour * current = *p_agent_colours;
+    //agent_colour * temp = NULL;
+    int colour=0;
+    while(current) {
+        //printf("&&&&&&&&&&&Comparing %s with %s ", current->name,name);
+        if(strcmp(current->name, name) == 0)
+            colour=current->colour;
+
+
+        current = current->next;
+    }
+
+    return colour;
 }
 
 void addmodel_colour(model_colour **p_model_colours,char *name, int colour)
 {
-	int flag=0;
-	model_colour *current,*temp;
-	current=*p_model_colours;
-	temp=*p_model_colours;
-	
-	/*while(temp)
-	{
-		counter++;
-		printf("reading %s ",temp->name);
-		temp=temp->next;
-	}*/
-	
-	if(colour>=15)
-	{
-		colour=0;
-	}
-	
-	while((current) && (flag==0))
-	{
-		if(strcmp(current->name,name)==0) 
-			flag=1;
-		//counter++;
-		//printf("\n%s,%d",current->name,colour_old);	
-		current=current->next;
-	}
-	
-	if(flag==0)
-	{
-		
-		if((current=(model_colour *)malloc(sizeof(model_colour)))==NULL)
-		{
-			printf("No memory allocated\n");
-			exit(0);
-		}
-		current->next=temp;
-		*p_model_colours=current;
-		
-		current->name=copystr(name);
-		current->colour = colour;
-	}
-	//printf("Number of model files is %d\n", counter);
+    int flag=0;
+    model_colour *current,*temp;
+    current=*p_model_colours;
+    temp=*p_model_colours;
+
+    /*while(temp)
+    {
+    	counter++;
+    	printf("reading %s ",temp->name);
+    	temp=temp->next;
+    }*/
+
+    if(colour>=15) {
+        colour=0;
+    }
+
+    while((current) && (flag==0)) {
+        if(strcmp(current->name,name)==0)
+            flag=1;
+        //counter++;
+        //printf("\n%s,%d",current->name,colour_old);
+        current=current->next;
+    }
+
+    if(flag==0) {
+
+        if((current=(model_colour *)malloc(sizeof(model_colour)))==NULL) {
+            printf("No memory allocated\n");
+            exit(0);
+        }
+        current->next=temp;
+        *p_model_colours=current;
+
+        current->name=copystr(name);
+        current->colour = colour;
+    }
+    //printf("Number of model files is %d\n", counter);
 }
 
 
 void freemodel_colours(model_colour **p_model_colours)
 {
-	model_colour * temp, * head;
-	head = *p_model_colours;
-	/* Loop until new elements of cells left */
-	while(head)
-	{
-		temp = head->next;
-		/* Free the cell memory */
-		//printf("MODEL FILE COLOURS ARE:");
-	//	printf("%s is colour %d \n",head->name, head->colour);
-		free(head->name);
-		
-		//free(head->colour);
-		free(head);
-		head = temp;
-	}
-	
-	*p_model_colours = NULL;
+    model_colour * temp, * head;
+    head = *p_model_colours;
+    /* Loop until new elements of cells left */
+    while(head) {
+        temp = head->next;
+        /* Free the cell memory */
+        //printf("MODEL FILE COLOURS ARE:");
+        //	printf("%s is colour %d \n",head->name, head->colour);
+        free(head->name);
+
+        //free(head->colour);
+        free(head);
+        head = temp;
+    }
+
+    *p_model_colours = NULL;
 }
 
 
 int displaymodel_colour(model_colour **p_model_colours, char * name)
 {
-	model_colour * current = *p_model_colours;
-	//agent_colour * temp = NULL;
-	int colour=0;
-	while(current)
-	{
-		//printf("&&&&&&&&&&&Comparing %s with %s ", current->name,name);
-		if(strcmp(current->name, name) == 0) 
-			colour=current->colour;
-		
-			
-		current = current->next;
-	}
-	
-	return colour;
+    model_colour * current = *p_model_colours;
+    //agent_colour * temp = NULL;
+    int colour=0;
+    while(current) {
+        //printf("&&&&&&&&&&&Comparing %s with %s ", current->name,name);
+        if(strcmp(current->name, name) == 0)
+            colour=current->colour;
+
+
+        current = current->next;
+    }
+
+    return colour;
 }
- 
+
 int length_colour(model_colour **p_model_colours)
 {
-	int count=0;
-	model_colour *current=*p_model_colours;
-	
-	while(current!=NULL)
-	{
-		count++;
-		current=current->next;
-	}
-	return count;
+    int count=0;
+    model_colour *current=*p_model_colours;
+
+    while(current!=NULL) {
+        count++;
+        current=current->next;
+    }
+    return count;
 }
 

--- a/memory.tmpl
+++ b/memory.tmpl
@@ -730,7 +730,7 @@ void clean_up(int code)
 	}
 }
 
-<?if serial?>
+<?if parallel?>
 /** \fn void propagate_agents()
  * \brief Check agent positions to see if any need to be moved to a another node.
  */

--- a/parsetemplate.c
+++ b/parsetemplate.c
@@ -3,103 +3,88 @@
 /* flag: 0 for usual rule, 1 for libmboard sync rule using map index */
 void writeRule(rule_data * current_rule_data, FILE *file, int flag)
 {
-	char data[100];
-	
-	if(current_rule_data->time_rule == 1)
-	{
-		if(current_rule_data->not == 1) fputs("!", file);
-		fputs("(", file);
-		fputs("iteration_loop", file);
-		fputs(current_rule_data->op, file);
-		fputs(" == ", file);
-		fputs(current_rule_data->rhs, file);
-		fputs(")", file);
-	}
-	/* If interaction radius */
-	else if(current_rule_data->box > 0)
-    {
-	    //Todo
-	    fputs("( /* interaction radius rule goes here */ )", file);
+    char data[100];
+
+    if(current_rule_data->time_rule == 1) {
+        if(current_rule_data->not == 1) fputs("!", file);
+        fputs("(", file);
+        fputs("iteration_loop", file);
+        fputs(current_rule_data->op, file);
+        fputs(" == ", file);
+        fputs(current_rule_data->rhs, file);
+        fputs(")", file);
     }
-	else
-	{
-		if(current_rule_data->not == 1) fputs("!", file);
-		fputs("(", file);
-		/* If rule operator is '==' and one value is a constant agent var */
-		if(flag == 1 && strcmp(current_rule_data->op, "==") == 0 &&
-			( (current_rule_data->lhs_variable->agent != NULL &&
-			   current_rule_data->lhs_variable->constant == 1) ||
-			  (current_rule_data->rhs_variable->agent != NULL &&
-			   current_rule_data->rhs_variable->constant == 1) ) )
-		{
-			fputs("MB_IndexMap_MemberOf(", file);
-			if(current_rule_data->lhs_variable->agent != NULL &&
-					current_rule_data->lhs_variable->constant == 1)
-			{
-				fputs("FLAME_map_", file);
-				fputs(current_rule_data->lhs_variable->agent->name, file);
-				fputs("_", file);
-				fputs(current_rule_data->lhs_variable->name, file);
-			}
-			if(current_rule_data->rhs_variable->agent != NULL &&
-								current_rule_data->rhs_variable->constant == 1)
-			{
-				fputs("FLAME_map_", file);
-				fputs(current_rule_data->rhs_variable->agent->name, file);
-				fputs("_", file);
-				fputs(current_rule_data->rhs_variable->name, file);
-			}
-			fputs(", pid, ", file);
-			if(!(current_rule_data->lhs_variable->agent != NULL &&
-								current_rule_data->lhs_variable->constant == 1))
-			{
-				fputs(current_rule_data->lhs, file);
-			}
-			if(!(current_rule_data->rhs_variable->agent != NULL &&
-					current_rule_data->rhs_variable->constant == 1))
-			{
-				fputs(current_rule_data->rhs, file);
-			}
-			fputs(")", file);
-		}
-		/* If rule operator is 'IN' i.e. integer value within an integer list */
-		else if(strcmp(current_rule_data->op, "IN") == 0)
-		{
-			fputs("FLAME_integer_in_array(", file);
-			fputs(current_rule_data->lhs, file);
-			fputs(", ", file);
-			fputs(current_rule_data->rhs, file);
-			if(current_rule_data->rhs_variable->arraylength == -1)
-			{
-				fputs(".array", file);
-			}
-			fputs(", ", file);
-			/* If array is dynamic */
-			if(current_rule_data->rhs_variable->arraylength == -1)
-			{
-				fputs(current_rule_data->rhs, file);
-				fputs(".size", file);
-			}
-			/* If array is static */
-			if(current_rule_data->rhs_variable->arraylength > 0)
-			{
-				sprintf(data, "%i", current_rule_data->rhs_variable->arraylength);
-				fputs(data, file);
-			}
-			fputs(")", file);
-		}
-		else
-		{
-			if(current_rule_data->lhs == NULL) writeRule(current_rule_data->lhs_rule, file, 0);
-			else fputs(current_rule_data->lhs, file);
-			fputs(" ", file);
-			fputs(current_rule_data->op, file);
-			fputs(" ", file);
-			if(current_rule_data->rhs == NULL) writeRule(current_rule_data->rhs_rule, file, 0);
-			else fputs(current_rule_data->rhs, file);
-		}
-		fputs(")", file);
-	}
+    /* If interaction radius */
+    else if(current_rule_data->box > 0) {
+        //Todo
+        fputs("( /* interaction radius rule goes here */ )", file);
+    } else {
+        if(current_rule_data->not == 1) fputs("!", file);
+        fputs("(", file);
+        /* If rule operator is '==' and one value is a constant agent var */
+        if(flag == 1 && strcmp(current_rule_data->op, "==") == 0 &&
+                ( (current_rule_data->lhs_variable->agent != NULL &&
+                   current_rule_data->lhs_variable->constant == 1) ||
+                  (current_rule_data->rhs_variable->agent != NULL &&
+                   current_rule_data->rhs_variable->constant == 1) ) ) {
+            fputs("MB_IndexMap_MemberOf(", file);
+            if(current_rule_data->lhs_variable->agent != NULL &&
+                    current_rule_data->lhs_variable->constant == 1) {
+                fputs("FLAME_map_", file);
+                fputs(current_rule_data->lhs_variable->agent->name, file);
+                fputs("_", file);
+                fputs(current_rule_data->lhs_variable->name, file);
+            }
+            if(current_rule_data->rhs_variable->agent != NULL &&
+                    current_rule_data->rhs_variable->constant == 1) {
+                fputs("FLAME_map_", file);
+                fputs(current_rule_data->rhs_variable->agent->name, file);
+                fputs("_", file);
+                fputs(current_rule_data->rhs_variable->name, file);
+            }
+            fputs(", pid, ", file);
+            if(!(current_rule_data->lhs_variable->agent != NULL &&
+                    current_rule_data->lhs_variable->constant == 1)) {
+                fputs(current_rule_data->lhs, file);
+            }
+            if(!(current_rule_data->rhs_variable->agent != NULL &&
+                    current_rule_data->rhs_variable->constant == 1)) {
+                fputs(current_rule_data->rhs, file);
+            }
+            fputs(")", file);
+        }
+        /* If rule operator is 'IN' i.e. integer value within an integer list */
+        else if(strcmp(current_rule_data->op, "IN") == 0) {
+            fputs("FLAME_integer_in_array(", file);
+            fputs(current_rule_data->lhs, file);
+            fputs(", ", file);
+            fputs(current_rule_data->rhs, file);
+            if(current_rule_data->rhs_variable->arraylength == -1) {
+                fputs(".array", file);
+            }
+            fputs(", ", file);
+            /* If array is dynamic */
+            if(current_rule_data->rhs_variable->arraylength == -1) {
+                fputs(current_rule_data->rhs, file);
+                fputs(".size", file);
+            }
+            /* If array is static */
+            if(current_rule_data->rhs_variable->arraylength > 0) {
+                sprintf(data, "%i", current_rule_data->rhs_variable->arraylength);
+                fputs(data, file);
+            }
+            fputs(")", file);
+        } else {
+            if(current_rule_data->lhs == NULL) writeRule(current_rule_data->lhs_rule, file, 0);
+            else fputs(current_rule_data->lhs, file);
+            fputs(" ", file);
+            fputs(current_rule_data->op, file);
+            fputs(" ", file);
+            if(current_rule_data->rhs == NULL) writeRule(current_rule_data->rhs_rule, file, 0);
+            else fputs(current_rule_data->rhs, file);
+        }
+        fputs(")", file);
+    }
 }
 
 /** \fn parseTemplate(char * filename, char * templatename, model_data * modeldata)
@@ -110,2782 +95,2240 @@ void writeRule(rule_data * current_rule_data, FILE *file, int flag)
  */
 void parseTemplate(char * filename, char * templatename, model_data * modeldata)
 {
-	/* Pointer to output file */
-	FILE *file;
-	/* Pointer to template file */
-	FILE *tmplfile;
-	char c = ' ';
-	int tmplcode = 0;
-	char chartag[100][100];
-	char tagbuffer[100];
-	char lastloop[100];
-	int lastiftag = 0;
-	int looppos[100];
-	char data[100];
-	int numtag = 0;
-	int exitforeach;
-	int pos;
-	int pos1;
-	int i;
-	int write = 1;
-	/*int lastwrite = 1;
-	int loopwrite[100];
-	int loopwritepos = 0;*/
-	int writetag[100];
-	int log = 0;
-	int var_count;
-	int message_count;
-	int xagent_count;
-	int found;
-	char_array * buffer = init_char_array();
-	char_array * buffer3 = init_char_array();
-	char_array * filebuffer = init_char_array();
-	char * previous_name;
-	int inenvvar = 0;
-	int inallvar = 0;
-	int inxagentvar = 0;
-	int indatatypevar = 0;
-	int inmessagevar = 0;
+    /* Pointer to output file */
+    FILE *file;
+    /* Pointer to template file */
+    FILE *tmplfile;
+    char c = ' ';
+    int tmplcode = 0;
+    char chartag[100][100];
+    char tagbuffer[100];
+    char lastloop[100];
+    int lastiftag = 0;
+    int looppos[100];
+    char data[100];
+    int numtag = 0;
+    int exitforeach;
+    int pos;
+    int pos1;
+    int i;
+    int write = 1;
+    /*int lastwrite = 1;
+    int loopwrite[100];
+    int loopwritepos = 0;*/
+    int writetag[100];
+    int log = 0;
+    int var_count;
+    int message_count;
+    int xagent_count;
+    int found;
+    char_array * buffer = init_char_array();
+    char_array * buffer3 = init_char_array();
+    char_array * filebuffer = init_char_array();
+    char * previous_name;
+    int inenvvar = 0;
+    int inallvar = 0;
+    int inxagentvar = 0;
+    int indatatypevar = 0;
+    int inmessagevar = 0;
 
-	/* pointers to model datatypes */
-	xmachine * current_xmachine;
-	xmachine_message * current_message = NULL;
-	xmachine_function * current_function;
-	xmachine_state * current_state;
-	xmachine_ioput * current_ioput = NULL;
-	variable * current_variable;
-	f_code * current_code;
-	function_pointer * current_function_pointer;
-	layer * current_layer = NULL;
-	env_func * current_envfunc;
-	variable * allvar;
-	variable * current_envvar;
-	variable * current_datatypevariable = NULL;
-	time_data * current_time_unit = NULL;
-	model_datatype * current_datatype = NULL;
-	xmachine_state_holder * current_end_state = NULL;
-	sync * current_sync = NULL;
-	sync_pointer * current_sync_pointer;
+    /* pointers to model datatypes */
+    xmachine * current_xmachine;
+    xmachine_message * current_message = NULL;
+    xmachine_function * current_function;
+    xmachine_state * current_state;
+    xmachine_ioput * current_ioput = NULL;
+    variable * current_variable;
+    f_code * current_code;
+    function_pointer * current_function_pointer;
+    layer * current_layer = NULL;
+    env_func * current_envfunc;
+    variable * allvar;
+    variable * current_envvar;
+    variable * current_datatypevariable = NULL;
+    time_data * current_time_unit = NULL;
+    model_datatype * current_datatype = NULL;
+    xmachine_state_holder * current_end_state = NULL;
+    sync * current_sync = NULL;
+    sync_pointer * current_sync_pointer;
 
-	/* Initialise variables */
-	lastloop[0] = '\0';
-	writetag[0] = 1;
+    /* Initialise variables */
+    lastloop[0] = '\0';
+    writetag[0] = 1;
 
-	/* Open the output file */
-	printf("Generating %s ", filename);
-	file = fopen(filename, "w");
-	/* Open the template file */
-	printf("using %s\n", templatename);
-	tmplfile = fopen(templatename, "r");
+    /* Open the output file */
+    printf("Generating %s ", filename);
+    file = fopen(filename, "w");
+    /* Open the template file */
+    printf("using %s\n", templatename);
+    tmplfile = fopen(templatename, "r");
+    if(tmplfile == NULL) {
 
-	/* Read the template file into memory */
-	while (c != (char)EOF)
-	{
-		c = (char)fgetc(tmplfile);
-		if (c != (char)EOF)
-			add_char(filebuffer, c);
-	}
-	/* Record the position reached in the template */
-	pos = 0;
-	/* While still parsing the template */
-	while (pos < filebuffer->size)
-	{
-		/* C is the next character in the template */
-		c = filebuffer->array[pos];
-		/* If in a template code tag */
-		if (tmplcode == 1)
-		{
-			/* If end of tag */
-			if (c == '>')
-			{
-				add_char(buffer, '>');
-				/* Handle tags */
-				if (strcmp(buffer->array, "<?if use_arrays?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif use_arrays\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (modeldata->agents_include_array_variables == 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if serial?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif serial\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (modeldata->code_type != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if parallel?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif parallel\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (modeldata->code_type != 1)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if has_arrays_or_adts?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_datatype != NULL)
-					{
-						if (current_datatype->has_arrays_or_adts == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if has_arrays?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_datatype != NULL)
-					{
-						if (current_datatype->has_arrays == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if dynamic_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif dynamic_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->arraylength != -1)
-							write = 0;
-					}
-					else if (inallvar)
-					{
-						if (allvar->arraylength != -1)
-							write = 0;
-					}
-					else if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (current_variable->arraylength != -1)
-							write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if static_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif static_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (allvar->arraylength < 1)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (current_variable->arraylength < 1)
-							write = 0;
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->arraylength < 1)
-							write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if not_static_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif static_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (allvar->arraylength > 0)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (current_variable->arraylength > 0)
-							write = 0;
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->arraylength > 0)
-							write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if not_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif not_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (allvar->arraylength != 0)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (current_variable->arraylength != 0)
-							write = 0;
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->arraylength != 0)
-							write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (allvar->arraylength == 0)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (current_variable->arraylength == 0)
-							write = 0;
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->arraylength == 0)
-							write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if modeldatatype?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif modeldatatype\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-					{
-						if (allvar->ismodeldatatype == 0) write = 0;
-					}
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-					{
-						if (current_variable->ismodeldatatype == 0) write = 0;
-					}
-					if (indatatypevar)
-					{
-						if (current_datatypevariable->ismodeldatatype == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if not_modeldatatype?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif not_modeldatatype\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (allvar->ismodeldatatype == 1)
-							write = 0;
-					if (inxagentvar || inmessagevar)
-						if(current_variable != NULL) if (current_variable->ismodeldatatype == 1)
-							write = 0;
-					if (indatatypevar)
-						if (current_datatypevariable->ismodeldatatype == 1)
-							write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if float?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif float\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach datatypevar") == 0)
-					{
-						if (indatatypevar)
-							if (strcmp(current_datatypevariable->type, "float") != 0 && strcmp(current_datatypevariable->type, "char_array") != 0)
-								write = 0;
-					}
-					else
-					{
-						if (inenvvar)
-							if (strcmp(current_envvar->type, "float") != 0 && strcmp(current_envvar->type, "char_array") != 0)
-								write = 0;
-						if (inallvar)
-							if (strcmp(allvar->type, "float") != 0 && strcmp(allvar->type, "float_array") != 0)
-								write = 0;
-						if ((inxagentvar || inmessagevar) && current_variable != NULL)
-							if (strcmp(current_variable->type, "float") != 0 && strcmp(current_variable->type, "float_array") != 0)
-								write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if char?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif not_char\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach datatypevar") == 0)
-					{
-						if (indatatypevar)
-							if (strcmp(current_datatypevariable->type, "char") != 0 && strcmp(current_datatypevariable->type, "char_array") != 0)
-								write = 0;
-					}
-					else
-					{
-						if (inenvvar)
-							if (strcmp(current_envvar->type, "char") != 0 && strcmp(current_envvar->type, "char_array") != 0)
-								write = 0;
-						if (inallvar)
-							if (strcmp(allvar->type, "char") != 0 && strcmp(allvar->type, "char_array") != 0)
-								write = 0;
-						if ((inxagentvar || inmessagevar) && current_variable != NULL)
-							if (strcmp(current_variable->type, "char") != 0 && strcmp(current_variable->type, "char_array") != 0)
-								write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if not_char?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif not_char\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach datatypevar") == 0)
-					{
-						if (indatatypevar)
-							if (strcmp(current_datatypevariable->type, "char") == 0 || strcmp(current_datatypevariable->type, "char_array") == 0)
-								write = 0;
-					}
-					else
-					{
-						if (inenvvar)
-							if (strcmp(current_envvar->type, "char") == 0 || strcmp(current_envvar->type, "char_array") == 0)
-								write = 0;
-						if (inallvar)
-							if (strcmp(allvar->type, "char") == 0 || strcmp(allvar->type, "char_array") == 0)
-								write = 0;
-						if ((inxagentvar || inmessagevar) && current_variable != NULL)
-							if (strcmp(current_variable->type, "char") == 0 || strcmp(current_variable->type, "char_array") == 0)
-								write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if char_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif char_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (strcmp(allvar->type, "char_array") != 0)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (strcmp(current_variable->type, "char_array") != 0)
-							write = 0;
-					if (indatatypevar)
-						if (strcmp(current_datatypevariable->type, "char_array") != 0 &&
-								strcmp(current_datatypevariable->type, "char") != 0)
-							write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if notchar_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif notchar_array\twrite:%d\n", numtag, write);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (inallvar)
-						if (strcmp(allvar->type, "char_array") == 0)
-							write = 0;
-					if ((inxagentvar || inmessagevar) && current_variable != NULL)
-						if (strcmp(current_variable->type, "char_array") == 0)
-							write = 0;
-					if (indatatypevar)
-						if (strcmp(current_datatypevariable->type, "char_array") == 0 ||
-								strcmp(current_datatypevariable->type, "char") == 0)
-							write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if int_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif int_array\twrite:%d\n", numtag, write);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(allvar->type, "int_array") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if float_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif float_array\twrite:%d\n", numtag, write);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(allvar->type, "float_array") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if double_array?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif double_array\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(allvar->type, "double_array") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if first?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif first\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach xagent") == 0)
-					if (current_xmachine != * modeldata->p_xmachines)
-						write = 0;
-					if (strcmp(lastloop, "foreach message") == 0)
-					if (current_message != * modeldata->p_xmessages)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if notfirst?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif notfirst\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach xagent") == 0)
-					if (current_xmachine == * modeldata->p_xmachines)
-						write = 0;
-					if (strcmp(lastloop, "foreach message") == 0)
-					if (current_message == * modeldata->p_xmessages)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if notlast?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif notlast\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(lastloop, "foreach xagent") == 0)
-						if (current_xmachine->next == NULL)
-							write = 0;
-					if (strcmp(lastloop, "foreach xagentvar") == 0)
-					{
-						if(current_variable != NULL)
-						{
-							if (current_variable->next == NULL) write = 0;
-						}
-						else write = 0;
-					}
-					if (strcmp(lastloop, "foreach message") == 0)
-						if (current_message->next == NULL)
-							write = 0;
-					if (strcmp(lastloop, "foreach messagevar") == 0)
-					{
-						if(current_variable != NULL)
-						{
-							if (current_variable->next == NULL)
-							write = 0;
-						}
-						else write = 0;
-					}
-					if (strcmp(lastloop, "foreach function") == 0)
-						if (current_function->next == NULL && current_xmachine->next == NULL)
-							write = 0;
-					if(strcmp(lastloop, "foreach datatypevar") == 0)
-					{
-						if(current_datatypevariable != NULL)
-						{
-							if (current_datatypevariable->next == NULL) write = 0;
-						}
-						else write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if last?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif last\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(strcmp(lastloop, "foreach datatypevar") == 0)
-					{
-						if(current_datatypevariable != NULL)
-						{
-							if (current_datatypevariable->next != NULL) write = 0;
-						}
-						else write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if allvar_in_agent?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif allvar_in_agent\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					found = 0;
-					current_variable = current_xmachine->variables;
-					while (current_variable)
-					{
-						if (strcmp(current_variable->name, allvar->name) == 0)
-							found = 1;
+        printf("\n***Error: Template file %s not found - xparser terminating!\n\n",templatename);
+        exit (1);
+    }
 
-						current_variable = current_variable->next;
-					}
-					if (found == 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if use_xvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif use_xvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->xvar, "0.0") == 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_xvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif no_xvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->xvar, "0.0") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if use_yvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif use_yvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->yvar, "0.0") == 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_yvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif no_yvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->yvar, "0.0") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if use_zvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif use_zvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->zvar, "0.0") == 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_zvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tif no_zvar\n", numtag);
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if (strcmp(current_xmachine->zvar, "0.0") != 0)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if single_vars?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_datatype != NULL)
-					{
-						if (current_datatype->has_single_vars == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if has_dynamic_arrays?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_datatype != NULL)
-					{
-						if (current_datatype->has_dynamic_arrays == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_dynamic_arrays?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_datatype != NULL)
-					{
-						if (current_datatype->has_dynamic_arrays == 1) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if not_idle?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_function != NULL)
-					{
-						//if (current_function->condition_function == NULL) write = 0;
-						if( strcmp(current_function->name, "idle") == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if condition?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_function != NULL)
-					{
-						if (current_function->condition_function == NULL) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if filter?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
+    /* Read the template file into memory */
+    while (c != (char)EOF) {
+        c = (char)fgetc(tmplfile);
+        if (c != (char)EOF)
+            add_char(filebuffer, c);
+    }
+    /* Record the position reached in the template */
+    pos = 0;
+    /* While still parsing the template */
+    while (pos < filebuffer->size) {
+        /* C is the next character in the template */
+        c = filebuffer->array[pos];
+        /* If in a template code tag */
+        if (tmplcode == 1) {
+            /* If end of tag */
+            if (c == '>') {
+                add_char(buffer, '>');
+                /* Handle tags */
+                if (strcmp(buffer->array, "<?if use_arrays?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif use_arrays\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->agents_include_array_variables == 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array,"<?if gsl_lib?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif gsl_lib\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->gsl_lib != 1)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if serial?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif serial\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->code_type != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if parallel?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif parallel\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->code_type != 1)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if has_arrays_or_adts?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_datatype != NULL) {
+                        if (current_datatype->has_arrays_or_adts == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if has_arrays?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_datatype != NULL) {
+                        if (current_datatype->has_arrays == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if dynamic_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif dynamic_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (indatatypevar) {
+                        if (current_datatypevariable->arraylength != -1)
+                            write = 0;
+                    } else if (inallvar) {
+                        if (allvar->arraylength != -1)
+                            write = 0;
+                    } else if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (current_variable->arraylength != -1)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if static_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif static_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (allvar->arraylength < 1)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (current_variable->arraylength < 1)
+                            write = 0;
+                    if (indatatypevar) {
+                        if (current_datatypevariable->arraylength < 1)
+                            write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if not_static_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif static_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (allvar->arraylength > 0)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (current_variable->arraylength > 0)
+                            write = 0;
+                    if (indatatypevar) {
+                        if (current_datatypevariable->arraylength > 0)
+                            write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if not_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif not_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (allvar->arraylength != 0)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (current_variable->arraylength != 0)
+                            write = 0;
+                    if (indatatypevar) {
+                        if (current_datatypevariable->arraylength != 0)
+                            write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (allvar->arraylength == 0)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (current_variable->arraylength == 0)
+                            write = 0;
+                    if (indatatypevar) {
+                        if (current_datatypevariable->arraylength == 0)
+                            write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if modeldatatype?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif modeldatatype\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar) {
+                        if (allvar->ismodeldatatype == 0) write = 0;
+                    }
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL) {
+                        if (current_variable->ismodeldatatype == 0) write = 0;
+                    }
+                    if (indatatypevar) {
+                        if (current_datatypevariable->ismodeldatatype == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if not_modeldatatype?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif not_modeldatatype\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (allvar->ismodeldatatype == 1)
+                            write = 0;
+                    if (inxagentvar || inmessagevar)
+                        if(current_variable != NULL) if (current_variable->ismodeldatatype == 1)
+                                write = 0;
+                    if (indatatypevar)
+                        if (current_datatypevariable->ismodeldatatype == 1)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if float?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif float\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach datatypevar") == 0) {
+                        if (indatatypevar)
+                            if (strcmp(current_datatypevariable->type, "float") != 0 && strcmp(current_datatypevariable->type, "char_array") != 0)
+                                write = 0;
+                    } else {
+                        if (inenvvar)
+                            if (strcmp(current_envvar->type, "float") != 0 && strcmp(current_envvar->type, "char_array") != 0)
+                                write = 0;
+                        if (inallvar)
+                            if (strcmp(allvar->type, "float") != 0 && strcmp(allvar->type, "float_array") != 0)
+                                write = 0;
+                        if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                            if (strcmp(current_variable->type, "float") != 0 && strcmp(current_variable->type, "float_array") != 0)
+                                write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if char?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif not_char\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach datatypevar") == 0) {
+                        if (indatatypevar)
+                            if (strcmp(current_datatypevariable->type, "char") != 0 && strcmp(current_datatypevariable->type, "char_array") != 0)
+                                write = 0;
+                    } else {
+                        if (inenvvar)
+                            if (strcmp(current_envvar->type, "char") != 0 && strcmp(current_envvar->type, "char_array") != 0)
+                                write = 0;
+                        if (inallvar)
+                            if (strcmp(allvar->type, "char") != 0 && strcmp(allvar->type, "char_array") != 0)
+                                write = 0;
+                        if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                            if (strcmp(current_variable->type, "char") != 0 && strcmp(current_variable->type, "char_array") != 0)
+                                write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if not_char?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif not_char\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach datatypevar") == 0) {
+                        if (indatatypevar)
+                            if (strcmp(current_datatypevariable->type, "char") == 0 || strcmp(current_datatypevariable->type, "char_array") == 0)
+                                write = 0;
+                    } else {
+                        if (inenvvar)
+                            if (strcmp(current_envvar->type, "char") == 0 || strcmp(current_envvar->type, "char_array") == 0)
+                                write = 0;
+                        if (inallvar)
+                            if (strcmp(allvar->type, "char") == 0 || strcmp(allvar->type, "char_array") == 0)
+                                write = 0;
+                        if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                            if (strcmp(current_variable->type, "char") == 0 || strcmp(current_variable->type, "char_array") == 0)
+                                write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if char_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif char_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (strcmp(allvar->type, "char_array") != 0)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (strcmp(current_variable->type, "char_array") != 0)
+                            write = 0;
+                    if (indatatypevar)
+                        if (strcmp(current_datatypevariable->type, "char_array") != 0 &&
+                                strcmp(current_datatypevariable->type, "char") != 0)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if notchar_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif notchar_array\twrite:%d\n", numtag, write);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (inallvar)
+                        if (strcmp(allvar->type, "char_array") == 0)
+                            write = 0;
+                    if ((inxagentvar || inmessagevar) && current_variable != NULL)
+                        if (strcmp(current_variable->type, "char_array") == 0)
+                            write = 0;
+                    if (indatatypevar)
+                        if (strcmp(current_datatypevariable->type, "char_array") == 0 ||
+                                strcmp(current_datatypevariable->type, "char") == 0)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if int_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif int_array\twrite:%d\n", numtag, write);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(allvar->type, "int_array") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if float_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif float_array\twrite:%d\n", numtag, write);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(allvar->type, "float_array") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if double_array?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif double_array\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(allvar->type, "double_array") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if first?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif first\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach xagent") == 0)
+                        if (current_xmachine != * modeldata->p_xmachines)
+                            write = 0;
+                    if (strcmp(lastloop, "foreach message") == 0)
+                        if (current_message != * modeldata->p_xmessages)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if notfirst?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif notfirst\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach xagent") == 0)
+                        if (current_xmachine == * modeldata->p_xmachines)
+                            write = 0;
+                    if (strcmp(lastloop, "foreach message") == 0)
+                        if (current_message == * modeldata->p_xmessages)
+                            write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if notlast?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif notlast\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(lastloop, "foreach xagent") == 0)
+                        if (current_xmachine->next == NULL)
+                            write = 0;
+                    if (strcmp(lastloop, "foreach xagentvar") == 0) {
+                        if(current_variable != NULL) {
+                            if (current_variable->next == NULL) write = 0;
+                        } else write = 0;
+                    }
+                    if (strcmp(lastloop, "foreach message") == 0)
+                        if (current_message->next == NULL)
+                            write = 0;
+                    if (strcmp(lastloop, "foreach messagevar") == 0) {
+                        if(current_variable != NULL) {
+                            if (current_variable->next == NULL)
+                                write = 0;
+                        } else write = 0;
+                    }
+                    if (strcmp(lastloop, "foreach function") == 0)
+                        if (current_function->next == NULL && current_xmachine->next == NULL)
+                            write = 0;
+                    if(strcmp(lastloop, "foreach datatypevar") == 0) {
+                        if(current_datatypevariable != NULL) {
+                            if (current_datatypevariable->next == NULL) write = 0;
+                        } else write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if last?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif last\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(strcmp(lastloop, "foreach datatypevar") == 0) {
+                        if(current_datatypevariable != NULL) {
+                            if (current_datatypevariable->next != NULL) write = 0;
+                        } else write = 0;
+                    }
+                    if(strcmp(lastloop, "foreach state") == 0) {
+                        if(current_state != NULL) {
+                            if (current_state->next != NULL) write = 0;
+                        } else write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if allvar_in_agent?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif allvar_in_agent\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    found = 0;
+                    current_variable = current_xmachine->variables;
+                    while (current_variable) {
+                        if (strcmp(current_variable->name, allvar->name) == 0)
+                            found = 1;
 
-					if(current_ioput != NULL)
-					{
-						if (current_ioput->filter_rule == NULL) write = 0;
-						//else if (current_ioput->filter_rule->box != 0) write = 0;
-					}
-					else write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_filter?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
+                        current_variable = current_variable->next;
+                    }
+                    if (found == 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if use_xvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif use_xvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->xvar, "0.0") == 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_xvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif no_xvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->xvar, "0.0") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if use_yvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif use_yvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->yvar, "0.0") == 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_yvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif no_yvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->yvar, "0.0") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if use_zvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif use_zvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->zvar, "0.0") == 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_zvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tif no_zvar\n", numtag);
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if (strcmp(current_xmachine->zvar, "0.0") != 0)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if single_vars?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_datatype != NULL) {
+                        if (current_datatype->has_single_vars == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if has_dynamic_arrays?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_datatype != NULL) {
+                        if (current_datatype->has_dynamic_arrays == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_dynamic_arrays?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_datatype != NULL) {
+                        if (current_datatype->has_dynamic_arrays == 1) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if not_idle?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_function != NULL) {
+                        //if (current_function->condition_function == NULL) write = 0;
+                        if( strcmp(current_function->name, "idle") == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if condition?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_function != NULL) {
+                        if (current_function->condition_function == NULL) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if filter?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
 
-					if(current_ioput != NULL)
-					{
-						if (current_ioput->filter_function != NULL) write = 0;
-						//    if (current_ioput->filter_rule->box == 0)
-						//        write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if sort?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
+                    if(current_ioput != NULL) {
+                        if (current_ioput->filter_rule == NULL) write = 0;
+                        //else if (current_ioput->filter_rule->box != 0) write = 0;
+                    } else write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_filter?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
 
-					if(current_ioput != NULL)
-					{
-						if (current_ioput->sort_function == NULL) write = 0;
-					}
-					else write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if no_sort?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
+                    if(current_ioput != NULL) {
+                        if (current_ioput->filter_function != NULL) write = 0;
+                        //    if (current_ioput->filter_rule->box == 0)
+                        //        write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if sort?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
 
-					if(current_ioput != NULL)
-					{
-						if (current_ioput->sort_function != NULL) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if sync_filter?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					
-					if(current_sync != NULL)
-					{
-						if(current_sync->has_agent_and_message_vars == 0) write = 0;
-					}
-					else write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if function_input?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_function != NULL)
-					{
-						if(current_function->inputs == NULL)
-						{
-							write = 0;
-						}
-					}
-					else write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if has_agent_var?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->filter_rule != NULL)
-						{
-							if(current_ioput->filter_rule->has_agent_var == 0) write = 0;
-						}
-					}
-					else if(current_function != NULL)
-					{
-						if(current_function->filter_rule != NULL)
-						{
-							if(current_function->filter_rule->has_agent_var == 0) write = 0;
-						}
-						else if(current_function->has_agent_var == 0) write = 0;
-					}
-					else if(current_xmachine != NULL)
-					{
-						if(current_xmachine->variables == NULL) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if has_message_var?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if (write == 1)
-						lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->filter_rule != NULL)
-						{
-							if (current_ioput->filter_rule->has_message_var == 0) write = 0;
-						}
-					}
-					else if(current_function != NULL)
-					{
-						 if(current_function->has_agent_var == 0) write = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if random?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->random == 0) write = 0;
-					}
-					
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if notrandom?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->random == 1) write = 0;
-					}
-					
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if ascend?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->sort_order != NULL)
-						if(strcmp(current_ioput->sort_order, "ascend") != 0) write = 0;
-					}
-					
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if descend?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if(current_ioput != NULL)
-					{
-						if(current_ioput->sort_order != NULL)
-						if(strcmp(current_ioput->sort_order, "descend") != 0) write = 0;
-					}
-					
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if debug?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if (modeldata->debug_mode == 0) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if final?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if (modeldata->debug_mode == 1) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if constant?>") == 0)
-				{
-					strcpy(&chartag[numtag][0], "if");
-					if(write == 1) lastiftag = numtag;
-					numtag++;
-					if (current_variable->constant == 0) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?if tree2d?>") == 0)
-                {
+                    if(current_ioput != NULL) {
+                        if (current_ioput->sort_function == NULL) write = 0;
+                    } else write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if no_sort?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+
+                    if(current_ioput != NULL) {
+                        if (current_ioput->sort_function != NULL) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if sync_filter?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+
+                    if(current_sync != NULL) {
+                        if(current_sync->has_agent_and_message_vars == 0) write = 0;
+                    } else write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if function_input?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_function != NULL) {
+                        if(current_function->inputs == NULL) {
+                            write = 0;
+                        }
+                    } else write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if has_agent_var?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_ioput != NULL) {
+                        if(current_ioput->filter_rule != NULL) {
+                            if(current_ioput->filter_rule->has_agent_var == 0) write = 0;
+                        }
+                    } else if(current_function != NULL) {
+                        if(current_function->filter_rule != NULL) {
+                            if(current_function->filter_rule->has_agent_var == 0) write = 0;
+                        } else if(current_function->has_agent_var == 0) write = 0;
+                    } else if(current_xmachine != NULL) {
+                        if(current_xmachine->variables == NULL) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if has_message_var?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if (write == 1)
+                        lastiftag = numtag;
+                    numtag++;
+                    if(current_ioput != NULL) {
+                        if(current_ioput->filter_rule != NULL) {
+                            if (current_ioput->filter_rule->has_message_var == 0) write = 0;
+                        }
+                    } else if(current_function != NULL) {
+                        if(current_function->has_agent_var == 0) write = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if random?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_message != NULL)
-                    {
+                    if(current_ioput != NULL) {
+                        if(current_ioput->random == 0) write = 0;
+                    }
+
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if notrandom?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if(current_ioput != NULL) {
+                        if(current_ioput->random == 1) write = 0;
+                    }
+
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if ascend?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if(current_ioput != NULL) {
+                        if(current_ioput->sort_order != NULL)
+                            if(strcmp(current_ioput->sort_order, "ascend") != 0) write = 0;
+                    }
+
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if descend?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if(current_ioput != NULL) {
+                        if(current_ioput->sort_order != NULL)
+                            if(strcmp(current_ioput->sort_order, "descend") != 0) write = 0;
+                    }
+
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if debug?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->debug_mode == 0) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if final?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if (modeldata->debug_mode == 1) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if constant?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if (current_variable->constant == 0) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?if tree2d?>") == 0) {
+                    strcpy(&chartag[numtag][0], "if");
+                    if(write == 1) lastiftag = numtag;
+                    numtag++;
+                    if(current_message != NULL) {
                         if(current_message->has_box2d == 0) write = 0;
                     }
-                    if(current_sync != NULL)
-                    {
+                    if(current_sync != NULL) {
                         if(current_sync->message->has_box2d == 0) write = 0;
                     }
-                    if(current_ioput != NULL)
-                    {
-                        if(current_ioput->filter_rule != NULL)
-                        {
+                    if(current_ioput != NULL) {
+                        if(current_ioput->filter_rule != NULL) {
                             if (current_ioput->filter_rule->box != 2) write = 0;
                         }
                     }
                     writetag[numtag] = write;
-                }
-				else if (strcmp(buffer->array, "<?if tree3d?>") == 0)
-                {
+                } else if (strcmp(buffer->array, "<?if tree3d?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_message != NULL)
-                    {
+                    if(current_message != NULL) {
                         if(current_message->has_box3d == 0) write = 0;
                     }
-                    if(current_sync != NULL)
-                    {
+                    if(current_sync != NULL) {
                         if(current_sync->message->has_box3d == 0) write = 0;
                     }
-                    if(current_ioput != NULL)
-                    {
-                        if(current_ioput->filter_rule != NULL)
-                        {
+                    if(current_ioput != NULL) {
+                        if(current_ioput->filter_rule != NULL) {
                             if (current_ioput->filter_rule->box != 3) write = 0;
                         }
                     }
                     writetag[numtag] = write;
-                }
-				else if (strcmp(buffer->array, "<?if nottree?>") == 0)
-                {
+                } else if (strcmp(buffer->array, "<?if nottree?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_ioput != NULL)
-                    {
-                        if(current_ioput->filter_rule != NULL)
-                        {
+                    if(current_ioput != NULL) {
+                        if(current_ioput->filter_rule != NULL) {
                             if (current_ioput->filter_rule->box != 0) write = 0;
                         }
                     }
                     writetag[numtag] = write;
-                }
-				else if (strcmp(buffer->array, "<?if make_x_func?>") == 0)
-                {
+                } else if (strcmp(buffer->array, "<?if make_x_func?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_message != NULL)
-                    {
+                    if(current_message != NULL) {
                         if (current_message->make_x_function == 0) write = 0;
                     }
                     writetag[numtag] = write;
-                }
-				else if (strcmp(buffer->array, "<?if make_y_func?>") == 0)
-                {
+                } else if (strcmp(buffer->array, "<?if make_y_func?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_message != NULL)
-                    {
+                    if(current_message != NULL) {
                         if (current_message->make_y_function == 0) write = 0;
                     }
                     writetag[numtag] = write;
-                }
-				else if (strcmp(buffer->array, "<?if make_z_func?>") == 0)
-                {
+                } else if (strcmp(buffer->array, "<?if make_z_func?>") == 0) {
                     strcpy(&chartag[numtag][0], "if");
                     if(write == 1) lastiftag = numtag;
                     numtag++;
-                    if(current_message != NULL)
-                    {
+                    if(current_message != NULL) {
                         if (current_message->make_z_function == 0) write = 0;
                     }
                     writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?end if?>") == 0) {
+                    /* Look at last tag */
+                    numtag--;
+                    /* If different then exit */
+                    if (strcmp("if", &chartag[numtag][0]) != 0) {
+                        printf("error with template tag nest\n");
+                        printf("tag to close: %s\n", &chartag[numtag][0]);
+                        exit(0);
+                    }
+
+                    if (log)
+                        printf("finish:%d\tif", numtag);
+                    /* if corresponds with first if*/
+                    if (log)
+                        printf("\tnumtag:%d\tlastiftag:%d\twrite:%d\tpos:%d\n", numtag, lastiftag, write, pos);
+                    if (numtag == lastiftag) {
+                        /*write = 1;
+                        lastwrite = 1;*/
+                        lastiftag = -1;
+                    }
+                    write = writetag[numtag];
+                } else if (strcmp(buffer->array, "<?end foreach?>") == 0) {
+                    exitforeach = 0;
+                    /* Look at last tag */
+                    numtag--;
+
+                    /* Check for next element in current loop */
+                    if (strcmp("foreach constant_filter_variable", &chartag[numtag][0]) == 0) {
+                        if (current_variable != NULL)
+                            current_variable = current_variable->next;
+                        if (current_variable == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                        }
+                    } else if (strcmp("foreach functionfiles", &chartag[numtag][0]) == 0) {
+                        if (current_envfunc != NULL)
+                            current_envfunc = current_envfunc->next;
+                        if (current_envfunc == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                        }
+                    } else if (strcmp("foreach allvar", &chartag[numtag][0]) == 0) {
+                        if (allvar != NULL) {
+                            allvar = allvar->next;
+                        }
+                        if (allvar == NULL) {
+                            exitforeach = 1;
+                            inallvar = 0;
+                        } else {
+                            current_datatype = allvar->datatype;
+                            pos = looppos[numtag];
+                            numtag++;
+                        }
+                    } else if (strcmp("foreach envvar", &chartag[numtag][0]) == 0) {
+                        if (current_envvar != NULL)
+                            current_envvar = current_envvar->next;
+                        if (current_envvar == NULL) {
+                            exitforeach = 1;
+                            inenvvar = 0;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                        }
+                    } else if (strcmp("foreach xagent", &chartag[numtag][0]) == 0 ||
+                               strcmp("foreach readingxagent", &chartag[numtag][0]) == 0 ||
+                               strcmp("foreach sendingxagent", &chartag[numtag][0]) == 0) {
+                        if (current_xmachine != NULL) {
+                            previous_name = current_xmachine->name;
+                            current_xmachine = current_xmachine->next;
+                        }
+                        if (current_xmachine == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            xagent_count++;
+                        }
+                    } else if (strcmp("foreach xagentvar", &chartag[numtag][0]) == 0) {
+                        if (current_variable != NULL) {
+                            current_variable = current_variable->next;
+                            if(current_variable != NULL) current_datatype = current_variable->datatype;
+                        }
+                        if (current_variable == NULL) {
+                            exitforeach = 1;
+                            inxagentvar = 0;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach state", &chartag[numtag][0]) == 0) {
+                        if (current_state != NULL) {
+                            current_state = current_state->next;
+                        }
+                        if (current_state == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach message", &chartag[numtag][0]) == 0) {
+                        if (current_message != NULL) {
+                            previous_name = current_message->name;
+                            current_message = current_message->next;
+                        }
+                        if (current_message == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            message_count++;
+                        }
+                    } else if (strcmp("foreach messagevar", &chartag[numtag][0]) == 0) {
+                        if (current_variable != NULL) {
+                            current_variable = current_variable->next;
+                            if(current_variable != NULL) current_datatype = current_variable->datatype;
+                        }
+                        if (current_variable == NULL) {
+                            exitforeach = 1;
+                            inmessagevar = 0;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach sync", &chartag[numtag][0]) == 0) {
+                        if (current_sync != NULL) {
+                            current_sync = current_sync->next;
+                        }
+                        if (current_sync == NULL) {
+                            exitforeach = 1;
+                            inmessagevar = 0;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach syncvar", &chartag[numtag][0]) == 0) {
+                        if (current_variable != NULL) {
+                            current_variable = current_variable->next;
+                        }
+                        if (current_variable == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach paramvar", &chartag[numtag][0]) == 0) {
+                        if (current_variable != NULL) {
+                            current_variable = current_variable->next;
+                        }
+                        if (current_variable == NULL) {
+                            if(current_xmachine != NULL)
+                                current_xmachine = current_xmachine->next;
+                            if(current_xmachine != NULL)
+                                current_variable = current_xmachine->variables;
+                        }
+                        if (current_variable == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach layer", &chartag[numtag][0]) == 0) {
+                        if (current_layer != NULL)
+                            current_layer = current_layer->next;
+                        if (current_layer == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                            current_function_pointer = current_layer->functions;
+                            current_function = current_function_pointer->function;
+                        }
+                    } else if (strcmp("foreach function_input", &chartag[numtag][0]) == 0) {
+                        if (current_ioput != NULL) {
+                            current_ioput = current_ioput->next;
+
+                            if(current_sync != NULL) {
+                                while(current_ioput != NULL &&
+                                        strcmp(current_ioput->messagetype, current_sync->message->name) != 0) {
+                                    current_ioput = current_ioput->next;
+                                }
+                            }
+                        }
+                        if (current_ioput == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach function_output", &chartag[numtag][0]) == 0) {
+                        if (current_ioput != NULL)
+                            current_ioput = current_ioput->next;
+                        if (current_ioput == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach complete_sync", &chartag[numtag][0]) == 0) {
+                        if (current_sync_pointer != NULL)
+                            current_sync_pointer = current_sync_pointer->next;
+                        if (current_sync_pointer == NULL) {
+                            current_sync = NULL;
+                            exitforeach = 1;
+                        } else {
+                            current_sync = current_sync_pointer->current_sync;
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach start_sync", &chartag[numtag][0]) == 0) {
+                        if (current_sync_pointer != NULL)
+                            current_sync_pointer = current_sync_pointer->next;
+                        if (current_sync_pointer == NULL) {
+                            current_sync = NULL;
+                            exitforeach = 1;
+                        } else {
+                            current_sync = current_sync_pointer->current_sync;
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach function", &chartag[numtag][0]) == 0) {
+                        if (current_layer != NULL) { // || current_sync != NULL)
+                            //if(current_layer != NULL) printf("current_layer: %d\n", current_layer->number);
+
+                            if (current_function_pointer != NULL) {
+                                //printf("foreach function: %s next: ", current_function_pointer->function->name);
+
+                                current_function_pointer = current_function_pointer->next;
+
+                                //if (current_function_pointer == NULL) printf("NULL\n");
+                                //else printf("%s\n", current_function_pointer->function->name);
+                            }
+                            if (current_function_pointer == NULL) {
+                                //printf("foreach function: NULL\n");
+                                current_function = NULL;
+                                exitforeach = 1;
+                            } else {
+                                current_function = current_function_pointer->function;
+                                pos = looppos[numtag];
+                                numtag++;
+                                var_count++;
+                            }
+                        } else {
+                            if (current_function != NULL)
+                                current_function = current_function->next;
+                            if (current_function == NULL)
+                                exitforeach = 1;
+                            else {
+                                pos = looppos[numtag];
+                                numtag++;
+                                var_count++;
+                            }
+                        }
+                    } else if (strcmp("foreach enditfunc", &chartag[numtag][0]) == 0) {
+                        if (current_code != NULL)
+                            current_code = current_code->next;
+                        if (current_code == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach datatype", &chartag[numtag][0]) == 0) {
+                        if (current_datatype != NULL)
+                            current_datatype = current_datatype->next;
+                        if (current_datatype == NULL)
+                            exitforeach = 1;
+                        else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach datatypevar", &chartag[numtag][0]) == 0) {
+                        if (current_datatypevariable != NULL)
+                            current_datatypevariable = current_datatypevariable->next;
+                        if (current_datatypevariable == NULL) {
+                            exitforeach = 1;
+                            indatatypevar = 0;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach timeunit", &chartag[numtag][0]) == 0) {
+                        if (current_time_unit != NULL)
+                            current_time_unit = current_time_unit->next;
+                        if (current_time_unit == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach endstate", &chartag[numtag][0]) == 0) {
+                        if (current_end_state != NULL)
+                            current_end_state = current_end_state->next;
+                        if (current_end_state == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    } else if (strcmp("foreach branching_state", &chartag[numtag][0]) == 0) {
+                        if (current_end_state != NULL) {
+                            current_end_state = current_end_state->next;
+                        }
+                        if (current_end_state == NULL) {
+                            exitforeach = 1;
+                        } else {
+                            current_state = current_end_state->state;
+
+                            pos = looppos[numtag];
+                            numtag++;
+                            var_count++;
+                        }
+                    }
+                    /* If different then exit */
+                    if (exitforeach) {
+                        strcpy(tagbuffer, &chartag[numtag][0]);
+                        tagbuffer[7] = '\0';
+                        if (strcmp("foreach", tagbuffer) != 0) {
+                            printf("error with template tag nest\n");
+                            printf("tag to close: %s\n", &chartag[numtag][0]);
+                            exit(0);
+                        }
+
+                        /*if(loopwritepos > 0)
+                        {
+                        	loopwritepos--;
+                        	write = loopwrite[loopwritepos];
+                        }
+                        else write = lastwrite;*/
+                        write = writetag[numtag];
+
+                        /* find last loop in chartag */
+                        if (log)
+                            printf("**** exit loop = %s\n", lastloop);
+                        strcpy(lastloop, "");
+                        for (i = 0; i < numtag; i++) {
+                            strcpy(tagbuffer, &chartag[i][0]);
+                            tagbuffer[7] = '\0';
+                            if (strcmp("foreach", tagbuffer) == 0) {
+                                strcpy(lastloop, &chartag[i][0]);
+                                if (log)
+                                    printf("**** found last loop = %s\n", lastloop);
+                            }
+                        }
+                    }
+                } else if (strcmp(buffer->array, "<?foreach constant_filter_variable?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach constant_filter_variable\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach constant_filter_variable");
+                    strcpy(lastloop, "foreach constant_filter_variable");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    /*lastwrite = write;*/
+
+                    current_variable = * modeldata->p_constant_filter_vars;
+                    if (current_variable == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach functionfiles?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach functionfiles\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach functionfiles");
+                    strcpy(lastloop, "foreach functionfiles");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    /*lastwrite = write;*/
+
+                    current_envfunc = * modeldata->p_envfuncs;
+                    if (current_envfunc == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach allvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach allvar\tpos: %d\n", numtag, looppos[numtag]);
+                    strcpy(&chartag[numtag][0], "foreach allvar");
+                    strcpy(lastloop, "foreach allvar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    /*lastwrite = write;*/
+                    inallvar = 1;
+                    allvar = * modeldata->p_allvars;
+                    if(allvar != NULL) current_datatype = allvar->datatype;
+                } else if (strcmp(buffer->array, "<?foreach envvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach envvar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach envvar");
+                    strcpy(lastloop, "foreach envvar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    /*lastwrite = write;*/
+                    inenvvar = 1;
+                    current_envvar = * modeldata->p_envvars;
+                    if (current_envvar == NULL) {
+                        write = 0;
+                        inenvvar = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach xagent?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach xagent\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach xagent");
+                    strcpy(lastloop, "foreach xagent");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    xagent_count = 0;
+                    /*lastwrite = write;*/
+                    previous_name = NULL;
+
+                    if(current_sync != NULL) {
+                        current_xmachine = current_sync->inputting_agents;
+                    }
+                    /*else if(current_message != NULL)
+                    {
+                    	current_xmachine = current_message->outputting_agents;
+                    }*/
+                    else current_xmachine = * modeldata->p_xmachines;
+
+                    if (current_xmachine == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                    strcpy(lastloop, "foreach xagent");
+                } else if (strcmp(buffer->array, "<?foreach sendingxagent?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach sendingxagent\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach sendingxagent");
+                    strcpy(lastloop, "foreach sendingxagent");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    xagent_count = 0;
+                    /*lastwrite = write;*/
+                    previous_name = NULL;
+
+                    if(current_message != NULL)
+                        current_xmachine = current_message->outputting_agents;
+                    else current_xmachine = NULL;
+
+                    if (current_xmachine == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                    strcpy(lastloop, "foreach sendingxagent");
+                } else if (strcmp(buffer->array, "<?foreach readingxagent?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach readingxagent\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach readingxagent");
+                    strcpy(lastloop, "foreach readingxagent");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    xagent_count = 0;
+                    /*lastwrite = write;*/
+                    previous_name = NULL;
+
+                    if(current_message != NULL)
+                        current_xmachine = current_message->inputting_agents;
+                    else current_xmachine = NULL;
+
+                    if (current_xmachine == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                    strcpy(lastloop, "foreach readingxagent");
+                } else if (strcmp(buffer->array, "<?foreach xagentvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach xagentvar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach xagentvar");
+                    strcpy(lastloop, "foreach xagentvar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    inxagentvar = 1;
+
+                    if(current_xmachine != NULL)
+                        current_variable = current_xmachine->variables;
+                    else current_variable = NULL;
+
+                    if(current_variable != NULL) {
+                        current_datatype = current_variable->datatype;
+                    }
+                    if (current_variable == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach state?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach state\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach state");
+                    strcpy(lastloop, "foreach state");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    if(current_xmachine == NULL) current_state = NULL;
+                    else current_state = current_xmachine->states;
+
+                    if (current_state == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach function_input?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach function_input\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach function_input");
+
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    if(current_function != NULL) current_ioput = current_function->inputs;
+                    else current_ioput = NULL;
+
+                    if(current_sync != NULL) {
+                        while(current_ioput != NULL && strcmp(current_ioput->messagetype, current_sync->message->name) != 0) {
+                            current_ioput = current_ioput->next;
+                        }
+
+                        //printf("filter messagetype = %s\tsync messagetype = %s\n", current_ioput->messagetype, current_sync->message->name);
+                    }
+
+                    strcpy(lastloop, "foreach function_input");
+
+                    if (current_ioput == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach function_output?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach function_output\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach function_output");
+                    strcpy(lastloop, "foreach function_output");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    current_ioput = current_function->outputs;
+                    if (current_ioput == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach complete_sync?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach complete_sync\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach complete_sync");
+                    strcpy(lastloop, "foreach complete_sync");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    current_sync_pointer = current_function->complete_syncs;
+                    if (current_sync_pointer == NULL) write = 0;
+                    else current_sync = current_sync_pointer->current_sync;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach start_sync?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach start_sync\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach start_sync");
+                    strcpy(lastloop, "foreach start_sync");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    if(current_function != NULL) current_sync_pointer = current_function->start_syncs;
+                    else current_sync_pointer = NULL;
+                    if (current_sync_pointer == NULL)
+                        write = 0;
+                    else current_sync = current_sync_pointer->current_sync;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach message?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach message\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach message");
+                    strcpy(lastloop, "foreach message");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    message_count = 0;
+                    /*lastwrite = write;*/
+                    previous_name = NULL;
+
+                    if(current_layer != NULL) current_message = current_layer->finished_messages;
+                    else current_message = * modeldata->p_xmessages;
+
+                    if (current_message == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach messagevar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach messagevar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach messagevar");
+                    strcpy(lastloop, "foreach messagevar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    inmessagevar = 1;
+                    if(current_message != NULL) current_variable = current_message->vars;
+                    else current_variable = NULL;
+                    if(current_variable != NULL) {
+                        current_datatype = current_variable->datatype;
+                    }
+                    if (current_variable == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach sync?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach sync\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach sync");
+                    strcpy(lastloop, "foreach sync");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    if(current_message != NULL) current_sync = current_message->syncs;
+                    else current_sync = NULL;
+                    if(current_sync == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach syncvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach syncvar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach syncvar");
+                    strcpy(lastloop, "foreach syncvar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    if(current_sync != NULL) current_variable = current_sync->vars;
+                    else current_variable = NULL;
+                    if(current_variable == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach paramvar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach paramvar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach paramvar");
+                    strcpy(lastloop, "foreach paramvar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*if(current_message != NULL)
+                    {
+                    	if(current_message->agents != NULL)
+                    	{
+                    		current_xmachine = current_message->agents;
+                    		current_variable = current_xmachine->variables;
+                    	}
+                    }
+                    else*/
+                    current_variable = NULL;
+                    if (current_variable == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach layer?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach layer\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach layer");
+                    strcpy(lastloop, "foreach layer");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    current_layer = * modeldata->p_layers;
+                    if (current_layer == NULL)
+                        write = 0;
+                    else {
+                        current_function_pointer = current_layer->functions;
+                        current_function = current_function_pointer->function;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach function?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach function\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach function");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    if (strcmp(lastloop, "foreach sync") == 0) {
+                        if(current_sync != NULL) {
+                            current_function_pointer = current_sync->inputting_functions;
+                            if (current_function_pointer == NULL) write = 0;
+                            else current_function = current_function_pointer->function;
+                        } else {
+                            current_function_pointer = NULL;
+                            current_function = NULL;
+                            write = 0;
+                        }
+                    } else if (strcmp(lastloop, "foreach layer") == 0) {
+                        //printf("layer: %d -> %p\n", current_layer->number, (void *)current_layer->functions);
+
+                        current_function_pointer = current_layer->functions;
+                        if (current_function_pointer == NULL) write = 0;
+                        else current_function = current_function_pointer->function;
+                    } else if (strcmp(lastloop, "foreach branching_state") == 0) {
+                        //printf("layer: %d -> %p\n", current_layer->number, (void *)current_layer->functions);
+                        if(current_end_state != NULL)
+                            current_function_pointer = current_end_state->state->outgoing_functions;
+                        else current_function_pointer = NULL;
+                        if (current_function_pointer == NULL) write = 0;
+                        else current_function = current_function_pointer->function;
+                    } else if (strcmp(lastloop, "foreach xagent") == 0) {
+                        if(current_xmachine != NULL) {
+                            current_function = current_xmachine->functions;
+                            /*current_ioput = current_function->filter_rule;*/
+                        } else current_function = NULL;
+                        if (current_function == NULL) write = 0;
+                    }
+
+                    strcpy(lastloop, "foreach function");
+
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach enditfunc?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach enditfunc\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach enditfunc");
+                    strcpy(lastloop, "foreach enditfunc");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+
+                    current_code = * modeldata->p_it_end_code;
+                    if (current_code == NULL)
+                        write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach datatype?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach datatype\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach datatype");
+                    strcpy(lastloop, "foreach datatype");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*loopwrite[loopwritepos] = write;
+                    loopwritepos++;*/
+
+                    current_datatype = * modeldata->p_datatypes;
+                    if (current_datatype == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach datatypevar?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach datatypevar\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach datatypevar");
+                    strcpy(lastloop, "foreach datatypevar");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*loopwrite[loopwritepos] = write;
+                    loopwritepos++;*/
+
+                    indatatypevar = 1;
+                    current_datatypevariable = NULL;
+                    if(current_datatype != NULL) current_datatypevariable = current_datatype->vars;
+                    if (current_datatypevariable == NULL) {
+                        write = 0;
+                        indatatypevar = 0;
+                    }
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach timeunit?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach timeunit\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach timeunit");
+                    strcpy(lastloop, "foreach timeunit");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*loopwrite[loopwritepos] = write;
+                    loopwritepos++;*/
+
+                    current_time_unit = * modeldata->p_time_units;
+                    if (current_time_unit == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach endstate?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach endstate\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach endstate");
+                    strcpy(lastloop, "foreach endstate");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*loopwrite[loopwritepos] = write;
+                    loopwritepos++;*/
+
+                    current_end_state = current_xmachine->end_states;
+                    if (current_end_state == NULL) write = 0;
+                    writetag[numtag] = write;
+                } else if (strcmp(buffer->array, "<?foreach branching_state?>") == 0) {
+                    if (log)
+                        printf("start :%d\tforeach branching_state\tpos: %d\n", numtag, pos);
+                    strcpy(&chartag[numtag][0], "foreach branching_state");
+                    strcpy(lastloop, "foreach branching_state");
+                    looppos[numtag] = pos;
+                    numtag++;
+                    var_count = 0;
+                    /*lastwrite = write;*/
+                    /*loopwrite[loopwritepos] = write;
+                    loopwritepos++;*/
+
+                    current_end_state = current_layer->branching_states;
+                    if (current_end_state == NULL) write = 0;
+                    else current_state = current_end_state->state;
+
+                    writetag[numtag] = write;
+                } else {
+                    if(write) fputs("<", file);
+                    pos = pos1;
                 }
-				else if (strcmp(buffer->array, "<?end if?>") == 0)
-				{
-					/* Look at last tag */
-					numtag--;
-					/* If different then exit */
-					if (strcmp("if", &chartag[numtag][0]) != 0)
-					{
-						printf("error with template tag nest\n");
-						printf("tag to close: %s\n", &chartag[numtag][0]);
-						exit(0);
-					}
+                tmplcode = 0;
+                reset_char_array(buffer);
+            } else if (c == '<' || c == '\n') {
+                if(write) fputs("<", file);
+                pos = pos1;
+                tmplcode = 0;
+            } else {
+                add_char(buffer, c);
+            }
+        } else {
+            /* If possible start of template variable */
+            if (c == '$' && write == 1) {
+                reset_char_array(buffer3);
+                pos1 = pos;
 
-					if (log)
-						printf("finish:%d\tif", numtag);
-					/* if corresponds with first if*/
-					if (log)
-						printf("\tnumtag:%d\tlastiftag:%d\twrite:%d\tpos:%d\n", numtag, lastiftag, write, pos);
-					if (numtag == lastiftag)
-					{
-						/*write = 1;
-						lastwrite = 1;*/
-						lastiftag = -1;
-					}
-					write = writetag[numtag];
-				}
-				else if (strcmp(buffer->array, "<?end foreach?>") == 0)
-				{
-					exitforeach = 0;
-					/* Look at last tag */
-					numtag--;
+                while (strcmp(buffer3->array, "$number_messagesplusone") != 0 &&
+                        strcmp(buffer3->array, "$number_xagentsplusone") != 0 &&
+                        strcmp(buffer3->array, "$model_name") != 0 &&
+                        strcmp(buffer3->array, "$xagent_total") != 0 &&
+                        pos <= (pos1 + 24) && pos <= filebuffer->size) {
+                    add_char(buffer3, c);
+                    pos++;
+                    c = filebuffer->array[pos];
+                }
+                pos--;
+                if (strcmp(buffer3->array, "$model_name") == 0) fputs(modeldata->name, file);
+                else if (strcmp(buffer3->array, "$number_messagesplusone") == 0) {
+                    sprintf(data, "%i", modeldata->number_messages + 1);
+                    fputs(data, file);
+                } else if (strcmp(buffer3->array, "$number_xagentsplusone") == 0) {
+                    sprintf(data, "%i", modeldata->number_xmachines + 1);
+                    fputs(data, file);
+                } else if (strcmp(buffer3->array, "$xagent_total") == 0) {
+                    sprintf(data, "%i", modeldata->number_xmachines);
+                    fputs(data, file);
+                } else {
+                    reset_char_array(buffer3);
+                    pos = pos1;
+                    c = '$';
 
-					/* Check for next element in current loop */
-					if (strcmp("foreach constant_filter_variable", &chartag[numtag][0]) == 0)
-					{
-						if (current_variable != NULL)
-							current_variable = current_variable->next;
-						if (current_variable == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-						}
-					}
-					else if (strcmp("foreach functionfiles", &chartag[numtag][0]) == 0)
-					{
-						if (current_envfunc != NULL)
-							current_envfunc = current_envfunc->next;
-						if (current_envfunc == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-						}
-					}
-					else if (strcmp("foreach allvar", &chartag[numtag][0]) == 0)
-					{
-						if (allvar != NULL)
-						{
-							allvar = allvar->next;
-						}
-						if (allvar == NULL)
-						{
-							exitforeach = 1;
-							inallvar = 0;
-						}
-						else
-						{
-							current_datatype = allvar->datatype;
-							pos = looppos[numtag];
-							numtag++;
-						}
-					}
-					else if (strcmp("foreach envvar", &chartag[numtag][0]) == 0)
-					{
-						if (current_envvar != NULL)
-							current_envvar = current_envvar->next;
-						if (current_envvar == NULL)
-						{
-							exitforeach = 1;
-							inenvvar = 0;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-						}
-					}
-					else if (strcmp("foreach xagent", &chartag[numtag][0]) == 0 ||
-							strcmp("foreach readingxagent", &chartag[numtag][0]) == 0 ||
-							strcmp("foreach sendingxagent", &chartag[numtag][0]) == 0)
-					{
-						if (current_xmachine != NULL)
-						{
-							previous_name = current_xmachine->name;
-							current_xmachine = current_xmachine->next;
-						}
-						if (current_xmachine == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							xagent_count++;
-						}
-					}
-					else if (strcmp("foreach xagentvar", &chartag[numtag][0]) == 0)
-					{
-						if (current_variable != NULL)
-						{
-							current_variable = current_variable->next;
-							if(current_variable != NULL) current_datatype = current_variable->datatype;
-						}
-						if (current_variable == NULL)
-						{
-							exitforeach = 1;
-							inxagentvar = 0;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach state", &chartag[numtag][0]) == 0)
-					{
-						if (current_state != NULL)
-						{
-							current_state = current_state->next;
-						}
-						if (current_state == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach message", &chartag[numtag][0]) == 0)
-					{
-						if (current_message != NULL)
-						{
-							previous_name = current_message->name;
-							current_message = current_message->next;
-						}
-						if (current_message == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							message_count++;
-						}
-					}
-					else if (strcmp("foreach messagevar", &chartag[numtag][0]) == 0)
-					{
-						if (current_variable != NULL)
-						{
-							current_variable = current_variable->next;
-							if(current_variable != NULL) current_datatype = current_variable->datatype;
-						}
-						if (current_variable == NULL)
-						{
-							exitforeach = 1;
-							inmessagevar = 0;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach sync", &chartag[numtag][0]) == 0)
-					{
-						if (current_sync != NULL)
-						{
-							current_sync = current_sync->next;
-						}
-						if (current_sync == NULL)
-						{
-							exitforeach = 1;
-							inmessagevar = 0;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach syncvar", &chartag[numtag][0]) == 0)
-					{
-						if (current_variable != NULL)
-						{
-							current_variable = current_variable->next;
-						}
-						if (current_variable == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach paramvar", &chartag[numtag][0]) == 0)
-					{
-						if (current_variable != NULL)
-						{
-							current_variable = current_variable->next;
-						}
-						if (current_variable == NULL)
-						{
-							if(current_xmachine != NULL)
-								current_xmachine = current_xmachine->next;
-							if(current_xmachine != NULL)
-								current_variable = current_xmachine->variables;
-						}
-						if (current_variable == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach layer", &chartag[numtag][0]) == 0)
-					{
-						if (current_layer != NULL)
-							current_layer = current_layer->next;
-						if (current_layer == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-							current_function_pointer = current_layer->functions;
-							current_function = current_function_pointer->function;
-						}
-					}
-					else if (strcmp("foreach function_input", &chartag[numtag][0]) == 0)
-					{
-						if (current_ioput != NULL)
-						{
-							current_ioput = current_ioput->next;
-
-							if(current_sync != NULL)
-							{
-								while(current_ioput != NULL &&
-										strcmp(current_ioput->messagetype, current_sync->message->name) != 0)
-								{
-									current_ioput = current_ioput->next;
-								}
-							}
-						}
-						if (current_ioput == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach function_output", &chartag[numtag][0]) == 0)
-					{
-						if (current_ioput != NULL)
-							current_ioput = current_ioput->next;
-						if (current_ioput == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach complete_sync", &chartag[numtag][0]) == 0)
-					{
-						if (current_sync_pointer != NULL)
-							current_sync_pointer = current_sync_pointer->next;
-						if (current_sync_pointer == NULL)
-						{
-							current_sync = NULL;
-							exitforeach = 1;
-						}
-						else
-						{
-							current_sync = current_sync_pointer->current_sync;
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach start_sync", &chartag[numtag][0]) == 0)
-					{
-						if (current_sync_pointer != NULL)
-							current_sync_pointer = current_sync_pointer->next;
-						if (current_sync_pointer == NULL)
-						{
-							current_sync = NULL;
-							exitforeach = 1;
-						}
-						else
-						{
-							current_sync = current_sync_pointer->current_sync;
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach function", &chartag[numtag][0]) == 0)
-					{
-						if (current_layer != NULL)// || current_sync != NULL)
-						{
-							//if(current_layer != NULL) printf("current_layer: %d\n", current_layer->number);
-
-							if (current_function_pointer != NULL)
-							{
-								//printf("foreach function: %s next: ", current_function_pointer->function->name);
-
-								current_function_pointer = current_function_pointer->next;
-
-								//if (current_function_pointer == NULL) printf("NULL\n");
-								//else printf("%s\n", current_function_pointer->function->name);
-							}
-							if (current_function_pointer == NULL)
-							{
-								//printf("foreach function: NULL\n");
-								current_function = NULL;
-								exitforeach = 1;
-							}
-							else
-							{
-							 	current_function = current_function_pointer->function;
-								pos = looppos[numtag];
-								numtag++;
-								var_count++;
-							}
-						}
-						else
-						{
-							if (current_function != NULL)
-								current_function = current_function->next;
-							if (current_function == NULL)
-								exitforeach = 1;
-							else
-							{
-								pos = looppos[numtag];
-								numtag++;
-								var_count++;
-							}
-						}
-					}
-					else if (strcmp("foreach enditfunc", &chartag[numtag][0]) == 0)
-					{
-						if (current_code != NULL)
-							current_code = current_code->next;
-						if (current_code == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach datatype", &chartag[numtag][0]) == 0)
-					{
-						if (current_datatype != NULL)
-							current_datatype = current_datatype->next;
-						if (current_datatype == NULL)
-							exitforeach = 1;
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach datatypevar", &chartag[numtag][0]) == 0)
-					{
-						if (current_datatypevariable != NULL)
-							current_datatypevariable = current_datatypevariable->next;
-						if (current_datatypevariable == NULL)
-						{
-							exitforeach = 1;
-							indatatypevar = 0;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach timeunit", &chartag[numtag][0]) == 0)
-					{
-						if (current_time_unit != NULL)
-							current_time_unit = current_time_unit->next;
-						if (current_time_unit == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach endstate", &chartag[numtag][0]) == 0)
-					{
-						if (current_end_state != NULL)
-							current_end_state = current_end_state->next;
-						if (current_end_state == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					else if (strcmp("foreach branching_state", &chartag[numtag][0]) == 0)
-					{
-						if (current_end_state != NULL)
-						{
-							current_end_state = current_end_state->next;
-						}
-						if (current_end_state == NULL)
-						{
-							exitforeach = 1;
-						}
-						else
-						{
-							current_state = current_end_state->state;
-							
-							pos = looppos[numtag];
-							numtag++;
-							var_count++;
-						}
-					}
-					/* If different then exit */
-					if (exitforeach)
-					{
-						strcpy(tagbuffer, &chartag[numtag][0]);
-						tagbuffer[7] = '\0';
-						if (strcmp("foreach", tagbuffer) != 0)
-						{
-							printf("error with template tag nest\n");
-							printf("tag to close: %s\n", &chartag[numtag][0]);
-							exit(0);
-						}
-
-						/*if(loopwritepos > 0)
-						{
-							loopwritepos--;
-							write = loopwrite[loopwritepos];
-						}
-						else write = lastwrite;*/
-						write = writetag[numtag];
-
-						/* find last loop in chartag */
-						if (log)
-							printf("**** exit loop = %s\n", lastloop);
-						strcpy(lastloop, "");
-						for (i = 0; i < numtag; i++)
-						{
-							strcpy(tagbuffer, &chartag[i][0]);
-							tagbuffer[7] = '\0';
-							if (strcmp("foreach", tagbuffer) == 0)
-							{
-								strcpy(lastloop, &chartag[i][0]);
-								if (log)
-									printf("**** found last loop = %s\n", lastloop);
-							}
-						}
-					}
-				}
-				else if (strcmp(buffer->array, "<?foreach constant_filter_variable?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach constant_filter_variable\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach constant_filter_variable");
-					strcpy(lastloop, "foreach constant_filter_variable");
-					looppos[numtag] = pos;
-					numtag++;
-					/*lastwrite = write;*/
-
-					current_variable = * modeldata->p_constant_filter_vars;
-					if (current_variable == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach functionfiles?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach functionfiles\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach functionfiles");
-					strcpy(lastloop, "foreach functionfiles");
-					looppos[numtag] = pos;
-					numtag++;
-					/*lastwrite = write;*/
-
-					current_envfunc = * modeldata->p_envfuncs;
-					if (current_envfunc == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach allvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach allvar\tpos: %d\n", numtag, looppos[numtag]);
-					strcpy(&chartag[numtag][0], "foreach allvar");
-					strcpy(lastloop, "foreach allvar");
-					looppos[numtag] = pos;
-					numtag++;
-					/*lastwrite = write;*/
-					inallvar = 1;
-					allvar = * modeldata->p_allvars;
-					if(allvar != NULL) current_datatype = allvar->datatype;
-				}
-				else if (strcmp(buffer->array, "<?foreach envvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach envvar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach envvar");
-					strcpy(lastloop, "foreach envvar");
-					looppos[numtag] = pos;
-					numtag++;
-					/*lastwrite = write;*/
-					inenvvar = 1;
-					current_envvar = * modeldata->p_envvars;
-					if (current_envvar == NULL)
-					{
-						write = 0;
-						inenvvar = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach xagent?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach xagent\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach xagent");
-					strcpy(lastloop, "foreach xagent");
-					looppos[numtag] = pos;
-					numtag++;
-					xagent_count = 0;
-					/*lastwrite = write;*/
-					previous_name = NULL;
-
-					if(current_sync != NULL)
-					{
-						current_xmachine = current_sync->inputting_agents;
-					}
-					/*else if(current_message != NULL)
-					{
-						current_xmachine = current_message->outputting_agents;
-					}*/
-					else current_xmachine = * modeldata->p_xmachines;
-
-					if (current_xmachine == NULL)
-						write = 0;
-					writetag[numtag] = write;
-					strcpy(lastloop, "foreach xagent");
-				}
-				else if (strcmp(buffer->array, "<?foreach sendingxagent?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach sendingxagent\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach sendingxagent");
-					strcpy(lastloop, "foreach sendingxagent");
-					looppos[numtag] = pos;
-					numtag++;
-					xagent_count = 0;
-					/*lastwrite = write;*/
-					previous_name = NULL;
-
-					if(current_message != NULL)
-						current_xmachine = current_message->outputting_agents;
-					else current_xmachine = NULL;
-
-					if (current_xmachine == NULL)
-						write = 0;
-					writetag[numtag] = write;
-					strcpy(lastloop, "foreach sendingxagent");
-				}
-				else if (strcmp(buffer->array, "<?foreach readingxagent?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach readingxagent\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach readingxagent");
-					strcpy(lastloop, "foreach readingxagent");
-					looppos[numtag] = pos;
-					numtag++;
-					xagent_count = 0;
-					/*lastwrite = write;*/
-					previous_name = NULL;
-
-					if(current_message != NULL)
-						current_xmachine = current_message->inputting_agents;
-					else current_xmachine = NULL;
-
-					if (current_xmachine == NULL)
-						write = 0;
-					writetag[numtag] = write;
-					strcpy(lastloop, "foreach readingxagent");
-				}
-				else if (strcmp(buffer->array, "<?foreach xagentvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach xagentvar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach xagentvar");
-					strcpy(lastloop, "foreach xagentvar");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					inxagentvar = 1;
-
-					if(current_xmachine != NULL)
-						current_variable = current_xmachine->variables;
-					else current_variable = NULL;
-
-					if(current_variable != NULL)
-					{
-						current_datatype = current_variable->datatype;
-					}
-					if (current_variable == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach state?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach state\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach state");
-					strcpy(lastloop, "foreach state");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					if(current_xmachine == NULL) current_state = NULL;
-					else current_state = current_xmachine->states;
-
-					if (current_state == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach function_input?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach function_input\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach function_input");
-
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					if(current_function != NULL) current_ioput = current_function->inputs;
-					else current_ioput = NULL;
-
-					if(current_sync != NULL)
-					{
-						while(current_ioput != NULL && strcmp(current_ioput->messagetype, current_sync->message->name) != 0)
-						{
-							current_ioput = current_ioput->next;
-						}
-
-						//printf("filter messagetype = %s\tsync messagetype = %s\n", current_ioput->messagetype, current_sync->message->name);
-					}
-
-					strcpy(lastloop, "foreach function_input");
-
-					if (current_ioput == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach function_output?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach function_output\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach function_output");
-					strcpy(lastloop, "foreach function_output");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					current_ioput = current_function->outputs;
-					if (current_ioput == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach complete_sync?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach complete_sync\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach complete_sync");
-					strcpy(lastloop, "foreach complete_sync");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					current_sync_pointer = current_function->complete_syncs;
-					if (current_sync_pointer == NULL) write = 0;
-					else current_sync = current_sync_pointer->current_sync;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach start_sync?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach start_sync\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach start_sync");
-					strcpy(lastloop, "foreach start_sync");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					if(current_function != NULL) current_sync_pointer = current_function->start_syncs;
-					else current_sync_pointer = NULL;
-					if (current_sync_pointer == NULL)
-						write = 0;
-					else current_sync = current_sync_pointer->current_sync;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach message?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach message\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach message");
-					strcpy(lastloop, "foreach message");
-					looppos[numtag] = pos;
-					numtag++;
-					message_count = 0;
-					/*lastwrite = write;*/
-					previous_name = NULL;
-
-					if(current_layer != NULL) current_message = current_layer->finished_messages;
-					else current_message = * modeldata->p_xmessages;
-					
-					if (current_message == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach messagevar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach messagevar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach messagevar");
-					strcpy(lastloop, "foreach messagevar");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					inmessagevar = 1;
-					if(current_message != NULL) current_variable = current_message->vars;
-					else current_variable = NULL;
-					if(current_variable != NULL)
-					{
-						current_datatype = current_variable->datatype;
-					}
-					if (current_variable == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach sync?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach sync\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach sync");
-					strcpy(lastloop, "foreach sync");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					if(current_message != NULL) current_sync = current_message->syncs;
-					else current_sync = NULL;
-					if(current_sync == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach syncvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach syncvar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach syncvar");
-					strcpy(lastloop, "foreach syncvar");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					if(current_sync != NULL) current_variable = current_sync->vars;
-					else current_variable = NULL;
-					if(current_variable == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach paramvar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach paramvar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach paramvar");
-					strcpy(lastloop, "foreach paramvar");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*if(current_message != NULL)
-					{
-						if(current_message->agents != NULL)
-						{
-							current_xmachine = current_message->agents;
-							current_variable = current_xmachine->variables;
-						}
-					}
-					else*/ current_variable = NULL;
-					if (current_variable == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach layer?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach layer\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach layer");
-					strcpy(lastloop, "foreach layer");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					current_layer = * modeldata->p_layers;
-					if (current_layer == NULL)
-						write = 0;
-					else
-					{
-						current_function_pointer = current_layer->functions;
-						current_function = current_function_pointer->function;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach function?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach function\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach function");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					if (strcmp(lastloop, "foreach sync") == 0)
-					{
-						if(current_sync != NULL)
-						{
-							current_function_pointer = current_sync->inputting_functions;
-							if (current_function_pointer == NULL) write = 0;
-							else current_function = current_function_pointer->function;
-						}
-						else
-						{
-							current_function_pointer = NULL;
-							current_function = NULL;
-							write = 0;
-						}
-					}
-					else if (strcmp(lastloop, "foreach layer") == 0)
-					{
-						//printf("layer: %d -> %p\n", current_layer->number, (void *)current_layer->functions);
-
-						current_function_pointer = current_layer->functions;
-						if (current_function_pointer == NULL) write = 0;
-						else current_function = current_function_pointer->function;
-					}
-					else if (strcmp(lastloop, "foreach branching_state") == 0)
-					{
-						//printf("layer: %d -> %p\n", current_layer->number, (void *)current_layer->functions);
-						if(current_end_state != NULL)
-						current_function_pointer = current_end_state->state->outgoing_functions;
-						else current_function_pointer = NULL;
-						if (current_function_pointer == NULL) write = 0;
-						else current_function = current_function_pointer->function;
-					}
-					else if (strcmp(lastloop, "foreach xagent") == 0)
-					{
-						if(current_xmachine != NULL)
-						{
-							current_function = current_xmachine->functions;
-							/*current_ioput = current_function->filter_rule;*/
-						}
-						else current_function = NULL;
-						if (current_function == NULL) write = 0;
-					}
-
-					strcpy(lastloop, "foreach function");
-					
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach enditfunc?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach enditfunc\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach enditfunc");
-					strcpy(lastloop, "foreach enditfunc");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-
-					current_code = * modeldata->p_it_end_code;
-					if (current_code == NULL)
-						write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach datatype?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach datatype\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach datatype");
-					strcpy(lastloop, "foreach datatype");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*loopwrite[loopwritepos] = write;
-					loopwritepos++;*/
-
-					current_datatype = * modeldata->p_datatypes;
-					if (current_datatype == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach datatypevar?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach datatypevar\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach datatypevar");
-					strcpy(lastloop, "foreach datatypevar");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*loopwrite[loopwritepos] = write;
-					loopwritepos++;*/
-
-					indatatypevar = 1;
-					current_datatypevariable = NULL;
-					if(current_datatype != NULL) current_datatypevariable = current_datatype->vars;
-					if (current_datatypevariable == NULL)
-					{
-						write = 0;
-						indatatypevar = 0;
-					}
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach timeunit?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach timeunit\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach timeunit");
-					strcpy(lastloop, "foreach timeunit");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*loopwrite[loopwritepos] = write;
-					loopwritepos++;*/
-
-					current_time_unit = * modeldata->p_time_units;
-					if (current_time_unit == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach endstate?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach endstate\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach endstate");
-					strcpy(lastloop, "foreach endstate");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*loopwrite[loopwritepos] = write;
-					loopwritepos++;*/
-
-					current_end_state = current_xmachine->end_states;
-					if (current_end_state == NULL) write = 0;
-					writetag[numtag] = write;
-				}
-				else if (strcmp(buffer->array, "<?foreach branching_state?>") == 0)
-				{
-					if (log)
-						printf("start :%d\tforeach branching_state\tpos: %d\n", numtag, pos);
-					strcpy(&chartag[numtag][0], "foreach branching_state");
-					strcpy(lastloop, "foreach branching_state");
-					looppos[numtag] = pos;
-					numtag++;
-					var_count = 0;
-					/*lastwrite = write;*/
-					/*loopwrite[loopwritepos] = write;
-					loopwritepos++;*/
-
-					current_end_state = current_layer->branching_states;
-					if (current_end_state == NULL) write = 0;
-					else current_state = current_end_state->state;
-						
-					writetag[numtag] = write;
-				}
-				else
-				{
-					if(write) fputs("<", file);
-					pos = pos1;
-				}
-				tmplcode = 0;
-				reset_char_array(buffer);
-			}
-			else if (c == '<' || c == '\n')
-			{
-				if(write) fputs("<", file);
-				pos = pos1;
-				tmplcode = 0;
-			}
-			else
-			{
-				add_char(buffer, c);
-			}
-		}
-		else
-		{
-			/* If possible start of template variable */
-			if (c == '$' && write == 1)
-			{
-				reset_char_array(buffer3);
-				pos1 = pos;
-
-				while (strcmp(buffer3->array, "$number_messagesplusone") != 0 &&
-					strcmp(buffer3->array, "$number_xagentsplusone") != 0 &&
-					strcmp(buffer3->array, "$model_name") != 0 &&
-					strcmp(buffer3->array, "$xagent_total") != 0 &&
-					pos <= (pos1 + 24) && pos <= filebuffer->size)
-				{
-					add_char(buffer3, c);
-					pos++;
-					c = filebuffer->array[pos];
-				}
-				pos--;
-				if (strcmp(buffer3->array, "$model_name") == 0) fputs(modeldata->name, file);
-				else if (strcmp(buffer3->array, "$number_messagesplusone") == 0)
-				{
-					sprintf(data, "%i", modeldata->number_messages + 1);
-					fputs(data, file);
-				}
-				else if (strcmp(buffer3->array, "$number_xagentsplusone") == 0)
-				{
-					sprintf(data, "%i", modeldata->number_xmachines + 1);
-					fputs(data, file);
-				}
-				else if (strcmp(buffer3->array, "$xagent_total") == 0)
-				{
-					sprintf(data, "%i", modeldata->number_xmachines);
-					fputs(data, file);
-				}
-				else
-				{
-					reset_char_array(buffer3);
-					pos = pos1;
-					c = '$';
-
-					if (strcmp("foreach constant_filter_variable", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 &&
-								strcmp(buffer3->array, "$agent_name") != 0 &&
-								strcmp(buffer3->array, "$agent_start") != 0 &&
-								pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_variable->name, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_variable->agent->name, file);
-						else if (strcmp(buffer3->array, "$agent_start") == 0)
-							fputs(current_variable->agent->start_state->name, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach allvar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(allvar->name, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(allvar->type, file);
-						else if (strcmp(buffer3->array, "$arraylength") == 0)
-						{
-							sprintf(data, "%i", allvar->arraylength);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$default_value") == 0)
-							fputs(allvar->defaultvalue, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(allvar->c_type, file);
-						else if (strcmp(buffer3->array, "$notarraytype") == 0)
-							fputs(allvar->typenotarray, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach envvar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$uc_name") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$c_type") != 0 && pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_envvar->name, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_envvar->type, file);
-						else if (strcmp(buffer3->array, "$uc_name") == 0)
-						{
-							strcpy(data, current_envvar->name);
-							for(i = 0; i < (int)strlen(data); i++) data[i] = (data[i] >= 'a' && data[i] <= 'z')?('A' + data[i] -'a'):data[i];
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$default_value") == 0)
-							fputs(current_envvar->defaultvalue, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(current_envvar->c_type, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach functionfiles", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$filepath") != 0 && pos <= (pos1 + 9))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$filepath") == 0)
-							fputs(current_envfunc->filepath, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach xagent", lastloop) == 0 ||
-							strcmp("foreach sendingxagent", lastloop) == 0 ||
-							strcmp("foreach readingxagent", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 &&
-								strcmp(buffer3->array, "$rangevar") != 0 &&
-								strcmp(buffer3->array, "$idvar") != 0 &&
-								strcmp(buffer3->array, "$xvar") != 0 &&
-								strcmp(buffer3->array, "$yvar") != 0 &&
-								strcmp(buffer3->array, "$zvar") != 0 &&
-								strcmp(buffer3->array, "$var_number") != 0 &&
-								strcmp(buffer3->array, "$allvar_name") != 0 &&
-								strcmp(buffer3->array, "$xagentcountplusone") != 0 &&
-								strcmp(buffer3->array, "$xagent_count") != 0 &&
-								strcmp(buffer3->array, "$previous_name") != 0 &&
-								strcmp(buffer3->array, "$start_state") != 0 &&
-								strcmp(buffer3->array, "$message_name") != 0 &&
-								strcmp(buffer3->array, "$layer") != 0 &&
-								pos <= (pos1 + 22))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_xmachine->name, file);
-						else if (strcmp(buffer3->array, "$rangevar") == 0)
-							fputs(current_xmachine->rangevar, file);
-						else if (strcmp(buffer3->array, "$idvar") == 0)
-							fputs(current_xmachine->idvar, file);
-						else if (strcmp(buffer3->array, "$xvar") == 0)
-							fputs(current_xmachine->xvar, file);
-						else if (strcmp(buffer3->array, "$yvar") == 0)
-							fputs(current_xmachine->yvar, file);
-						else if (strcmp(buffer3->array, "$zvar") == 0)
-							fputs(current_xmachine->zvar, file);
-						else if (strcmp(buffer3->array, "$allvar_name") == 0)
-							fputs(allvar->name, file);
-						else if (strcmp(buffer3->array, "$start_state") == 0)
-							fputs(current_xmachine->start_state->name, file);
-						else if (strcmp(buffer3->array, "$var_number") == 0)
-						{
-							sprintf(data, "%i", current_xmachine->var_number);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$xagentcountplusone") == 0)
-						{
-							sprintf(data, "%i", xagent_count + 1);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$xagent_count") == 0)
-						{
-							sprintf(data, "%i", xagent_count);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$previous_name") == 0)
-						{
-							if(previous_name != NULL)
-							{
-								sprintf(data, "%s", previous_name);
-								fputs(data, file);
-							}
-						}
-						else if (strcmp(buffer3->array, "$message_name") == 0)
-							fputs(current_message->name, file);
-						else if (strcmp(buffer3->array, "$layer") == 0)
-						{
-							if(current_sync->inputting_functions == NULL) fputs("unknown", file);
-							else
-							{
-								sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
-								fputs(data, file);
-							}
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach xagentvar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && strcmp(buffer3->array, "$default_value") != 0 && pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_variable->name, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_variable->type, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_xmachine->name, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(current_variable->c_type, file);
-						else if (strcmp(buffer3->array, "$mpi_type") == 0)
-							fputs(current_variable->mpi_type, file);
-						else if (strcmp(buffer3->array, "$arraylength") == 0)
-						{
-							sprintf(data, "%i", current_variable->arraylength);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$var_count") == 0)
-						{
-							sprintf(data, "%i", var_count);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$notarraytype") == 0)
-							fputs(current_variable->typenotarray, file);
-						else if (strcmp(buffer3->array, "$default_value") == 0)
-							fputs(current_variable->defaultvalue, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach state", lastloop) == 0 ||
-							strcmp("foreach branching_state", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 &&
-								strcmp(buffer3->array, "$agent_name") != 0 &&
-								strcmp(buffer3->array, "$agent_start") != 0 &&
-								strcmp(buffer3->array, "$xagent_count") != 0 &&
-								pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_state->name, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_state->agent_name, file);
-						else if (strcmp(buffer3->array, "$agent_start") == 0)
-							fputs(current_xmachine->start_state->name, file);
-						else if (strcmp(buffer3->array, "$xagent_count") == 0)
-						{
-							sprintf(data, "%i", xagent_count);
-							fputs(data, file);
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach endstate", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$agent_start") != 0 && pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_end_state->state->name, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_xmachine->name, file);
-						else if (strcmp(buffer3->array, "$agent_start") == 0)
-							fputs(current_xmachine->start_state->name, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach function_input", lastloop) == 0 ||
-							strcmp("foreach function_output", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$agent_name") != 0 &&
-								strcmp(buffer3->array, "$filter") != 0 && strcmp(buffer3->array, "$rule") != 0 &&
-								strcmp(buffer3->array, "$sort") != 0 &&
-								strcmp(buffer3->array, "$box") != 0 &&
-								strcmp(buffer3->array, "$key") != 0 && pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_ioput->messagetype, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_function->agent_name, file);
-						else if (strcmp(buffer3->array, "$filter") == 0)
-							fputs(current_ioput->filter_function, file);
-						else if (strcmp(buffer3->array, "$sort") == 0)
-							fputs(current_ioput->sort_function, file);
-						else if (strcmp(buffer3->array, "$key") == 0)
-							fputs(current_ioput->sort_key, file);
-						else if (strcmp(buffer3->array, "$box") == 0)
+                    if (strcmp("foreach constant_filter_variable", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 &&
+                                strcmp(buffer3->array, "$agent_name") != 0 &&
+                                strcmp(buffer3->array, "$agent_start") != 0 &&
+                                pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_variable->name, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_variable->agent->name, file);
+                        else if (strcmp(buffer3->array, "$agent_start") == 0)
+                            fputs(current_variable->agent->start_state->name, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach allvar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(allvar->name, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(allvar->type, file);
+                        else if (strcmp(buffer3->array, "$arraylength") == 0) {
+                            sprintf(data, "%i", allvar->arraylength);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$default_value") == 0)
+                            fputs(allvar->defaultvalue, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(allvar->c_type, file);
+                        else if (strcmp(buffer3->array, "$notarraytype") == 0)
+                            fputs(allvar->typenotarray, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach envvar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$uc_name") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$c_type") != 0 && pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_envvar->name, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_envvar->type, file);
+                        else if (strcmp(buffer3->array, "$uc_name") == 0) {
+                            strcpy(data, current_envvar->name);
+                            for(i = 0; i < (int)strlen(data); i++) data[i] = (data[i] >= 'a' && data[i] <= 'z')?('A' + data[i] -'a'):data[i];
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$default_value") == 0)
+                            fputs(current_envvar->defaultvalue, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(current_envvar->c_type, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach functionfiles", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$filepath") != 0 && pos <= (pos1 + 9)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$filepath") == 0)
+                            fputs(current_envfunc->filepath, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach xagent", lastloop) == 0 ||
+                               strcmp("foreach sendingxagent", lastloop) == 0 ||
+                               strcmp("foreach readingxagent", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 &&
+                                strcmp(buffer3->array, "$rangevar") != 0 &&
+                                strcmp(buffer3->array, "$idvar") != 0 &&
+                                strcmp(buffer3->array, "$xvar") != 0 &&
+                                strcmp(buffer3->array, "$yvar") != 0 &&
+                                strcmp(buffer3->array, "$zvar") != 0 &&
+                                strcmp(buffer3->array, "$var_number") != 0 &&
+                                strcmp(buffer3->array, "$allvar_name") != 0 &&
+                                strcmp(buffer3->array, "$xagentcountplusone") != 0 &&
+                                strcmp(buffer3->array, "$xagent_count") != 0 &&
+                                strcmp(buffer3->array, "$previous_name") != 0 &&
+                                strcmp(buffer3->array, "$start_state") != 0 &&
+                                strcmp(buffer3->array, "$message_name") != 0 &&
+                                strcmp(buffer3->array, "$layer") != 0 &&
+                                pos <= (pos1 + 22)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_xmachine->name, file);
+                        else if (strcmp(buffer3->array, "$rangevar") == 0)
+                            fputs(current_xmachine->rangevar, file);
+                        else if (strcmp(buffer3->array, "$idvar") == 0)
+                            fputs(current_xmachine->idvar, file);
+                        else if (strcmp(buffer3->array, "$xvar") == 0)
+                            fputs(current_xmachine->xvar, file);
+                        else if (strcmp(buffer3->array, "$yvar") == 0)
+                            fputs(current_xmachine->yvar, file);
+                        else if (strcmp(buffer3->array, "$zvar") == 0)
+                            fputs(current_xmachine->zvar, file);
+                        else if (strcmp(buffer3->array, "$allvar_name") == 0)
+                            fputs(allvar->name, file);
+                        else if (strcmp(buffer3->array, "$start_state") == 0)
+                            fputs(current_xmachine->start_state->name, file);
+                        else if (strcmp(buffer3->array, "$var_number") == 0) {
+                            sprintf(data, "%i", current_xmachine->var_number);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$xagentcountplusone") == 0) {
+                            sprintf(data, "%i", xagent_count + 1);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$xagent_count") == 0) {
+                            sprintf(data, "%i", xagent_count);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$previous_name") == 0) {
+                            if(previous_name != NULL) {
+                                sprintf(data, "%s", previous_name);
+                                fputs(data, file);
+                            }
+                        } else if (strcmp(buffer3->array, "$message_name") == 0)
+                            fputs(current_message->name, file);
+                        else if (strcmp(buffer3->array, "$layer") == 0) {
+                            if(current_sync->inputting_functions == NULL) fputs("unknown", file);
+                            else {
+                                sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
+                                fputs(data, file);
+                            }
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach xagentvar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && strcmp(buffer3->array, "$default_value") != 0 && pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_variable->name, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_variable->type, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_xmachine->name, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(current_variable->c_type, file);
+                        else if (strcmp(buffer3->array, "$mpi_type") == 0)
+                            fputs(current_variable->mpi_type, file);
+                        else if (strcmp(buffer3->array, "$arraylength") == 0) {
+                            sprintf(data, "%i", current_variable->arraylength);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$var_count") == 0) {
+                            sprintf(data, "%i", var_count);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$notarraytype") == 0)
+                            fputs(current_variable->typenotarray, file);
+                        else if (strcmp(buffer3->array, "$default_value") == 0)
+                            fputs(current_variable->defaultvalue, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach state", lastloop) == 0 ||
+                               strcmp("foreach branching_state", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 &&
+                                strcmp(buffer3->array, "$agent_name") != 0 &&
+                                strcmp(buffer3->array, "$agent_start") != 0 &&
+                                strcmp(buffer3->array, "$xagent_count") != 0 &&
+                                pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_state->name, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_state->agent_name, file);
+                        else if (strcmp(buffer3->array, "$agent_start") == 0)
+                            fputs(current_xmachine->start_state->name, file);
+                        else if (strcmp(buffer3->array, "$xagent_count") == 0) {
+                            sprintf(data, "%i", xagent_count);
+                            fputs(data, file);
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach endstate", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$agent_start") != 0 && pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_end_state->state->name, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_xmachine->name, file);
+                        else if (strcmp(buffer3->array, "$agent_start") == 0)
+                            fputs(current_xmachine->start_state->name, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach function_input", lastloop) == 0 ||
+                               strcmp("foreach function_output", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$agent_name") != 0 &&
+                                strcmp(buffer3->array, "$filter") != 0 && strcmp(buffer3->array, "$rule") != 0 &&
+                                strcmp(buffer3->array, "$sort") != 0 &&
+                                strcmp(buffer3->array, "$box") != 0 &&
+                                strcmp(buffer3->array, "$key") != 0 && pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_ioput->messagetype, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_function->agent_name, file);
+                        else if (strcmp(buffer3->array, "$filter") == 0)
+                            fputs(current_ioput->filter_function, file);
+                        else if (strcmp(buffer3->array, "$sort") == 0)
+                            fputs(current_ioput->sort_function, file);
+                        else if (strcmp(buffer3->array, "$key") == 0)
+                            fputs(current_ioput->sort_key, file);
+                        else if (strcmp(buffer3->array, "$box") == 0)
                             fputs(current_ioput->box_apothem, file);
-						else if (strcmp(buffer3->array, "$rule") == 0)
-							writeRule(current_ioput->filter_rule, file, 0);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach start_sync", lastloop) == 0 ||
-							strcmp("foreach complete_sync", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$message_name") != 0 &&
-								strcmp(buffer3->array, "$filter_name") != 0 &&
-								pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$message_name") == 0)
-							fputs(current_sync->message->name, file);
-						else if (strcmp(buffer3->array, "$filter_name") == 0)
-							fputs(current_sync->name, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach message", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$var_number") != 0 && strcmp(buffer3->array, "$message_countplusone") != 0 && strcmp(buffer3->array, "$previous_name") != 0 && strcmp(buffer3->array, "$capsname") != 0 && pos <= (pos1 + 22))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_message->name, file);
-						else if (strcmp(buffer3->array, "$capsname") == 0)
-						{
-							strcpy(data, current_message->name);
-							for(i = 0; i < (int)strlen(data); i++) data[i] = (data[i] >= 'a' && data[i] <= 'z')?('A' + data[i] -'a'):data[i];
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$var_number") == 0)
-						{
-							sprintf(data, "%i", current_message->var_number);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$message_countplusone") == 0)
-						{
-							sprintf(data, "%i", message_count + 1);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$previous_name") == 0)
-						{
-							if(previous_name != NULL)
-							{
-								sprintf(data, "%s", previous_name);
-								fputs(data, file);
-							}
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach messagevar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$messagename") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_variable->name, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_variable->type, file);
-						else if (strcmp(buffer3->array, "$messagename") == 0)
-							fputs(current_message->name, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(current_variable->c_type, file);
-						else if (strcmp(buffer3->array, "$mpi_type") == 0)
-							fputs(current_variable->mpi_type, file);
-						else if (strcmp(buffer3->array, "$arraylength") == 0)
-						{
-							sprintf(data, "%i", current_variable->arraylength);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$var_count") == 0)
-						{
-							sprintf(data, "%i", var_count);
-							fputs(data, file);
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach sync", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 &&
-								strcmp(buffer3->array, "$messagename") != 0 &&
-								strcmp(buffer3->array, "$layer") != 0 &&
-								strcmp(buffer3->array, "$filteragentcount") != 0 &&
-								pos <= (pos1 + 20))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_sync->name, file);
-						else if (strcmp(buffer3->array, "$messagename") == 0)
-							fputs(current_sync->message->name, file);
-						else if (strcmp(buffer3->array, "$layer") == 0)
-						{
-							if(current_sync->inputting_functions == NULL) fputs("unknown", file);
-							else
-							{
-								sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
-								fputs(data, file);
-							}
-						}
-						else if (strcmp(buffer3->array, "$filteragentcount") == 0)
-						{
-							sprintf(data, "%i", current_sync->filter_agent_count);
-							fputs(data, file);
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach syncvar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$type") != 0 &&
-								pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_variable->type, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach paramvar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0
-								&& strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$c_type") != 0 && pos <= (pos1 + 14))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_variable->name, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_variable->type, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_variable->agent->name, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(current_variable->c_type, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach function", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$note") != 0 && strcmp(buffer3->array, "$agent_name") != 0 &&
-						strcmp(buffer3->array, "$current_state") != 0 && strcmp(buffer3->array, "$next_state") != 0 && strcmp(buffer3->array, "$condition") != 0 &&
-						strcmp(buffer3->array, "$message_name") != 0 &&
-						strcmp(buffer3->array, "$layer") != 0 &&
-						strcmp(buffer3->array, "$filter_rule") != 0 &&
-						strcmp(buffer3->array, "$rule") != 0 && pos <= (pos1 + 15))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_function->name, file);
-						else if (strcmp(buffer3->array, "$note") == 0)
-							fputs(current_function->note, file);
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_function->agent_name, file);
-						else if (strcmp(buffer3->array, "$current_state") == 0)
-							fputs(current_function->current_state, file);
-						else if (strcmp(buffer3->array, "$next_state") == 0)
-							fputs(current_function->next_state, file);
-						else if (strcmp(buffer3->array, "$condition") == 0)
-						{
-							if(current_function->condition_function == NULL) fputs("1", file);
-							else fputs(current_function->condition_function, file);
-						}
-						else if (strcmp(buffer3->array, "$rule") == 0)
-						{
-							writeRule(current_function->condition_rule, file, 0);
-						}
-						else if (strcmp(buffer3->array, "$message_name") == 0)
-							fputs(current_message->name, file);
-						else if (strcmp(buffer3->array, "$layer") == 0)
-						{
-							if(current_sync->inputting_functions == NULL) fputs("unknown", file);
-							else
-							{
-								sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
-								fputs(data, file);
-							}
-						}
-						else if (strcmp(buffer3->array, "$filter_rule") == 0)
-						{
-							/* Rule for libmboard syncs */
-							writeRule(current_function->filter_rule, file, 1);
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach enditfunc", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$code") != 0 && pos <= (pos1 + 5))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$code") == 0)
-							fputs(current_code->code, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach timeunit", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$unit_name") != 0 && strcmp(buffer3->array, "$period") != 0 && pos <= (pos1 + 11))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_time_unit->name, file);
-						else if (strcmp(buffer3->array, "$unit_name") == 0)
-						{
-							if(current_time_unit->unit == NULL) fputs("ITERATION", file);
-							else fputs(current_time_unit->unit->name, file);
-						}
-						else if (strcmp(buffer3->array, "$period") == 0)
-						{
-							if(current_time_unit->unit != NULL)
-							{
-								sprintf(data, "%i", current_time_unit->period * current_time_unit->unit->period);
-								fputs(data, file);
-							}
-							else fputs("ITERATION", file);
-						}
-					}
-					else if (strcmp("foreach datatype", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$desc") != 0 && pos <= (pos1 + 5))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_datatype->name, file);
-						else if (strcmp(buffer3->array, "$desc") == 0)
-							if(current_datatype->desc != NULL) fputs(current_datatype->desc, file);
-					}
-					else if (strcmp("foreach datatypevar", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$messagename") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && strcmp(buffer3->array, "$datatypevarname") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && pos <= (pos1 + 16))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$name") == 0)
-							fputs(current_datatypevariable->name, file);
-						else if (strcmp(buffer3->array, "$datatypevarname") == 0)
-						{
-							if(inallvar) fputs(allvar->name, file);
-							if(inxagentvar) fputs(current_variable->name, file);
-						}
-						else if (strcmp(buffer3->array, "$agent_name") == 0)
-							fputs(current_xmachine->name, file);
-						else if (strcmp(buffer3->array, "$default_value") == 0)
-							fputs(current_datatypevariable->defaultvalue, file);
-						else if (strcmp(buffer3->array, "$type") == 0)
-							fputs(current_datatypevariable->type, file);
-						else if (strcmp(buffer3->array, "$messagename") == 0)
-							fputs(current_datatypevariable->name, file);
-						else if (strcmp(buffer3->array, "$c_type") == 0)
-							fputs(current_datatypevariable->c_type, file);
-						else if (strcmp(buffer3->array, "$mpi_type") == 0)
-							fputs(current_datatypevariable->mpi_type, file);
-						else if (strcmp(buffer3->array, "$arraylength") == 0)
-						{
-							sprintf(data, "%i", current_datatypevariable->arraylength);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$var_count") == 0)
-						{
-							sprintf(data, "%i", var_count);
-							fputs(data, file);
-						}
-						else if (strcmp(buffer3->array, "$notarraytype") == 0)
-							fputs(current_datatypevariable->typenotarray, file);
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if (strcmp("foreach layer", lastloop) == 0)
-					{
-						while (strcmp(buffer3->array, "$number") != 0 && pos <= (pos1 + 16))
-						{
-							add_char(buffer3, c);
-							pos++;
-							c = filebuffer->array[pos];
-						}
-						pos--;
-						if (strcmp(buffer3->array, "$number") == 0)
-						{
-							sprintf(data, "%i", current_layer->number);
-							fputs(data, file);
-						}
-						else
-						{
-							fputs("$", file);
-							pos = pos1;
-						}
-					}
-					else if(write) fputc(c, file);
-				}
-			}
-			else if (c == '<')
-			{
-				tmplcode = 1;
-				reset_char_array(buffer);
-				add_char(buffer, '<');
-				pos1 = pos;
-			}
-			else if (write)
-				fputc(c, file);
-		}
+                        else if (strcmp(buffer3->array, "$rule") == 0)
+                            writeRule(current_ioput->filter_rule, file, 0);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach start_sync", lastloop) == 0 ||
+                               strcmp("foreach complete_sync", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$message_name") != 0 &&
+                                strcmp(buffer3->array, "$filter_name") != 0 &&
+                                pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$message_name") == 0)
+                            fputs(current_sync->message->name, file);
+                        else if (strcmp(buffer3->array, "$filter_name") == 0)
+                            fputs(current_sync->name, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach message", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$var_number") != 0 && strcmp(buffer3->array, "$message_countplusone") != 0 && strcmp(buffer3->array, "$previous_name") != 0 && strcmp(buffer3->array, "$capsname") != 0 && pos <= (pos1 + 22)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_message->name, file);
+                        else if (strcmp(buffer3->array, "$capsname") == 0) {
+                            strcpy(data, current_message->name);
+                            for(i = 0; i < (int)strlen(data); i++) data[i] = (data[i] >= 'a' && data[i] <= 'z')?('A' + data[i] -'a'):data[i];
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$var_number") == 0) {
+                            sprintf(data, "%i", current_message->var_number);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$message_countplusone") == 0) {
+                            sprintf(data, "%i", message_count + 1);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$previous_name") == 0) {
+                            if(previous_name != NULL) {
+                                sprintf(data, "%s", previous_name);
+                                fputs(data, file);
+                            }
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach messagevar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$messagename") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_variable->name, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_variable->type, file);
+                        else if (strcmp(buffer3->array, "$messagename") == 0)
+                            fputs(current_message->name, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(current_variable->c_type, file);
+                        else if (strcmp(buffer3->array, "$mpi_type") == 0)
+                            fputs(current_variable->mpi_type, file);
+                        else if (strcmp(buffer3->array, "$arraylength") == 0) {
+                            sprintf(data, "%i", current_variable->arraylength);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$var_count") == 0) {
+                            sprintf(data, "%i", var_count);
+                            fputs(data, file);
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach sync", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 &&
+                                strcmp(buffer3->array, "$messagename") != 0 &&
+                                strcmp(buffer3->array, "$layer") != 0 &&
+                                strcmp(buffer3->array, "$filteragentcount") != 0 &&
+                                pos <= (pos1 + 20)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_sync->name, file);
+                        else if (strcmp(buffer3->array, "$messagename") == 0)
+                            fputs(current_sync->message->name, file);
+                        else if (strcmp(buffer3->array, "$layer") == 0) {
+                            if(current_sync->inputting_functions == NULL) fputs("unknown", file);
+                            else {
+                                sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
+                                fputs(data, file);
+                            }
+                        } else if (strcmp(buffer3->array, "$filteragentcount") == 0) {
+                            sprintf(data, "%i", current_sync->filter_agent_count);
+                            fputs(data, file);
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach syncvar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$type") != 0 &&
+                                pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_variable->type, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach paramvar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0
+                                && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$c_type") != 0 && pos <= (pos1 + 14)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_variable->name, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_variable->type, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_variable->agent->name, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(current_variable->c_type, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach function", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$note") != 0 && strcmp(buffer3->array, "$agent_name") != 0 &&
+                                strcmp(buffer3->array, "$current_state") != 0 && strcmp(buffer3->array, "$next_state") != 0 && strcmp(buffer3->array, "$condition") != 0 &&
+                                strcmp(buffer3->array, "$message_name") != 0 &&
+                                strcmp(buffer3->array, "$layer") != 0 &&
+                                strcmp(buffer3->array, "$filter_rule") != 0 &&
+                                strcmp(buffer3->array, "$rule") != 0 && pos <= (pos1 + 15)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_function->name, file);
+                        else if (strcmp(buffer3->array, "$note") == 0)
+                            fputs(current_function->note, file);
+                        else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_function->agent_name, file);
+                        else if (strcmp(buffer3->array, "$current_state") == 0)
+                            fputs(current_function->current_state, file);
+                        else if (strcmp(buffer3->array, "$next_state") == 0)
+                            fputs(current_function->next_state, file);
+                        else if (strcmp(buffer3->array, "$condition") == 0) {
+                            if(current_function->condition_function == NULL) fputs("1", file);
+                            else fputs(current_function->condition_function, file);
+                        } else if (strcmp(buffer3->array, "$rule") == 0) {
+                            writeRule(current_function->condition_rule, file, 0);
+                        } else if (strcmp(buffer3->array, "$message_name") == 0)
+                            fputs(current_message->name, file);
+                        else if (strcmp(buffer3->array, "$layer") == 0) {
+                            if(current_sync->inputting_functions == NULL) fputs("unknown", file);
+                            else {
+                                sprintf(data, "%i", current_sync->inputting_functions->function->rank_in);
+                                fputs(data, file);
+                            }
+                        } else if (strcmp(buffer3->array, "$filter_rule") == 0) {
+                            /* Rule for libmboard syncs */
+                            writeRule(current_function->filter_rule, file, 1);
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach enditfunc", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$code") != 0 && pos <= (pos1 + 5)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$code") == 0)
+                            fputs(current_code->code, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach timeunit", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$unit_name") != 0 && strcmp(buffer3->array, "$period") != 0 && pos <= (pos1 + 11)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_time_unit->name, file);
+                        else if (strcmp(buffer3->array, "$unit_name") == 0) {
+                            if(current_time_unit->unit == NULL) fputs("ITERATION", file);
+                            else fputs(current_time_unit->unit->name, file);
+                        } else if (strcmp(buffer3->array, "$period") == 0) {
+                            if(current_time_unit->unit != NULL) {
+                                sprintf(data, "%i", current_time_unit->period * current_time_unit->unit->period);
+                                fputs(data, file);
+                            } else fputs("ITERATION", file);
+                        }
+                    } else if (strcmp("foreach datatype", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$desc") != 0 && pos <= (pos1 + 5)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_datatype->name, file);
+                        else if (strcmp(buffer3->array, "$desc") == 0)
+                            if(current_datatype->desc != NULL) fputs(current_datatype->desc, file);
+                    } else if (strcmp("foreach datatypevar", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$name") != 0 && strcmp(buffer3->array, "$type") != 0 && strcmp(buffer3->array, "$messagename") != 0 && strcmp(buffer3->array, "$c_type") != 0 && strcmp(buffer3->array, "$mpi_type") != 0 && strcmp(buffer3->array, "$arraylength") != 0 && strcmp(buffer3->array, "$var_count") != 0 && strcmp(buffer3->array, "$datatypevarname") != 0 && strcmp(buffer3->array, "$default_value") != 0 && strcmp(buffer3->array, "$agent_name") != 0 && strcmp(buffer3->array, "$notarraytype") != 0 && pos <= (pos1 + 16)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$name") == 0)
+                            fputs(current_datatypevariable->name, file);
+                        else if (strcmp(buffer3->array, "$datatypevarname") == 0) {
+                            if(inallvar) fputs(allvar->name, file);
+                            if(inxagentvar) fputs(current_variable->name, file);
+                        } else if (strcmp(buffer3->array, "$agent_name") == 0)
+                            fputs(current_xmachine->name, file);
+                        else if (strcmp(buffer3->array, "$default_value") == 0)
+                            fputs(current_datatypevariable->defaultvalue, file);
+                        else if (strcmp(buffer3->array, "$type") == 0)
+                            fputs(current_datatypevariable->type, file);
+                        else if (strcmp(buffer3->array, "$messagename") == 0)
+                            fputs(current_datatypevariable->name, file);
+                        else if (strcmp(buffer3->array, "$c_type") == 0)
+                            fputs(current_datatypevariable->c_type, file);
+                        else if (strcmp(buffer3->array, "$mpi_type") == 0)
+                            fputs(current_datatypevariable->mpi_type, file);
+                        else if (strcmp(buffer3->array, "$arraylength") == 0) {
+                            sprintf(data, "%i", current_datatypevariable->arraylength);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$var_count") == 0) {
+                            sprintf(data, "%i", var_count);
+                            fputs(data, file);
+                        } else if (strcmp(buffer3->array, "$notarraytype") == 0)
+                            fputs(current_datatypevariable->typenotarray, file);
+                        else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if (strcmp("foreach layer", lastloop) == 0) {
+                        while (strcmp(buffer3->array, "$number") != 0 && pos <= (pos1 + 16)) {
+                            add_char(buffer3, c);
+                            pos++;
+                            c = filebuffer->array[pos];
+                        }
+                        pos--;
+                        if (strcmp(buffer3->array, "$number") == 0) {
+                            sprintf(data, "%i", current_layer->number);
+                            fputs(data, file);
+                        } else {
+                            fputs("$", file);
+                            pos = pos1;
+                        }
+                    } else if(write) fputc(c, file);
+                }
+            } else if (c == '<') {
+                tmplcode = 1;
+                reset_char_array(buffer);
+                add_char(buffer, '<');
+                pos1 = pos;
+            } else if (write)
+                fputc(c, file);
+        }
 
-		pos++;
-	}
+        pos++;
+    }
 
-	if (numtag != 0)
-		printf("error: template tag nest not closed, numtag = %d\n", numtag);
+    if (numtag != 0)
+        printf("error: template tag nest not closed, numtag = %d\n", numtag);
 
-	/* Close the files */
-	fclose(tmplfile);
-	fclose(file);
+    /* Close the files */
+    fclose(tmplfile);
+    fclose(file);
 
-	/* Clear memory */
-	free_char_array(buffer);
-	free_char_array(buffer3);
-	free_char_array(filebuffer);
+    /* Clear memory */
+    free_char_array(buffer);
+    free_char_array(buffer3);
+    free_char_array(filebuffer);
 }
 
 /** \fn parseAgentHeaderTemplate(char * directory, model_data * modeldata)
@@ -2895,201 +2338,193 @@ void parseTemplate(char * filename, char * templatename, model_data * modeldata)
  */
 void parseAgentHeaderTemplate(char * directory, model_data * modeldata)
 {
-	FILE *file;
-	char filename[1000];
-	char buffer[1000];
-	int i;
-	xmachine * current_xmachine = * modeldata->p_xmachines;
-	variable * current_variable;
+    FILE *file;
+    char filename[1000];
+    char buffer[1000];
+    int i;
+    xmachine * current_xmachine = * modeldata->p_xmachines;
+    variable * current_variable;
 
-	while(current_xmachine)
-	{
-		/* Open the output file */
-		strcpy(filename, directory);
-		strcat(filename, current_xmachine->name);
-		strcat(filename, "_agent_header.h");
-		printf("Writing header file : %s\n", filename);
-		file = fopen(filename, "w");
+    while(current_xmachine) {
+        /* Open the output file */
+        strcpy(filename, directory);
+        strcat(filename, current_xmachine->name);
+        strcat(filename, "_agent_header.h");
+        printf("Writing header file : %s\n", filename);
+        file = fopen(filename, "w");
 
-		fputs("/**\n", file);
-		fputs(" * \\file  ", file);
-		fputs(current_xmachine->name, file);
-		fputs("_agent_header.h\n", file);
-		fputs(" * \\brief Header for agent type memory access.\n", file);
-		fputs(" */\n\n", file);
+        fputs("/**\n", file);
+        fputs(" * \\file  ", file);
+        fputs(current_xmachine->name, file);
+        fputs("_agent_header.h\n", file);
+        fputs(" * \\brief Header for agent type memory access.\n", file);
+        fputs(" */\n\n", file);
 
-		current_variable = current_xmachine->variables;
-		while(current_variable)
-		{
-			strcpy(buffer, current_variable->name);
-			for(i = 0; i < (int)strlen(buffer); i++) buffer[i] = (buffer[i] >= 'a' && buffer[i] <= 'z')?('A' + buffer[i] -'a'):buffer[i];
-			
-			/* If variable is defined as a constant */
-			if(current_variable->constant == 1)
-			{
-				fputs("/** \\def ", file);
-				fputs(buffer, file);
-				fputs("\n", file);
-				fputs(" * \\brief Provides access to ", file);
-				fputs(current_variable->name, file);
-				fputs(" of ", file);
-				fputs(current_xmachine->name, file);
-				fputs(" agent memory variable via a function. */\n", file);
-				fputs("#define ", file);
-				fputs(buffer, file);
-				fputs(" (FLAME_get_", file);
-				fputs(current_xmachine->name, file);
-				fputs("_variable_", file);
-				fputs(current_variable->name, file);
-				fputs("())\n", file);
-			}
-			else
-			{
-				fputs("/** \\def ", file);
-				fputs(buffer, file);
-				fputs("\n", file);
-				fputs(" * \\brief Direct access to ", file);
-				fputs(current_variable->name, file);
-				fputs(" of ", file);
-				fputs(current_xmachine->name, file);
-				fputs(" agent memory variable. */\n", file);
-				fputs("#define ", file);
-				fputs(buffer, file);
-				fputs(" (current_xmachine_", file);
-				fputs(current_xmachine->name, file);
-				fputs("->", file);
-				fputs(current_variable->name, file);
-				fputs(")\n", file);
-			}
+        current_variable = current_xmachine->variables;
+        while(current_variable) {
+            strcpy(buffer, current_variable->name);
+            for(i = 0; i < (int)strlen(buffer); i++) buffer[i] = (buffer[i] >= 'a' && buffer[i] <= 'z')?('A' + buffer[i] -'a'):buffer[i];
 
-			current_variable = current_variable->next;
-		}
+            /* If variable is defined as a constant */
+            if(current_variable->constant == 1) {
+                fputs("/** \\def ", file);
+                fputs(buffer, file);
+                fputs("\n", file);
+                fputs(" * \\brief Provides access to ", file);
+                fputs(current_variable->name, file);
+                fputs(" of ", file);
+                fputs(current_xmachine->name, file);
+                fputs(" agent memory variable via a function. */\n", file);
+                fputs("#define ", file);
+                fputs(buffer, file);
+                fputs(" (FLAME_get_", file);
+                fputs(current_xmachine->name, file);
+                fputs("_variable_", file);
+                fputs(current_variable->name, file);
+                fputs("())\n", file);
+            } else {
+                fputs("/** \\def ", file);
+                fputs(buffer, file);
+                fputs("\n", file);
+                fputs(" * \\brief Direct access to ", file);
+                fputs(current_variable->name, file);
+                fputs(" of ", file);
+                fputs(current_xmachine->name, file);
+                fputs(" agent memory variable. */\n", file);
+                fputs("#define ", file);
+                fputs(buffer, file);
+                fputs(" (current_xmachine_", file);
+                fputs(current_xmachine->name, file);
+                fputs("->", file);
+                fputs(current_variable->name, file);
+                fputs(")\n", file);
+            }
 
-		/* Close the files */
-		fclose(file);
+            current_variable = current_variable->next;
+        }
 
-		current_xmachine = current_xmachine->next;
-	}
+        /* Close the files */
+        fclose(file);
+
+        current_xmachine = current_xmachine->next;
+    }
 }
 
 void parseUnittest(char * directory, model_data * modeldata)
 {
-	FILE *file;
-	char filename[100];
-	/*xmachine * current_xmachine = * modeldata->p_xmachines;
-	xmachine_function * current_function;
-	xmachine_ioput * current_ioput;*/
+    FILE *file;
+    char filename[100];
+    /*xmachine * current_xmachine = * modeldata->p_xmachines;
+    xmachine_function * current_function;
+    xmachine_ioput * current_ioput;*/
 
-	/* Open the output file */
-	strcpy(filename, directory);
-	strcat(filename, "unittest.c");
-	printf("writing file: %s\n", filename);
-	file = fopen(filename, "w");
+    /* Open the output file */
+    strcpy(filename, directory);
+    strcat(filename, "unittest.c");
+    printf("writing file: %s\n", filename);
+    file = fopen(filename, "w");
 
-	fputs("/**\n", file);
-	fputs(" * \\file unittest.c\n", file);
-	fputs(" * \\brief Unit test program.\n", file);
-	fputs(" */\n\n", file);
-	fputs("#include \"header.h\"\n", file);
-	fputs("#include <CUnit/Basic.h>\"\n\n", file);
-	fputs("int main(int argc, char * argv[])\n", file);
-	fputs("{\n", file);
-	fputs("\tprintf(\"unittest\\n\");\n", file);
-	fputs("\t/* Exit successfully by returning zero to Operating System */\n", file);
-	fputs("\treturn 0;\n", file);
-	fputs("}\n", file);
+    fputs("/**\n", file);
+    fputs(" * \\file unittest.c\n", file);
+    fputs(" * \\brief Unit test program.\n", file);
+    fputs(" */\n\n", file);
+    fputs("#include \"header.h\"\n", file);
+    fputs("#include <CUnit/Basic.h>\"\n\n", file);
+    fputs("int main(int argc, char * argv[])\n", file);
+    fputs("{\n", file);
+    fputs("\tprintf(\"unittest\\n\");\n", file);
+    fputs("\t/* Exit successfully by returning zero to Operating System */\n", file);
+    fputs("\treturn 0;\n", file);
+    fputs("}\n", file);
 
-	/* Close the files */
-	fclose(file);
+    /* Close the files */
+    fclose(file);
 }
 
 void parser0xsd(char * directory, model_data * modeldata)
 {
-	FILE *file;
-	char filename[100];
-	/*xmachine * current_xmachine = * modeldata->p_xmachines;*/
-	//variable * current_envvar;
-	//variable * allvar;
-	
-	/* Open the output file */
-	strcpy(filename, directory);
-	strcat(filename, "0.xsd");
-	printf("writing file: %s\n", filename);
-	file = fopen(filename, "w");
-	
-	fputs("<?xml version=\"1.0\"?>\n", file);
-	fputs("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n", file);
-	
-	fputs("<xs:element name=\"states\">\n", file);
-	fputs("<xs:complexType>\n", file);
-	fputs("<xs:sequence>\n", file);
-	fputs("<xs:element name=\"imports\"/>\n", file);
-	fputs("<xs:element name=\"outputs\">\n", file);
-	fputs("<xs:element name=\"environment\"/>\n", file);
-	fputs("<xs:element name=\"xagents\"/>\n", file);
-	fputs("</xs:sequence>\n", file);
-	fputs("</xs:complexType>\n", file);
-	fputs("</xs:element>\n", file);
+    FILE *file;
+    char filename[100];
+    /*xmachine * current_xmachine = * modeldata->p_xmachines;*/
+    //variable * current_envvar;
+    //variable * allvar;
 
-	/* Close the file */
-	fclose(file);
+    /* Open the output file */
+    strcpy(filename, directory);
+    strcat(filename, "0.xsd");
+    printf("writing file: %s\n", filename);
+    file = fopen(filename, "w");
+
+    fputs("<?xml version=\"1.0\"?>\n", file);
+    fputs("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n", file);
+
+    fputs("<xs:element name=\"states\">\n", file);
+    fputs("<xs:complexType>\n", file);
+    fputs("<xs:sequence>\n", file);
+    fputs("<xs:element name=\"imports\"/>\n", file);
+    fputs("<xs:element name=\"outputs\">\n", file);
+    fputs("<xs:element name=\"environment\"/>\n", file);
+    fputs("<xs:element name=\"xagents\"/>\n", file);
+    fputs("</xs:sequence>\n", file);
+    fputs("</xs:complexType>\n", file);
+    fputs("</xs:element>\n", file);
+
+    /* Close the file */
+    fclose(file);
 }
 
 void parser0dtd(char * directory, model_data * modeldata)
 {
-	FILE *file;
-	char filename[100];
-	/*xmachine * current_xmachine = * modeldata->p_xmachines;*/
-	variable * current_envvar;
-	variable * allvar;
-	
-	/* Open the output file */
-	strcpy(filename, directory);
-	strcat(filename, "0.dtd");
-	printf("writing file: %s\n", filename);
-	file = fopen(filename, "w");
-	
-	fputs("<!ELEMENT states (itno?,imports?,outputs?,environment?,xagents?)>\n", file);
-	fputs("<!ELEMENT imports (import*)>\n", file);
-	fputs("<!ELEMENT outputs (output*)>\n", file);
-	fputs("<!ELEMENT environment (", file);
-	for(current_envvar = * modeldata->p_envvars; current_envvar != NULL; current_envvar = current_envvar->next)
-	{
-		fputs(current_envvar->name, file);
-		if(current_envvar->next != NULL) fputs(",", file);
-	}
-	fputs(")>\n", file);
-	fputs("<!ELEMENT xagents (xagent*)>\n", file);
-	fputs("<!ELEMENT import (type,format,location)>\n", file);
-	fputs("<!ELEMENT output (type,name?,format,location,time)>\n", file);
-	/* Unfortunately xagent tags can hold all the different agent type variables */
-	fputs("<!ELEMENT xagent ANY>\n", file);
-	fputs("<!ELEMENT time (period, phase, duration?)>\n", file);
-	fputs("<!ELEMENT itno (#PCDATA)>\n", file);
-	fputs("<!ELEMENT location (#PCDATA)>\n", file);
-	fputs("<!ELEMENT format (#PCDATA)>\n", file);
-	fputs("<!ELEMENT type (#PCDATA)>\n", file);
-	fputs("<!ELEMENT name (#PCDATA)>\n", file);
-	fputs("<!ELEMENT period (#PCDATA)>\n", file);
-	fputs("<!ELEMENT phase (#PCDATA)>\n", file);
-	fputs("<!ELEMENT duration (#PCDATA)>\n", file);
-	/* For each agent variable */
-	for(allvar = * modeldata->p_allvars; allvar != NULL; allvar = allvar->next)
-	{
-		if(strcmp(allvar->name, "itno") != 0 ||
-			strcmp(allvar->name, "location") != 0 ||
-			strcmp(allvar->name, "format") != 0 ||
-			strcmp(allvar->name, "type") != 0 ||
-			strcmp(allvar->name, "name") != 0 ||
-			strcmp(allvar->name, "period") != 0 ||
-			strcmp(allvar->name, "phase") != 0 ||
-			strcmp(allvar->name, "duration") != 0)
-		{
-			fputs("<!ELEMENT ", file);
-			fputs(allvar->name, file);
-			fputs(" (#PCDATA)>\n", file);
-		}
-	}
-	/* Close the file */
-	fclose(file);
+    FILE *file;
+    char filename[100];
+    /*xmachine * current_xmachine = * modeldata->p_xmachines;*/
+    variable * current_envvar;
+    variable * allvar;
+
+    /* Open the output file */
+    strcpy(filename, directory);
+    strcat(filename, "0.dtd");
+    printf("writing file: %s\n", filename);
+    file = fopen(filename, "w");
+
+    fputs("<!ELEMENT states (itno?,imports?,outputs?,environment?,xagents?)>\n", file);
+    fputs("<!ELEMENT imports (import*)>\n", file);
+    fputs("<!ELEMENT outputs (output*)>\n", file);
+    fputs("<!ELEMENT environment (", file);
+    for(current_envvar = * modeldata->p_envvars; current_envvar != NULL; current_envvar = current_envvar->next) {
+        fputs(current_envvar->name, file);
+        if(current_envvar->next != NULL) fputs(",", file);
+    }
+    fputs(")>\n", file);
+    fputs("<!ELEMENT xagents (xagent*)>\n", file);
+    fputs("<!ELEMENT import (type,format,location)>\n", file);
+    fputs("<!ELEMENT output (type,name?,format,location,time)>\n", file);
+    /* Unfortunately xagent tags can hold all the different agent type variables */
+    fputs("<!ELEMENT xagent ANY>\n", file);
+    fputs("<!ELEMENT time (period, phase, duration?)>\n", file);
+    fputs("<!ELEMENT itno (#PCDATA)>\n", file);
+    fputs("<!ELEMENT location (#PCDATA)>\n", file);
+    fputs("<!ELEMENT format (#PCDATA)>\n", file);
+    fputs("<!ELEMENT type (#PCDATA)>\n", file);
+    fputs("<!ELEMENT name (#PCDATA)>\n", file);
+    fputs("<!ELEMENT period (#PCDATA)>\n", file);
+    fputs("<!ELEMENT phase (#PCDATA)>\n", file);
+    fputs("<!ELEMENT duration (#PCDATA)>\n", file);
+    /* For each agent variable */
+    for(allvar = * modeldata->p_allvars; allvar != NULL; allvar = allvar->next) {
+        if(strcmp(allvar->name, "itno") != 0 ||
+                strcmp(allvar->name, "location") != 0 ||
+                strcmp(allvar->name, "format") != 0 ||
+                strcmp(allvar->name, "type") != 0 ||
+                strcmp(allvar->name, "name") != 0 ||
+                strcmp(allvar->name, "period") != 0 ||
+                strcmp(allvar->name, "phase") != 0 ||
+                strcmp(allvar->name, "duration") != 0) {
+            fputs("<!ELEMENT ", file);
+            fputs(allvar->name, file);
+            fputs(" (#PCDATA)>\n", file);
+        }
+    }
+    /* Close the file */
+    fclose(file);
 }

--- a/readmodel.c
+++ b/readmodel.c
@@ -6,219 +6,188 @@
  */
 int checkRuleAgentVar(rule_data * current_rule_data)
 {
-	int flag = 0;
+    int flag = 0;
 
-	if(current_rule_data->time_rule == 1)
-	{
-		if(strncmp(current_rule_data->rhs, "a.", 2) == 0) flag = 1;
-	}
-	else
-	{
-		if(current_rule_data->lhs == NULL)
-		{
-			if(checkRuleAgentVar(current_rule_data->lhs_rule) == 1) flag = 1;
-		}
-		else
-		{
-			if(strncmp(current_rule_data->lhs, "a.", 2) == 0) flag = 1;
-		}
+    if(current_rule_data->time_rule == 1) {
+        if(strncmp(current_rule_data->rhs, "a.", 2) == 0) flag = 1;
+    } else {
+        if(current_rule_data->lhs == NULL) {
+            if(checkRuleAgentVar(current_rule_data->lhs_rule) == 1) flag = 1;
+        } else {
+            if(strncmp(current_rule_data->lhs, "a.", 2) == 0) flag = 1;
+        }
 
-		if(current_rule_data->rhs == NULL)
-		{
-			if(checkRuleAgentVar(current_rule_data->rhs_rule) == 1) flag = 1;
-		}
-		else
-		{
-			if(strncmp(current_rule_data->rhs, "a.", 2) == 0) flag = 1;
-		}
-	}
-	
-	return flag;
+        if(current_rule_data->rhs == NULL) {
+            if(checkRuleAgentVar(current_rule_data->rhs_rule) == 1) flag = 1;
+        } else {
+            if(strncmp(current_rule_data->rhs, "a.", 2) == 0) flag = 1;
+        }
+    }
+
+    return flag;
 }
 
 int checkRuleMessageVar(rule_data * current_rule_data)
 {
-	int flag = 0;
+    int flag = 0;
 
-		if(current_rule_data->lhs == NULL)
-		{
-			if(checkRuleMessageVar(current_rule_data->lhs_rule) == 1) flag = 1;
-		}
-		else
-		{
-			if(strncmp(current_rule_data->lhs, "m.", 2) == 0) flag = 1;
-		}
+    if(current_rule_data->lhs == NULL) {
+        if(checkRuleMessageVar(current_rule_data->lhs_rule) == 1) flag = 1;
+    } else {
+        if(strncmp(current_rule_data->lhs, "m.", 2) == 0) flag = 1;
+    }
 
-		if(current_rule_data->rhs == NULL)
-		{
-			if(checkRuleAgentVar(current_rule_data->rhs_rule) == 1) flag = 1;
-		}
-		else
-		{
-			if(strncmp(current_rule_data->rhs, "m.", 2) == 0) flag = 1;
-		}
+    if(current_rule_data->rhs == NULL) {
+        if(checkRuleAgentVar(current_rule_data->rhs_rule) == 1) flag = 1;
+    } else {
+        if(strncmp(current_rule_data->rhs, "m.", 2) == 0) flag = 1;
+    }
 
-	return flag;
+    return flag;
 }
 
 
 void handleVariableType(char_array * current_string, variable * current_variable, model_data * modeldata)
 {
-	model_datatype * current_datatype;
-	char buffer[100];
-	int i;
+    model_datatype * current_datatype;
+    char buffer[100];
+    int i;
 
-	current_variable->type = copy_array_to_str(current_string);
+    current_variable->type = copy_array_to_str(current_string);
 
-	current_variable->arraylength = 0;
-	current_variable->ismodeldatatype = 0;
+    current_variable->arraylength = 0;
+    current_variable->ismodeldatatype = 0;
 
-	strcpy(current_variable->defaultvalue, "");
-	strcpy(current_variable->c_type, "");
+    strcpy(current_variable->defaultvalue, "");
+    strcpy(current_variable->c_type, "");
 
-	if(strcmp(current_variable->type, "int") == 0 ||
-		strcmp(current_variable->type, "short int") == 0 ||
-		strcmp(current_variable->type, "long int") == 0 ||
-		strcmp(current_variable->type, "unsigned int") == 0 ||
-		strcmp(current_variable->type, "unsigned short int") == 0 ||
-		strcmp(current_variable->type, "unsigned long int") == 0 ||
-		strcmp(current_variable->type, "int_array") == 0)
-	{
-		strcpy(current_variable->defaultvalue, "0");
-		strcpy(current_variable->c_type, "i");
-	}
+    if(strcmp(current_variable->type, "int") == 0 ||
+            strcmp(current_variable->type, "short int") == 0 ||
+            strcmp(current_variable->type, "long int") == 0 ||
+            strcmp(current_variable->type, "unsigned int") == 0 ||
+            strcmp(current_variable->type, "unsigned short int") == 0 ||
+            strcmp(current_variable->type, "unsigned long int") == 0 ||
+            strcmp(current_variable->type, "int_array") == 0) {
+        strcpy(current_variable->defaultvalue, "0");
+        strcpy(current_variable->c_type, "i");
+    }
 
-	if(strcmp(current_variable->type, "double") == 0 ||
-		strcmp(current_variable->type, "float") == 0 ||
-		strcmp(current_variable->type, "double_array") == 0 ||
-		strcmp(current_variable->type, "float_array") == 0)
-	{
-		strcpy(current_variable->defaultvalue, "0.0");
-		strcpy(current_variable->c_type, "f");
-	}
+    if(strcmp(current_variable->type, "double") == 0 ||
+            strcmp(current_variable->type, "float") == 0 ||
+            strcmp(current_variable->type, "double_array") == 0 ||
+            strcmp(current_variable->type, "float_array") == 0) {
+        strcpy(current_variable->defaultvalue, "0.0");
+        strcpy(current_variable->c_type, "f");
+    }
 
-	if(strcmp(current_variable->type, "char") == 0 ||
-		strcmp(current_variable->type, "unsigned char") == 0 ||
-		strcmp(current_variable->type, "char_array") == 0)
-	{
-		strcpy(current_variable->defaultvalue, "' '");
-		strcpy(current_variable->c_type, "c");
-	}
+    if(strcmp(current_variable->type, "char") == 0 ||
+            strcmp(current_variable->type, "unsigned char") == 0 ||
+            strcmp(current_variable->type, "char_array") == 0) {
+        strcpy(current_variable->defaultvalue, "' '");
+        strcpy(current_variable->c_type, "c");
+    }
 
-	/*copycharlist(&current_variable->type, &chardata[0]);*/
-	/* These are C to MPI datatype mappings */
-	if(strcmp(current_variable->type, "int") == 0) strcpy(current_variable->mpi_type, "MPI_INT");
-	if(strcmp(current_variable->type, "double") == 0) strcpy(current_variable->mpi_type, "MPI_DOUBLE");
-	if(strcmp(current_variable->type, "float") == 0) strcpy(current_variable->mpi_type, "MPI_FLOAT");
-	if(strcmp(current_variable->type, "char") == 0) strcpy(current_variable->mpi_type, "MPI_CHAR");
-	if(strcmp(current_variable->type, "short int") == 0) strcpy(current_variable->mpi_type, "MPI_SHORT");
-	if(strcmp(current_variable->type, "long int") == 0) strcpy(current_variable->mpi_type, "MPI_LONG");
-	if(strcmp(current_variable->type, "long double") == 0) strcpy(current_variable->mpi_type, "MPI_LONG_DOUBLE");
-	if(strcmp(current_variable->type, "unsigned int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED");
-	if(strcmp(current_variable->type, "unsigned short int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_SHORT");
-	if(strcmp(current_variable->type, "unsigned long int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_LONG");
-	if(strcmp(current_variable->type, "unsigned char") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_CHAR");
-	if(strcmp(current_variable->type, "int_array") == 0)
-	{
-		current_variable->arraylength = -1;
-		strcpy(current_variable->mpi_type, "MPI_INT");
-	}
-	if(strcmp(current_variable->type, "float_array") == 0)
-	{
-		current_variable->arraylength = -1;
-		strcpy(current_variable->mpi_type, "MPI_FLOAT");
-	}
-	if(strcmp(current_variable->type, "double_array") == 0)
-	{
-		current_variable->arraylength = -1;
-		strcpy(current_variable->mpi_type, "MPI_DOUBLE");
-	}
-	if(strcmp(current_variable->type, "char_array") == 0)
-	{
-		current_variable->arraylength = -1;
-		strcpy(current_variable->mpi_type, "MPI_CHAR");
-	}
-	/* Handle model defined data types */
-	current_datatype = * modeldata->p_datatypes;
-	while(current_datatype)
-	{
-		if(strcmp(current_variable->type, current_datatype->name) == 0)
-		{
-			current_variable->ismodeldatatype = 1;
-			current_variable->datatype = current_datatype;
-		}
+    /*copycharlist(&current_variable->type, &chardata[0]);*/
+    /* These are C to MPI datatype mappings */
+    if(strcmp(current_variable->type, "int") == 0) strcpy(current_variable->mpi_type, "MPI_INT");
+    if(strcmp(current_variable->type, "double") == 0) strcpy(current_variable->mpi_type, "MPI_DOUBLE");
+    if(strcmp(current_variable->type, "float") == 0) strcpy(current_variable->mpi_type, "MPI_FLOAT");
+    if(strcmp(current_variable->type, "char") == 0) strcpy(current_variable->mpi_type, "MPI_CHAR");
+    if(strcmp(current_variable->type, "short int") == 0) strcpy(current_variable->mpi_type, "MPI_SHORT");
+    if(strcmp(current_variable->type, "long int") == 0) strcpy(current_variable->mpi_type, "MPI_LONG");
+    if(strcmp(current_variable->type, "long double") == 0) strcpy(current_variable->mpi_type, "MPI_LONG_DOUBLE");
+    if(strcmp(current_variable->type, "unsigned int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED");
+    if(strcmp(current_variable->type, "unsigned short int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_SHORT");
+    if(strcmp(current_variable->type, "unsigned long int") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_LONG");
+    if(strcmp(current_variable->type, "unsigned char") == 0) strcpy(current_variable->mpi_type, "MPI_UNSIGNED_CHAR");
+    if(strcmp(current_variable->type, "int_array") == 0) {
+        current_variable->arraylength = -1;
+        strcpy(current_variable->mpi_type, "MPI_INT");
+    }
+    if(strcmp(current_variable->type, "float_array") == 0) {
+        current_variable->arraylength = -1;
+        strcpy(current_variable->mpi_type, "MPI_FLOAT");
+    }
+    if(strcmp(current_variable->type, "double_array") == 0) {
+        current_variable->arraylength = -1;
+        strcpy(current_variable->mpi_type, "MPI_DOUBLE");
+    }
+    if(strcmp(current_variable->type, "char_array") == 0) {
+        current_variable->arraylength = -1;
+        strcpy(current_variable->mpi_type, "MPI_CHAR");
+    }
+    /* Handle model defined data types */
+    current_datatype = * modeldata->p_datatypes;
+    while(current_datatype) {
+        if(strcmp(current_variable->type, current_datatype->name) == 0) {
+            current_variable->ismodeldatatype = 1;
+            current_variable->datatype = current_datatype;
+        }
 
-		strcpy(buffer, current_datatype->name);
-		strcat(buffer, "_array");
+        strcpy(buffer, current_datatype->name);
+        strcat(buffer, "_array");
 
-		if(strcmp(current_variable->type, buffer) == 0)
-		{
-			current_variable->ismodeldatatype = 1;
-			current_variable->datatype = current_datatype;
-			current_variable->arraylength = -1;
-		}
+        if(strcmp(current_variable->type, buffer) == 0) {
+            current_variable->ismodeldatatype = 1;
+            current_variable->datatype = current_datatype;
+            current_variable->arraylength = -1;
+        }
 
-		current_datatype = current_datatype->next;
-	}
+        current_datatype = current_datatype->next;
+    }
 
-	current_variable->typenotarray = copy_array_to_str(current_string);
-	/* Handle model data type arrays */
-	i = (int)strlen(current_variable->type);
-	if(i > 6)
-	{
-		if(current_variable->type[i-1] == 'y' &&
-			current_variable->type[i-2] == 'a' &&
-			current_variable->type[i-3] == 'r' &&
-			current_variable->type[i-4] == 'r' &&
-			current_variable->type[i-5] == 'a' &&
-			current_variable->type[i-6] == '_')
-		{
-			remove_char(current_string, i-1);
-			remove_char(current_string, i-2);
-			remove_char(current_string, i-3);
-			remove_char(current_string, i-4);
-			remove_char(current_string, i-5);
-			remove_char(current_string, i-6);
-			free(current_variable->typenotarray);
-			current_variable->typenotarray = copy_array_to_str(current_string);
-		}
-	}
+    current_variable->typenotarray = copy_array_to_str(current_string);
+    /* Handle model data type arrays */
+    i = (int)strlen(current_variable->type);
+    if(i > 6) {
+        if(current_variable->type[i-1] == 'y' &&
+                current_variable->type[i-2] == 'a' &&
+                current_variable->type[i-3] == 'r' &&
+                current_variable->type[i-4] == 'r' &&
+                current_variable->type[i-5] == 'a' &&
+                current_variable->type[i-6] == '_') {
+            remove_char(current_string, i-1);
+            remove_char(current_string, i-2);
+            remove_char(current_string, i-3);
+            remove_char(current_string, i-4);
+            remove_char(current_string, i-5);
+            remove_char(current_string, i-6);
+            free(current_variable->typenotarray);
+            current_variable->typenotarray = copy_array_to_str(current_string);
+        }
+    }
 }
 
 void handleVariableName(char_array * current_string, variable * current_variable)
 {
-	int j, i = 0;
-	char buffer[100];
-	
-	current_variable->name = copy_array_to_str(current_string);
+    int j, i = 0;
+    char buffer[100];
 
-	/* Handle static arrays */
-	while(current_variable->name[i] != '\0')
-	{
-		if(current_variable->name[i] == '[')
-		{
-			current_variable->name[i] = '\0';
-			j = 0;
-			i++;
-			while(current_variable->name[i] != ']')
-			{
-				buffer[j] = current_variable->name[i];
-				j++;
-				i++;
-			}
+    current_variable->name = copy_array_to_str(current_string);
 
-			buffer[j] = '\0';
+    /* Handle static arrays */
+    while(current_variable->name[i] != '\0') {
+        if(current_variable->name[i] == '[') {
+            current_variable->name[i] = '\0';
+            j = 0;
+            i++;
+            while(current_variable->name[i] != ']') {
+                buffer[j] = current_variable->name[i];
+                j++;
+                i++;
+            }
 
-			/* If no number*/
-			if(j == 0) current_variable->arraylength = -1;
-			else
-			{
-				current_variable->arraylength = atoi(buffer);
-			}
-		}
+            buffer[j] = '\0';
 
-		i++;
-	}
+            /* If no number*/
+            if(j == 0) current_variable->arraylength = -1;
+            else {
+                current_variable->arraylength = atoi(buffer);
+            }
+        }
+
+        i++;
+    }
 }
 
 /** \fn void readModel(char * inputfile, char * directory, model_data * modeldata)
@@ -229,668 +198,749 @@ void handleVariableName(char_array * current_string, variable * current_variable
  */
 void readModel(input_file * inputfile, char * directory, model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	/* Pointer to file */
-	FILE *file;
-	/* Pointer to possible code file */
-	FILE *filecode;
-	/* Comment variable */
-	int xmlcomment = 0;
-	/* Variables for handling files for function code */
-	int j, k;
-	/* Char and char buffer for reading file to */
-	char c = ' ';
-	int numtag = 0;
-	char chartag[100][100];
-	int tagline[100];
-	char chardata[1000];
-	int dynamic_array_found;
-	int linenumber = 1;
-	int variable_count;
-	int lastd;
-	int lhs_last = 0;
-	/* Variable to keep reading file */
-	int reading;
-	/* Variable for buffer position */
-	int i;
-	/* Variable to handle xml codes */
-	int xmlcode;
-	/* Variable for if in a tag */
-	int intag;
-	/* Variables for checking tags */
-	int name, xmachine, memory, var, type;
-	int state, functions, function;
-	int note, message, code, cdata, environment, define, value, codefile;
-	int header, iteration_end_code, depends, datatype, desc, cur_state, next_state;
-	int input, output, messagetype, timetag, unit, period, lhs, op, rhs, condition;
-	int model, filter, phase, enabled, not, random, sort, constant, order, key;
-	int box2d, box3d;
-	//int not_value;
-	/* Pointer to new structs */
-	xmachine_message * current_message;
-	/* xmachine_state * current_state; */
-	xmachine_function * current_function;
-	adj_function * current_adj_function;
-	variable * current_envdefine;
-	env_func * current_envfunc;
-	variable ** p_variable;
-	variable * tvariable;
-	variable * current_variable;
-	model_datatype * current_datatype;
-	/*char_list ** p_charlist;*/
-	/*char_list * charlist;*/
-	/*char_list * current_charlist;*/
-	f_code ** p_fcode;
-	f_code * fcode;
-	f_code * current_fcode;
-	f_code * end_it_fcode;
-	xmachine_ioput * current_ioput;
-	input_file * current_input_file;
-	rule_data * current_rule_data;
-	rule_data * last_rule_data;
-	/* new use of char_array */
-	char_array * current_string;
-	char * temp_char = NULL;
-	char * temp_char2 = NULL;
-	/* variables in time_data */
-	char * time_name = NULL;
-	char * unit_name = NULL;
-	int period_int;
+    xmachine * current_xmachine;
+    /* Pointer to file */
+    FILE *file;
+    /* Pointer to possible code file */
+    FILE *filecode;
+    /* Comment variable */
+    int xmlcomment = 0;
+    /* Variables for handling files for function code */
+    int j, k;
+    /* Char and char buffer for reading file to */
+    char c = ' ';
+    int numtag = 0;
+    char chartag[100][100];
+    int tagline[100];
+    char chardata[1000];
+    int dynamic_array_found;
+    int linenumber = 1;
+    int variable_count;
+    int lastd;
+    int lhs_last = 0;
+    /* Variable to keep reading file */
+    int reading;
+    /* Variable for buffer position */
+    int i;
+    /* Variable to handle xml codes */
+    int xmlcode;
+    /* Variable for if in a tag */
+    int intag;
+    /* Variables for checking tags */
+    int name, xmachine, memory, var, type;
+    int state, functions, function;
+    int note, message, code, cdata, environment, define, value, codefile;
+    int header, iteration_end_code, depends, datatype, desc, cur_state, next_state;
+    int input, output, messagetype, timetag, unit, period, lhs, op, rhs, condition;
+    int model, filter, phase, enabled, not, random, sort, constant, order, key;
+    int box2d, box3d;
+    //int not_value;
+    /* Pointer to new structs */
+    xmachine_message * current_message;
+    /* xmachine_state * current_state; */
+    xmachine_function * current_function;
+    adj_function * current_adj_function;
+    variable * current_envdefine;
+    env_func * current_envfunc;
+    variable ** p_variable;
+    variable * tvariable;
+    variable * current_variable;
+    model_datatype * current_datatype;
+    /*char_list ** p_charlist;*/
+    /*char_list * charlist;*/
+    /*char_list * current_charlist;*/
+    f_code ** p_fcode;
+    f_code * fcode;
+    f_code * current_fcode;
+    f_code * end_it_fcode;
+    xmachine_ioput * current_ioput;
+    input_file * current_input_file;
+    rule_data * current_rule_data;
+    rule_data * last_rule_data;
+    /* new use of char_array */
+    char_array * current_string;
+    char * temp_char = NULL;
+    char * temp_char2 = NULL;
+    /* variables in time_data */
+    char * time_name = NULL;
+    char * unit_name = NULL;
+    int period_int;
 
-	/* check var name for array */
-	/*char_list * charcheck;*/
-	modeldata->number_messages = 0;
-	modeldata->number_xmachines = 0;
-	modeldata->agents_include_array_variables = 0;
+    /* check var name for array */
+    /*char_list * charcheck;*/
+    modeldata->number_messages = 0;
+    modeldata->number_xmachines = 0;
+    modeldata->agents_include_array_variables = 0;
 
-	/* Open config file to read-only */
-	if((file = fopen(inputfile->fullfilepath, "r"))==NULL)
-	{
-		fprintf(stderr, "ERROR: Cannot read file: %s\n", inputfile->fullfilepath);
-		exit(1);
-	}
-	else 
-    { 
-        printf("Reading XMML file (%s)\n", inputfile->fullfilepath); 
+    /* Open config file to read-only */
+    if((file = fopen(inputfile->fullfilepath, "r"))==NULL) {
+        fprintf(stderr, "ERROR: Cannot read file: %s\n", inputfile->fullfilepath);
+        exit(1);
+    } else {
+        printf("Reading XMML file (%s)\n", inputfile->fullfilepath);
     }
 
-	/* Initialise variables */
-	/*p_charlist = &charlist;*/
-	p_fcode = &fcode;
-	p_variable = &tvariable;
-	current_string = init_char_array();
+    /* Initialise variables */
+    /*p_charlist = &charlist;*/
+    p_fcode = &fcode;
+    p_variable = &tvariable;
+    current_string = init_char_array();
 
-	i = 0;
-	xmlcode = 0;
-	reading = 1;
-	intag = 0;
-	name = 0;
-	xmachine = 0;
-	memory = 0;
-	var = 0;
-	type = 0;
-	state = 0;
-	functions = 0;
-	function = 0;
-	note = 0;
-	message = 0;
-	code = 0;
-	cdata = 0;
-	environment = 0;
-	define = 0;
-	value = 0;
-	codefile = 0;
-	header = 0;
-	iteration_end_code = 0;
-	depends = 0;
-	datatype = 0;
-	desc = 0;
-	cur_state = 0;
-	next_state = 0;
-	input = 0;
-	output = 0;
-	messagetype = 0;
-	timetag = 0;
-	unit = 0;
-	period = 0;
-	lhs = 0;
-	rhs = 0;
-	op = 0;
-	condition = 0;
-	model = 0;
-	filter = 0;
-	period = 0;
-	phase = 0;
-	enabled = 0;
-	not = 0;
-	random = 0;
-	sort = 0;
-	constant = 0;
-	order = 0;
-	key = 0;
-	box2d = 0;
-	box3d = 0;
+    i = 0;
+    xmlcode = 0;
+    reading = 1;
+    intag = 0;
+    name = 0;
+    xmachine = 0;
+    memory = 0;
+    var = 0;
+    type = 0;
+    state = 0;
+    functions = 0;
+    function = 0;
+    note = 0;
+    message = 0;
+    code = 0;
+    cdata = 0;
+    environment = 0;
+    define = 0;
+    value = 0;
+    codefile = 0;
+    header = 0;
+    iteration_end_code = 0;
+    depends = 0;
+    datatype = 0;
+    desc = 0;
+    cur_state = 0;
+    next_state = 0;
+    input = 0;
+    output = 0;
+    messagetype = 0;
+    timetag = 0;
+    unit = 0;
+    period = 0;
+    lhs = 0;
+    rhs = 0;
+    op = 0;
+    condition = 0;
+    model = 0;
+    filter = 0;
+    period = 0;
+    phase = 0;
+    enabled = 0;
+    not = 0;
+    random = 0;
+    sort = 0;
+    constant = 0;
+    order = 0;
+    key = 0;
+    box2d = 0;
+    box3d = 0;
 
-	/*printf("%i> ", linenumber);*/
+    /*printf("%i> ", linenumber);*/
 
-	/* Read characters until the end of the file */
-	/*while(c != EOF)*/
-	/* Read characters until end of xml found */
-	while(reading == 1 && c != (char)EOF)
-	{
-		/* Get the next char from the file */
-		c = (char)fgetc(file);
+    /* Read characters until the end of the file */
+    /*while(c != EOF)*/
+    /* Read characters until end of xml found */
+    while(reading == 1 && c != (char)EOF) {
+        /* Get the next char from the file */
+        c = (char)fgetc(file);
 
-		/* Print char */
-		/*printf("%c\n", c);*/
-		if(c == '\n' || c == '\r') linenumber++;
-		/*printf("%i> ", linenumber);*/
+        /* Print char */
+        /*printf("%c\n", c);*/
+        if(c == '\n' || c == '\r') linenumber++;
+        /*printf("%i> ", linenumber);*/
 
-		/*printf("xmlcomment: %d\t%c\n", xmlcomment, c);*/
+        /*    printf("xmlcomment: %d\t%c\n", xmlcomment, c); */
 
-		/* If in cdata then don't parse as xml */
-		if(cdata)
-		{
-			/*printf("in cdata\n");*/
+        /* If in cdata then don't parse as xml */
+        if(cdata) {
+            /*printf("in cdata\n");*/
 
-			/* Handle CDATA tags */
-			if(xmlcode != 0)
-			{
-				if((xmlcode == 1) && (c == ']')) xmlcode = 2;
-				else if((xmlcode == 11) && (c == '!')) xmlcode = 2;
-				else if((xmlcode == 11) && (c == 'f')) xmlcode = 22;
-				else if(xmlcode == 2 && (c == '>' || c == '['))
-				{
-					if(c == '>') cdata = 0;
-					else xmlcode = 3;
-				}
-				else if(xmlcode == 3 && c == 'C') xmlcode = 4;
-				else if(xmlcode == 4 && c == 'D') xmlcode = 5;
-				else if(xmlcode == 5 && c == 'A') xmlcode = 6;
-				else if(xmlcode == 6 && c == 'T') xmlcode = 7;
-				else if(xmlcode == 7 && c == 'A') xmlcode = 8;
-				else if(xmlcode == 8 && c == '[') xmlcode = 9;
-				else if(xmlcode == 22 && c == 'i') xmlcode = 23;
-				else if(xmlcode == 23 && c == 'l') xmlcode = 24;
-				else if(xmlcode == 24 && c == 'e') xmlcode = 25;
-				else if(xmlcode == 25 && c == '>')
-				{
-					cdata = 0;
-					codefile = 1;
+            /* Handle CDATA tags */
+            if(xmlcode != 0) {
+                if((xmlcode == 1) && (c == ']')) xmlcode = 2;
+                else if((xmlcode == 11) && (c == '!')) xmlcode = 2;
+                else if((xmlcode == 11) && (c == 'f')) xmlcode = 22;
+                else if(xmlcode == 2 && (c == '>' || c == '[')) {
+                    if(c == '>') cdata = 0;
+                    else xmlcode = 3;
+                } else if(xmlcode == 3 && c == 'C') xmlcode = 4;
+                else if(xmlcode == 4 && c == 'D') xmlcode = 5;
+                else if(xmlcode == 5 && c == 'A') xmlcode = 6;
+                else if(xmlcode == 6 && c == 'T') xmlcode = 7;
+                else if(xmlcode == 7 && c == 'A') xmlcode = 8;
+                else if(xmlcode == 8 && c == '[') xmlcode = 9;
+                else if(xmlcode == 22 && c == 'i') xmlcode = 23;
+                else if(xmlcode == 23 && c == 'l') xmlcode = 24;
+                else if(xmlcode == 24 && c == 'e') xmlcode = 25;
+                else if(xmlcode == 25 && c == '>') {
+                    cdata = 0;
+                    codefile = 1;
 
-					strcpy(&chartag[numtag][0], "file");
-					numtag++;
+                    strcpy(&chartag[numtag][0], "file");
+                    numtag++;
 
-					reset_char_array(current_string);
-				}
-				else
-				{
-					if(xmlcode == 1)
-					{
-						/*current_charlist = addchar(p_charlist);*/
-						/*current_charlist->character = ']';*/
-						add_char(current_string, ']');
-					}
-					else if(xmlcode == 11)
-					{
-						/*current_charlist = addchar(p_charlist);*/
-						/*current_charlist->character = '<';*/
-						add_char(current_string, '<');
-					}
-					xmlcode = 0;
-				}
-			}
-			else if(c == ']') xmlcode = 1;
-			else if(c == '<') xmlcode = 11;
-			if(xmlcode == 0)
-			{
-				/*current_charlist = addchar(p_charlist);*/
-				/*current_charlist->character = c;*/
-				add_char(current_string, c);
-			}
-			if(xmlcode == 9) xmlcode = 0;
+                    reset_char_array(current_string);
+                } else {
+                    if(xmlcode == 1) {
+                        /*current_charlist = addchar(p_charlist);*/
+                        /*current_charlist->character = ']';*/
+                        add_char(current_string, ']');
+                    } else if(xmlcode == 11) {
+                        /*current_charlist = addchar(p_charlist);*/
+                        /*current_charlist->character = '<';*/
+                        add_char(current_string, '<');
+                    }
+                    xmlcode = 0;
+                }
+            } else if(c == ']') xmlcode = 1;
+            else if(c == '<') xmlcode = 11;
+            if(xmlcode == 0) {
+                /*current_charlist = addchar(p_charlist);*/
+                /*current_charlist->character = c;*/
+                add_char(current_string, c);
+            }
+            if(xmlcode == 9) xmlcode = 0;
 
-			/* Print xmlcode */
-			/*printf("xmlcode: %d", xmlcode);*/
-		}
-		/* If in xml comment then don't parse as xml */
-		else if(xmlcomment > 3)
-		{
-			if(xmlcomment == 4 && c == '-') xmlcomment = 5;
-			else if(xmlcomment == 5 && c == '-') xmlcomment = 6;
-			else if(xmlcomment == 6 && c == '>') { xmlcomment = 0; intag = 0; i = 0; }
-			else xmlcomment = 4;
-		}
-		/* If the end of a tag */
-		else if(c == '>')
-		{
-			/*printf("in c == >\n");*/
+            /* Print xmlcode */
+            /*printf("xmlcode: %d", xmlcode);*/
+        }
+        /* If in xml comment then don't parse as xml */
+        else if(xmlcomment > 3) {
+            if(xmlcomment == 4 && c == '-') xmlcomment = 5;
+            else if(xmlcomment == 5 && c == '-') xmlcomment = 6;
+            else if(xmlcomment == 6 && c == '>') {
+                xmlcomment = 0;
+                intag = 0;
+                i = 0;
+            } else xmlcomment = 4;
+        }
+        /* If the end of a tag */
+        else if(c == '>') {
+            /*printf("in c == >\n");*/
 
-			/* Place 0 at end of buffer to make chars a string */
-			/*buffer[i] = 0;*/
+            /* Place 0 at end of buffer to make chars a string */
+            /*buffer[i] = 0;*/
 
-			/*printf("buffer = %s\n", buffer);*/
-			/*printf("string = ");*/
-			/*print_char_array(current_string);*/
+            /*printf("buffer = %s\n", buffer);*/
+            /*printf("string = ");*/
+            /*print_char_array(current_string);*/
 
-			/* Handle truncated empty content tag */
-			/* If last character of string in tag is not a slash */
-			if(current_string->array[current_string->size-1] != '/')
-			{
-				/* Handle XML nested tag errors */
-				/* If start tag or xml start tag */
-				if(current_string->array[0] != '/')
-				{
-					/* Add to list of tags */
-					strcpy(&chartag[numtag][0], current_string->array);
-					tagline[numtag] = linenumber;
-					/* Advance list to next free place */
-					numtag++;
-				}
-				/* If end tag */
-				else
-				{
-					/* Look at last tag */
-					numtag--;
-					/* If different then exit */
-					if(strcmp(&current_string->array[1], &chartag[numtag][0]) != 0 && strcmp(current_string->array, "/xmodel") != 0)
-					{
-						fprintf(stderr, "ERROR: The tag <%s> on line number %i\n", current_string->array, linenumber);
-						fprintf(stderr, "ERROR: doesn't close the tag <%s> on line number %i\n", &chartag[numtag][0], tagline[numtag]);
-						exit(1);
-					}
-				}
-			}
+            /* Handle truncated empty content tag */
+            /* If last character of string in tag is not a slash */
+            if(current_string->array[current_string->size-1] != '/') {
+                /* Handle XML nested tag errors */
+                /* If start tag or xml start tag */
+                if(current_string->array[0] != '/') {
+                    /* Add to list of tags */
+                    strcpy(&chartag[numtag][0], current_string->array);
+                    tagline[numtag] = linenumber;
+                    /* Advance list to next free place */
+                    numtag++;
+                }
+                /* If end tag */
+                else {
+                    /* Look at last tag */
+                    numtag--;
+                    /* If different then exit */
+                    if(strcmp(&current_string->array[1], &chartag[numtag][0]) != 0 && strcmp(current_string->array, "/xmodel") != 0) {
+                        fprintf(stderr, "ERROR: The tag <%s> on line number %i\n", current_string->array, linenumber);
+                        fprintf(stderr, "ERROR: doesn't close the tag <%s> on line number %i\n", &chartag[numtag][0], tagline[numtag]);
+                        exit(1);
+                    }
+                }
+            }
 
-			if(strcmp(current_string->array, "xmachine_agent_model") == 0 || strcmp(current_string->array, "xmodel") == 0) { }
-			if(strcmp(current_string->array, "/xmachine_agent_model") == 0 || strcmp(current_string->array, "/xmodel") == 0) { reading = 0; printf("End of XMML file\n\n"); }
-			if(strcmp(current_string->array, "name") == 0) { name = 1; }/*reset_char_array(current_string); */
-			if(strcmp(current_string->array, "/name") == 0) { name = 0; }
-			if(strcmp(current_string->array, "environment") == 0) { environment = 1; }
-			if(strcmp(current_string->array, "/environment") == 0) { environment = 0; }
-			if(strcmp(current_string->array, "define") == 0)
-			{
-				define = 1;
-				current_envdefine = addvariable(modeldata->p_envdefines);
-			}
-			if(strcmp(current_string->array, "/define") == 0) { define = 0; }
-			if(strcmp(current_string->array, "value") == 0) { value = 1; }/* charlist = NULL; */
-			if(strcmp(current_string->array, "/value") == 0) { value = 0; }
-			if(strcmp(current_string->array, "xmachine") == 0) { xmachine = 1; }
-			if(strcmp(current_string->array, "/xmachine") == 0) { xmachine = 0; }
-			if(strcmp(current_string->array, "xagent") == 0) { xmachine = 1; }
-			if(strcmp(current_string->array, "/xagent") == 0) { xmachine = 0; }
-			if(strcmp(current_string->array, "memory") == 0)
-			{
-				memory = 1;
+            if(strcmp(current_string->array, "xmachine_agent_model") == 0 || strcmp(current_string->array, "xmodel") == 0) { }
+            if(strcmp(current_string->array, "/xmachine_agent_model") == 0 || strcmp(current_string->array, "/xmodel") == 0) {
+                reading = 0;
+                printf("End of XMML file\n\n");
+            }
+            if(strcmp(current_string->array, "name") == 0) {
+                name = 1;    /*reset_char_array(current_string); */
+            }
+            if(strcmp(current_string->array, "/name") == 0) {
+                name = 0;
+            }
+            if(strcmp(current_string->array, "environment") == 0) {
+                environment = 1;
+            }
+            if(strcmp(current_string->array, "/environment") == 0) {
+                environment = 0;
+            }
+            if(strcmp(current_string->array, "define") == 0) {
+                define = 1;
+                current_envdefine = addvariable(modeldata->p_envdefines);
+            }
+            if(strcmp(current_string->array, "/define") == 0) {
+                define = 0;
+            }
+            if(strcmp(current_string->array, "value") == 0) {
+                value = 1;    /* charlist = NULL; */
+            }
+            if(strcmp(current_string->array, "/value") == 0) {
+                value = 0;
+            }
+            if(strcmp(current_string->array, "xmachine") == 0) {
+                xmachine = 1;
+            }
+            if(strcmp(current_string->array, "/xmachine") == 0) {
+                xmachine = 0;
+            }
+            if(strcmp(current_string->array, "xagent") == 0) {
+                xmachine = 1;
+            }
+            if(strcmp(current_string->array, "/xagent") == 0) {
+                xmachine = 0;
+            }
+            if(strcmp(current_string->array, "memory") == 0) {
+                memory = 1;
 
-				tvariable = NULL;
-			}
-			if(strcmp(current_string->array, "/memory") == 0)
-			{
-				memory = 0;
-				//current_memory->vars = *p_variable;
-			}
-			if(strcmp(current_string->array, "var") == 0 || strcmp(current_string->array, "variable") == 0)
-			{
-				var = 1;
-				if(datatype == 1) current_variable = addvariable(p_variable);
-				else if(environment == 1) current_variable = addvariable(modeldata->p_envvars);
-				else if(memory == 1)
-				{
-					current_variable = addvariable(&current_xmachine->variables);
-					current_variable->agent = current_xmachine;
-				}
-				else current_variable = addvariable(p_variable);
+                tvariable = NULL;
+            }
+            if(strcmp(current_string->array, "/memory") == 0) {
+                memory = 0;
+                //current_memory->vars = *p_variable;
+            }
+            if(strcmp(current_string->array, "var") == 0 || strcmp(current_string->array, "variable") == 0) {
+                var = 1;
+                if(datatype == 1) current_variable = addvariable(p_variable);
+                else if(environment == 1) current_variable = addvariable(modeldata->p_envvars);
+                else if(memory == 1) {
+                    current_variable = addvariable(&current_xmachine->variables);
+                    current_variable->agent = current_xmachine;
+                } else current_variable = addvariable(p_variable);
 
-				current_variable->file = copystr(inputfile->fullfilepath);
-			}
-			if(strcmp(current_string->array, "/var") == 0 || strcmp(current_string->array, "/variable") == 0) { var = 0; }
-			if(strcmp(current_string->array, "type") == 0) { type = 1; }/*charlist = NULL; */
-			if(strcmp(current_string->array, "/type") == 0) { type = 0; }
-			if(strcmp(current_string->array, "datatype") == 0 || strcmp(current_string->array, "dataType") == 0)
-			{
-				datatype = 1;
-				current_datatype = adddatatype(modeldata->p_datatypes);
-				tvariable = NULL;
-				reset_char_array(current_string);
-			}
-			if(strcmp(current_string->array, "/datatype") == 0 || strcmp(current_string->array, "/dataType") == 0)
-			{
-				datatype = 0;
-				current_datatype->vars = *p_variable;
+                current_variable->file = copystr(inputfile->fullfilepath);
+            }
+            if(strcmp(current_string->array, "/var") == 0 || strcmp(current_string->array, "/variable") == 0) {
+                var = 0;
+            }
+            if(strcmp(current_string->array, "type") == 0) {
+                type = 1;    /*charlist = NULL; */
+            }
+            if(strcmp(current_string->array, "/type") == 0) {
+                type = 0;
+            }
+            if(strcmp(current_string->array, "datatype") == 0 || strcmp(current_string->array, "dataType") == 0) {
+                datatype = 1;
+                current_datatype = adddatatype(modeldata->p_datatypes);
+                tvariable = NULL;
+                reset_char_array(current_string);
+            }
+            if(strcmp(current_string->array, "/datatype") == 0 || strcmp(current_string->array, "/dataType") == 0) {
+                datatype = 0;
+                current_datatype->vars = *p_variable;
 
-				current_datatype->has_single_vars = 0;
-				current_datatype->has_dynamic_arrays = 0;
-				current_datatype->has_arrays = 0;
-				current_datatype->has_arrays_or_adts = 0;
-				/* Check if datatype has single variables and dynamic arrays */
-				current_variable = current_datatype->vars;
-				while(current_variable)
-				{
-					if((strcmp(current_variable->type, "int") == 0 ||
-						strcmp(current_variable->type, "float") == 0 ||
-						strcmp(current_variable->type, "double") == 0 ||
-						strcmp(current_variable->type, "char") == 0) &&
-						current_variable->arraylength == 0) current_datatype->has_single_vars = 1;
+                current_datatype->has_single_vars = 0;
+                current_datatype->has_dynamic_arrays = 0;
+                current_datatype->has_arrays = 0;
+                current_datatype->has_arrays_or_adts = 0;
+                /* Check if datatype has single variables and dynamic arrays */
+                current_variable = current_datatype->vars;
+                while(current_variable) {
+                    if((strcmp(current_variable->type, "int") == 0 ||
+                            strcmp(current_variable->type, "float") == 0 ||
+                            strcmp(current_variable->type, "double") == 0 ||
+                            strcmp(current_variable->type, "char") == 0) &&
+                            current_variable->arraylength == 0) current_datatype->has_single_vars = 1;
 
-					if(current_variable->ismodeldatatype == 1) current_datatype->has_arrays_or_adts = 1;
-					if(current_variable->arraylength != 0)
-					{
-						current_datatype->has_arrays = 1;
-						current_datatype->has_arrays_or_adts = 1;
-					}
-					if(current_variable->arraylength == -1) current_datatype->has_dynamic_arrays = 1;
-					if(current_variable->ismodeldatatype == 1 && current_variable->datatype->has_dynamic_arrays == 1) current_datatype->has_dynamic_arrays = 1;
+                    if(current_variable->ismodeldatatype == 1) current_datatype->has_arrays_or_adts = 1;
+                    if(current_variable->arraylength != 0) {
+                        current_datatype->has_arrays = 1;
+                        current_datatype->has_arrays_or_adts = 1;
+                    }
+                    if(current_variable->arraylength == -1) current_datatype->has_dynamic_arrays = 1;
+                    if(current_variable->ismodeldatatype == 1 && current_variable->datatype->has_dynamic_arrays == 1) current_datatype->has_dynamic_arrays = 1;
 
-					current_variable = current_variable->next;
-				}
-			}
-			if(strcmp(current_string->array, "functions") == 0) { functions = 1; }
-			if(strcmp(current_string->array, "/functions") == 0) { functions = 0; }
-			if(strcmp(current_string->array, "functionFiles") == 0) { functions = 1; }
-			if(strcmp(current_string->array, "/functionFiles") == 0) { functions = 0; }
-			if(strcmp(current_string->array, "current_state") == 0 || strcmp(current_string->array, "currentState") == 0) { cur_state = 1; }
-			if(strcmp(current_string->array, "/current_state") == 0 || strcmp(current_string->array, "/currentState") == 0) { cur_state = 0; }
-			if(strcmp(current_string->array, "next_state") == 0 || strcmp(current_string->array, "nextState") == 0) { next_state = 1; }
-			if(strcmp(current_string->array, "/next_state") == 0 || strcmp(current_string->array, "/nextState") == 0) { next_state = 0; }
-			if(strcmp(current_string->array, "currentState") == 0) { cur_state = 1; }
-			if(strcmp(current_string->array, "/currentState") == 0) { cur_state = 0; }
-			if(strcmp(current_string->array, "nextState") == 0) { next_state = 1; }
-			if(strcmp(current_string->array, "/nextState") == 0) { next_state = 0; }
-			if(strcmp(current_string->array, "input") == 0)
-			{
-				input = 1;
+                    current_variable = current_variable->next;
+                }
+            }
+            if(strcmp(current_string->array, "functions") == 0) {
+                functions = 1;
+            }
+            if(strcmp(current_string->array, "/functions") == 0) {
+                functions = 0;
+            }
+            if(strcmp(current_string->array, "functionFiles") == 0) {
+                functions = 1;
+            }
+            if(strcmp(current_string->array, "/functionFiles") == 0) {
+                functions = 0;
+            }
+            if(strcmp(current_string->array, "current_state") == 0 || strcmp(current_string->array, "currentState") == 0) {
+                cur_state = 1;
+            }
+            if(strcmp(current_string->array, "/current_state") == 0 || strcmp(current_string->array, "/currentState") == 0) {
+                cur_state = 0;
+            }
+            if(strcmp(current_string->array, "next_state") == 0 || strcmp(current_string->array, "nextState") == 0) {
+                next_state = 1;
+            }
+            if(strcmp(current_string->array, "/next_state") == 0 || strcmp(current_string->array, "/nextState") == 0) {
+                next_state = 0;
+            }
+            if(strcmp(current_string->array, "currentState") == 0) {
+                cur_state = 1;
+            }
+            if(strcmp(current_string->array, "/currentState") == 0) {
+                cur_state = 0;
+            }
+            if(strcmp(current_string->array, "nextState") == 0) {
+                next_state = 1;
+            }
+            if(strcmp(current_string->array, "/nextState") == 0) {
+                next_state = 0;
+            }
+            if(strcmp(current_string->array, "input") == 0) {
+                input = 1;
 
-				current_ioput = addioput(&current_function->inputs);
-				current_ioput->function = current_function;
-				/* Default random setting is false */
-				current_ioput->random = 0;
-			}
-			if(strcmp(current_string->array, "/input") == 0) { input = 0; }
-			if(strcmp(current_string->array, "output") == 0)
-			{
-				output = 1;
+                current_ioput = addioput(&current_function->inputs);
+                current_ioput->function = current_function;
+                /* Default random setting is false */
+                current_ioput->random = 0;
+            }
+            if(strcmp(current_string->array, "/input") == 0) {
+                input = 0;
+            }
+            if(strcmp(current_string->array, "output") == 0) {
+                output = 1;
 
-				current_ioput = addioput(&current_function->outputs);
-				current_ioput->function = current_function;
-			}
-			if(strcmp(current_string->array, "/output") == 0) { output = 0; }
-			if(strcmp(current_string->array, "messagetype") == 0 || strcmp(current_string->array, "messageName") == 0) { messagetype = 1; }
-			if(strcmp(current_string->array, "/messagetype") == 0 || strcmp(current_string->array, "/messageName") == 0) { messagetype = 0; }
-			if(strcmp(current_string->array, "function") == 0)
-			{
-				function = 1;
+                current_ioput = addioput(&current_function->outputs);
+                current_ioput->function = current_function;
+            }
+            if(strcmp(current_string->array, "/output") == 0) {
+                output = 0;
+            }
+            if(strcmp(current_string->array, "messagetype") == 0 || strcmp(current_string->array, "messageName") == 0) {
+                messagetype = 1;
+            }
+            if(strcmp(current_string->array, "/messagetype") == 0 || strcmp(current_string->array, "/messageName") == 0) {
+                messagetype = 0;
+            }
+            if(strcmp(current_string->array, "function") == 0) {
+                function = 1;
 
-				if(environment == 1)
-				{
-					current_envfunc = addenvfunc(modeldata->p_envfuncs);
-				}
-				else
-				{
-					/*current_function = addxfunction(p_xfunctions);*/
-					current_function = addxfunction(&current_xmachine->functions);
-					fcode = NULL;
-					/*current_trans = addtrans(&current_function->depends);*/
-					current_function->file = copystr(inputfile->fullfilepath);
-				}
-			}
-			if(strcmp(current_string->array, "/function") == 0)
-			{
-				function = 0;
+                if(environment == 1) {
+                    current_envfunc = addenvfunc(modeldata->p_envfuncs);
+                } else {
+                    /*current_function = addxfunction(p_xfunctions);*/
+                    current_function = addxfunction(&current_xmachine->functions);
+                    fcode = NULL;
+                    /*current_trans = addtrans(&current_function->depends);*/
+                    current_function->file = copystr(inputfile->fullfilepath);
+                }
+            }
+            if(strcmp(current_string->array, "/function") == 0) {
+                function = 0;
 
-				current_function->agent_name = copystr(current_xmachine->name);
+                current_function->agent_name = copystr(current_xmachine->name);
 
-				if(current_function->current_state != NULL) addxstate(current_function->current_state, current_function->agent_name, &current_xmachine->states);
-				if(current_function->next_state != NULL) addxstate(current_function->next_state, current_function->agent_name, &current_xmachine->states);
+                if(current_function->current_state != NULL) addxstate(current_function->current_state, current_function->agent_name, &current_xmachine->states);
+                if(current_function->next_state != NULL) addxstate(current_function->next_state, current_function->agent_name, &current_xmachine->states);
 
-				/*if(current_function->has_radius1d) printf("%s has radius1d\n", current_function->name);
+                /*if(current_function->has_radius1d) printf("%s has radius1d\n", current_function->name);
                 if(current_function->has_radius2d) printf("%s has radius2d\n", current_function->name);
                 if(current_function->has_radius3d) printf("%s has radius3d\n", current_function->name);
                 if(current_function->has_apothem1d) printf("%s has apothem1d\n", current_function->name);
                 if(current_function->has_apothem2d) printf("%s has apothem2d\n", current_function->name);
                 if(current_function->has_apothem3d) printf("%s has apothem3d\n", current_function->name);*/
-			}
-			if(strcmp(current_string->array, "header") == 0) { header = 1; current_envfunc = addenvfunc(modeldata->p_envfuncs); }
-			if(strcmp(current_string->array, "/header") == 0) { header = 0; }
-			if(strcmp(current_string->array, "note") == 0) { note = 1; }
-			if(strcmp(current_string->array, "/note") == 0) { note = 0; }
-			if(strcmp(current_string->array, "desc") == 0 || strcmp(current_string->array, "description") == 0) { desc = 1; }
-			if(strcmp(current_string->array, "/desc") == 0 || strcmp(current_string->array, "/description") == 0) { desc = 0; }
-			if(strcmp(current_string->array, "message") == 0)
-			{
-				message = 1;
-				current_message = addxmessage(modeldata->p_xmessages);
-				tvariable = NULL;
-				modeldata->number_messages++;
-				current_message->file = copystr(inputfile->fullfilepath);
-			}
-			if(strcmp(current_string->array, "/message") == 0)
-			{
-				message = 0;
-				current_message->vars = *p_variable;
+            }
+            if(strcmp(current_string->array, "header") == 0) {
+                header = 1;
+                current_envfunc = addenvfunc(modeldata->p_envfuncs);
+            }
+            if(strcmp(current_string->array, "/header") == 0) {
+                header = 0;
+            }
+            if(strcmp(current_string->array, "note") == 0) {
+                note = 1;
+            }
+            if(strcmp(current_string->array, "/note") == 0) {
+                note = 0;
+            }
+            if(strcmp(current_string->array, "desc") == 0 || strcmp(current_string->array, "description") == 0) {
+                desc = 1;
+            }
+            if(strcmp(current_string->array, "/desc") == 0 || strcmp(current_string->array, "/description") == 0) {
+                desc = 0;
+            }
+            if(strcmp(current_string->array, "message") == 0) {
+                message = 1;
+                current_message = addxmessage(modeldata->p_xmessages);
+                tvariable = NULL;
+                modeldata->number_messages++;
+                current_message->file = copystr(inputfile->fullfilepath);
+            }
+            if(strcmp(current_string->array, "/message") == 0) {
+                message = 0;
+                current_message->vars = *p_variable;
 
-				/* Count number of variables */
-				variable_count = 0;
-				/* Find unallowed dynamic arrays */
-				dynamic_array_found = 0;
-				current_variable = current_message->vars;
-				while(current_variable)
-				{
-					variable_count++;
-					if(current_variable->arraylength == -1 || (current_variable->ismodeldatatype == 1 && current_variable->datatype->has_dynamic_arrays == 1))
-					{
-						fprintf(stderr, "Error: %s - dyamic array found in message\n", current_variable->name);
-						dynamic_array_found = 1;
-					}
+                /* Count number of variables */
+                variable_count = 0;
+                /* Find unallowed dynamic arrays */
+                dynamic_array_found = 0;
+                current_variable = current_message->vars;
+                while(current_variable) {
+                    variable_count++;
+                    if(current_variable->arraylength == -1 || (current_variable->ismodeldatatype == 1 && current_variable->datatype->has_dynamic_arrays == 1)) {
+                        fprintf(stderr, "Error: %s - dyamic array found in message\n", current_variable->name);
+                        dynamic_array_found = 1;
+                    }
 
-					current_variable->message = current_message;
+                    current_variable->message = current_message;
 
-					current_variable = current_variable->next;
-				}
+                    current_variable = current_variable->next;
+                }
 
-				if(dynamic_array_found == 1)
-				{
-					fprintf(stderr, "Error: Dynamic array found in %s message\n", current_message->name);
-					exit(1);
-				}
+                if(dynamic_array_found == 1) {
+                    fprintf(stderr, "Error: Dynamic array found in %s message\n", current_message->name);
+                    exit(1);
+                }
 
-				current_message->var_number = variable_count;
-			}
-			if(strcmp(current_string->array, "code") == 0)
-			{
-				/*printf("in code == 0\n");*/
+                current_message->var_number = variable_count;
+            }
+            if(strcmp(current_string->array, "code") == 0) {
+                /*printf("in code == 0\n");*/
 
-				code = 1;
-				cdata = 1;
-				/*charlist = NULL;*/
-				reset_char_array(current_string);
-				if(environment == 0 && iteration_end_code == 0)
-				{
-					current_fcode = addfcode(p_fcode);
-				}
-			}
-			if(strcmp(current_string->array, "/code") == 0) { code = 0; }
-			if(strcmp(current_string->array, "file") == 0) { codefile = 1; } /* actually handled in cdata */
-			if(strcmp(current_string->array, "/file") == 0) { codefile = 0; }
-			if(strcmp(current_string->array, "iteration_end_code") == 0) { iteration_end_code = 1; }
-			if(strcmp(current_string->array, "/iteration_end_code") == 0) { iteration_end_code = 0; }
-			if(strcmp(current_string->array, "timeunit") == 0 || strcmp(current_string->array, "timeUnit") == 0)
-			{
-				timetag = 1;
-			}
-			if(strcmp(current_string->array, "/timeunit") == 0 || strcmp(current_string->array, "/timeUnit") == 0)
-			{
-				timetag = 0;
-				add_time_unit(time_name, unit_name, period_int, modeldata->p_time_units);
-			}
-			if(strcmp(current_string->array, "unit") == 0) { unit = 1; }
-			if(strcmp(current_string->array, "/unit") == 0) { unit = 0; }
-			if(strcmp(current_string->array, "time") == 0)
-			{
-				if(lhs || rhs)
-				{
-					last_rule_data = current_rule_data;
-					if(lhs_last) { current_rule_data = add_rule_data(&current_rule_data->lhs_rule); }
-					else { current_rule_data = add_rule_data(&current_rule_data->rhs_rule); }
-				}
-				else //if(condition)
-				{
-					current_rule_data = add_rule_data(&current_function->condition_rule);
-				}
+                code = 1;
+                cdata = 1;
+                /*charlist = NULL;*/
+                reset_char_array(current_string);
+                if(environment == 0 && iteration_end_code == 0) {
+                    current_fcode = addfcode(p_fcode);
+                }
+            }
+            if(strcmp(current_string->array, "/code") == 0) {
+                code = 0;
+            }
+            if(strcmp(current_string->array, "file") == 0) {
+                codefile = 1;    /* actually handled in cdata */
+            }
+            if(strcmp(current_string->array, "/file") == 0) {
+                codefile = 0;
+            }
+            if(strcmp(current_string->array, "iteration_end_code") == 0) {
+                iteration_end_code = 1;
+            }
+            if(strcmp(current_string->array, "/iteration_end_code") == 0) {
+                iteration_end_code = 0;
+            }
+            if(strcmp(current_string->array, "timeunit") == 0 || strcmp(current_string->array, "timeUnit") == 0) {
+                timetag = 1;
+            }
+            if(strcmp(current_string->array, "/timeunit") == 0 || strcmp(current_string->array, "/timeUnit") == 0) {
+                timetag = 0;
+                add_time_unit(time_name, unit_name, period_int, modeldata->p_time_units);
+            }
+            if(strcmp(current_string->array, "unit") == 0) {
+                unit = 1;
+            }
+            if(strcmp(current_string->array, "/unit") == 0) {
+                unit = 0;
+            }
+            if(strcmp(current_string->array, "time") == 0) {
+                if(lhs || rhs) {
+                    last_rule_data = current_rule_data;
+                    if(lhs_last) {
+                        current_rule_data = add_rule_data(&current_rule_data->lhs_rule);
+                    } else {
+                        current_rule_data = add_rule_data(&current_rule_data->rhs_rule);
+                    }
+                } else { //if(condition)
+                    current_rule_data = add_rule_data(&current_function->condition_rule);
+                }
 
-				current_rule_data->time_rule = 1;
-				if(not == 1) {
-				    current_rule_data->not = 1;
-				    not = 0;
-				}
-			}
-			if(strcmp(current_string->array, "/time") == 0)
-			{
-				current_rule_data = last_rule_data;
-			}
-			if(strcmp(current_string->array, "period") == 0) { period = 1; }
-			if(strcmp(current_string->array, "/period") == 0) { period = 0; }
-			if(strcmp(current_string->array, "phase") == 0) { phase = 1; }
-			if(strcmp(current_string->array, "/phase") == 0) { phase = 0; }
-			if(strcmp(current_string->array, "not") == 0) { not = 1; }
-			if(strcmp(current_string->array, "/not") == 0) { not = 0; }
-			if(strcmp(current_string->array, "lhs") == 0)
-			{
-				lhs = 1;
+                current_rule_data->time_rule = 1;
+                if(not == 1) {
+                    current_rule_data->not = 1;
+                    not = 0;
+                }
+            }
+            if(strcmp(current_string->array, "/time") == 0) {
+                current_rule_data = last_rule_data;
+            }
+            if(strcmp(current_string->array, "period") == 0) {
+                period = 1;
+            }
+            if(strcmp(current_string->array, "/period") == 0) {
+                period = 0;
+            }
+            if(strcmp(current_string->array, "phase") == 0) {
+                phase = 1;
+            }
+            if(strcmp(current_string->array, "/phase") == 0) {
+                phase = 0;
+            }
+            if(strcmp(current_string->array, "not") == 0) {
+                not = 1;
+            }
+            if(strcmp(current_string->array, "/not") == 0) {
+                not = 0;
+            }
+            if(strcmp(current_string->array, "lhs") == 0) {
+                lhs = 1;
 
-				if(current_rule_data == NULL)
-				{
-					if(condition) { current_rule_data = add_rule_data(&current_function->condition_rule); }
-					if(filter) { current_rule_data = add_rule_data(&current_ioput->filter_rule); }
-					//last_rule_data = NULL;
-				}
-				else
-				{
-					last_rule_data = current_rule_data;
-					if(lhs_last) { current_rule_data = add_rule_data(&current_rule_data->lhs_rule); }
-					else { current_rule_data = add_rule_data(&current_rule_data->rhs_rule); }
-					current_rule_data->parent_rule = last_rule_data;
-				}
+                if(current_rule_data == NULL) {
+                    if(condition) {
+                        current_rule_data = add_rule_data(&current_function->condition_rule);
+                    }
+                    if(filter) {
+                        current_rule_data = add_rule_data(&current_ioput->filter_rule);
+                    }
+                    //last_rule_data = NULL;
+                } else {
+                    last_rule_data = current_rule_data;
+                    if(lhs_last) {
+                        current_rule_data = add_rule_data(&current_rule_data->lhs_rule);
+                    } else {
+                        current_rule_data = add_rule_data(&current_rule_data->rhs_rule);
+                    }
+                    current_rule_data->parent_rule = last_rule_data;
+                }
 
-				if(not == 1) {
-				    current_rule_data->not = 1;
-				    not = 0;
-				}
+                if(not == 1) {
+                    current_rule_data->not = 1;
+                    not = 0;
+                }
 
-				lhs_last = 1;
-			}
-			if(strcmp(current_string->array, "/lhs") == 0) { lhs = 0; }
-			if(strcmp(current_string->array, "rhs") == 0)
-			{
-				rhs = 1;
-				lhs_last = 0;
-			}
-			if(strcmp(current_string->array, "/rhs") == 0)
-			{
-				rhs = 0;
-				current_rule_data = current_rule_data->parent_rule;
-			}
-			if(strcmp(current_string->array, "op") == 0) { op = 1; }
-			if(strcmp(current_string->array, "/op") == 0) { op = 0; }
-			if(strcmp(current_string->array, "condition") == 0)
-			{
-				condition = 1;
-				current_rule_data = NULL;
-				// not_value = 0;
-			}
-			if(strcmp(current_string->array, "/condition") == 0)
-			{
-				condition = 0;
-				// if(not_value == 1) { current_rule_data->not = 1; printf("*********** condition is not\n"); }
-			}
-			if(strcmp(current_string->array, "model") == 0)
-			{
-				model = 1;
-				current_input_file = add_input_file(modeldata->p_files);
-			}
-			if(strcmp(current_string->array, "/model") == 0)
-			{
-				model = 0;
+                lhs_last = 1;
+            }
+            if(strcmp(current_string->array, "/lhs") == 0) {
+                lhs = 0;
+            }
+            if(strcmp(current_string->array, "rhs") == 0) {
+                rhs = 1;
+                lhs_last = 0;
+            }
+            if(strcmp(current_string->array, "/rhs") == 0) {
+                rhs = 0;
+                current_rule_data = current_rule_data->parent_rule;
+            }
+            if(strcmp(current_string->array, "op") == 0) {
+                op = 1;
+            }
+            if(strcmp(current_string->array, "/op") == 0) {
+                op = 0;
+            }
+            if(strcmp(current_string->array, "condition") == 0) {
+                condition = 1;
+                current_rule_data = NULL;
+                // not_value = 0;
+            }
+            if(strcmp(current_string->array, "/condition") == 0) {
+                condition = 0;
+                // if(not_value == 1) { current_rule_data->not = 1; printf("*********** condition is not\n"); }
+            }
+            if(strcmp(current_string->array, "model") == 0) {
+                model = 1;
+                current_input_file = add_input_file(modeldata->p_files);
+            }
+            if(strcmp(current_string->array, "/model") == 0) {
+                model = 0;
 
-				printf("- Nested model   : %s ", current_input_file->fullfilepath);
-				if(current_input_file->enabled == 1) printf("(enabled)\n");
-				else printf("(disabled)\n");
-			}
-			if(strcmp(current_string->array, "depends") == 0)
-			{
-				depends = 1;
-				/*charlist = NULL;*/
-				current_adj_function = add_depends_adj_function(current_function);
+                printf("- Nested model   : %s ", current_input_file->fullfilepath);
+                if(current_input_file->enabled == 1) printf("(enabled)\n");
+                else printf("(disabled)\n");
+            }
+            if(strcmp(current_string->array, "depends") == 0) {
+                depends = 1;
+                /*charlist = NULL;*/
+                current_adj_function = add_depends_adj_function(current_function);
 
-				modeldata->depends_style = 1;
-			}
-			if(strcmp(current_string->array, "/depends") == 0)
-			{
-				depends = 0;
+                modeldata->depends_style = 1;
+            }
+            if(strcmp(current_string->array, "/depends") == 0) {
+                depends = 0;
 
-				//add_adj_function(current_function2, current_function, "internal");
+                //add_adj_function(current_function2, current_function, "internal");
 
-				//printf("depends: %s %s %s\n", current_function->name, current_adj_function->name, current_adj_function->type);
+                //printf("depends: %s %s %s\n", current_function->name, current_adj_function->name, current_adj_function->type);
 
 
-				/*printf("depends: ");
-				printcharlist(&current_trans->func);
-				printf(" ");
-				printcharlist(&current_trans->dest);
-				printf("\n");*/
+                /*printf("depends: ");
+                printcharlist(&current_trans->func);
+                printf(" ");
+                printcharlist(&current_trans->dest);
+                printf("\n");*/
 
-			}
-			if(strcmp(current_string->array, "filter") == 0)
-			{
-				filter = 1;
-				current_rule_data = NULL;
-			}
-			if(strcmp(current_string->array, "/filter") == 0)
-			{
-				filter = 0;
-				/* Check if filter rule contains agent/message variables */
-				current_ioput->filter_rule->has_agent_var = checkRuleAgentVar(current_ioput->filter_rule);
-				current_ioput->filter_rule->has_message_var = checkRuleMessageVar(current_ioput->filter_rule);
+            }
+            if(strcmp(current_string->array, "filter") == 0) {
+                filter = 1;
+                current_rule_data = NULL;
+            }
+            if(strcmp(current_string->array, "/filter") == 0) {
+                filter = 0;
+                /* Check if filter rule contains agent/message variables */
+                current_ioput->filter_rule->has_agent_var = checkRuleAgentVar(current_ioput->filter_rule);
+                current_ioput->filter_rule->has_message_var = checkRuleMessageVar(current_ioput->filter_rule);
 
-				/* Update function is say certain filters are being used */
-				/*if(current_ioput->filter_rule->radius == 1) current_function->has_radius1d = 1;
-				if(current_ioput->filter_rule->radius == 2) current_function->has_radius2d = 1;
-				if(current_ioput->filter_rule->radius == 3) current_function->has_radius3d = 1;
-				if(current_ioput->filter_rule->apothem == 1) current_function->has_apothem1d = 1;
-				if(current_ioput->filter_rule->apothem == 2) current_function->has_apothem2d = 1;
-				if(current_ioput->filter_rule->apothem == 3) current_function->has_apothem3d = 1;*/
+                /* Update function is say certain filters are being used */
+                /*if(current_ioput->filter_rule->radius == 1) current_function->has_radius1d = 1;
+                if(current_ioput->filter_rule->radius == 2) current_function->has_radius2d = 1;
+                if(current_ioput->filter_rule->radius == 3) current_function->has_radius3d = 1;
+                if(current_ioput->filter_rule->apothem == 1) current_function->has_apothem1d = 1;
+                if(current_ioput->filter_rule->apothem == 2) current_function->has_apothem2d = 1;
+                if(current_ioput->filter_rule->apothem == 3) current_function->has_apothem3d = 1;*/
 
-				/* Test code */
-				/*if(current_ioput->filter_rule->radius > 0)
-				    printf("%s input filter radius%dd = '%s'\n",
-				            current_ioput->messagetype,
-				            current_ioput->filter_rule->radius,
-				            current_ioput->filter_rule->lhs);
-				if(current_ioput->filter_rule->apothem > 0)
+                /* Test code */
+                /*if(current_ioput->filter_rule->radius > 0)
+                    printf("%s input filter radius%dd = '%s'\n",
+                            current_ioput->messagetype,
+                            current_ioput->filter_rule->radius,
+                            current_ioput->filter_rule->lhs);
+                if(current_ioput->filter_rule->apothem > 0)
                     printf("%s input filter apothem%dd = '%s'\n",
                             current_ioput->messagetype,
                             current_ioput->filter_rule->apothem,
                             current_ioput->filter_rule->lhs);*/
-			}
-			if(strcmp(current_string->array, "value") == 0) { value = 1; }
-			if(strcmp(current_string->array, "/value") == 0) { value = 0; }
-			if(strcmp(current_string->array, "enabled") == 0) { enabled = 1; }
-			if(strcmp(current_string->array, "/enabled") == 0) { enabled = 0; }
-			if(strcmp(current_string->array, "random") == 0) { random = 1; }
-			if(strcmp(current_string->array, "/random") == 0) { random = 0; }
-			if(strcmp(current_string->array, "sort") == 0) { sort = 1; }
-			if(strcmp(current_string->array, "/sort") == 0) { sort = 0; }
-			if(strcmp(current_string->array, "constant") == 0) { constant = 1; }
-			if(strcmp(current_string->array, "/constant") == 0) { constant = 0; }
-			if(strcmp(current_string->array, "order") == 0) { order = 1; }
-			if(strcmp(current_string->array, "/order") == 0) { order = 0; }
-			if(strcmp(current_string->array, "key") == 0) { key = 1; }
-			if(strcmp(current_string->array, "/key") == 0) { key = 0; }
+            }
+            if(strcmp(current_string->array, "value") == 0) {
+                value = 1;
+            }
+            if(strcmp(current_string->array, "/value") == 0) {
+                value = 0;
+            }
+            if(strcmp(current_string->array, "enabled") == 0) {
+                enabled = 1;
+            }
+            if(strcmp(current_string->array, "/enabled") == 0) {
+                enabled = 0;
+            }
+            if(strcmp(current_string->array, "random") == 0) {
+                random = 1;
+            }
+            if(strcmp(current_string->array, "/random") == 0) {
+                random = 0;
+            }
+            if(strcmp(current_string->array, "sort") == 0) {
+                sort = 1;
+            }
+            if(strcmp(current_string->array, "/sort") == 0) {
+                sort = 0;
+            }
+            if(strcmp(current_string->array, "constant") == 0) {
+                constant = 1;
+            }
+            if(strcmp(current_string->array, "/constant") == 0) {
+                constant = 0;
+            }
+            if(strcmp(current_string->array, "order") == 0) {
+                order = 1;
+            }
+            if(strcmp(current_string->array, "/order") == 0) {
+                order = 0;
+            }
+            if(strcmp(current_string->array, "key") == 0) {
+                key = 1;
+            }
+            if(strcmp(current_string->array, "/key") == 0) {
+                key = 0;
+            }
             if(strcmp(current_string->array, "box2d") == 0) {
                 /* Check last tag before this one was filter */
-                if(strcmp("filter", &chartag[numtag-2][0]) != 0)
-                {
+                if(strcmp("filter", &chartag[numtag-2][0]) != 0) {
                     fprintf(stderr, "ERROR: The tag box2d must be used after a filter tag only\n");
                     exit(1);
                 }
@@ -898,11 +948,12 @@ void readModel(input_file * inputfile, char * directory, model_data * modeldata)
                 current_rule_data = add_rule_data(&current_ioput->filter_rule);
                 current_rule_data->box = 2;
             }
-            if(strcmp(current_string->array, "/box2d") == 0) { box2d = 0; }
+            if(strcmp(current_string->array, "/box2d") == 0) {
+                box2d = 0;
+            }
             if(strcmp(current_string->array, "box3d") == 0) {
                 /* Check last tag before this one was filter */
-                if(strcmp("filter", &chartag[numtag-2][0]) != 0)
-                {
+                if(strcmp("filter", &chartag[numtag-2][0]) != 0) {
                     fprintf(stderr, "ERROR: The tag box3d must be used after a filter tag only\n");
                     exit(1);
                 }
@@ -910,1372 +961,1235 @@ void readModel(input_file * inputfile, char * directory, model_data * modeldata)
                 current_rule_data = add_rule_data(&current_ioput->filter_rule);
                 current_rule_data->box = 3;
             }
-            if(strcmp(current_string->array, "/box3d") == 0) { box3d = 0; }
+            if(strcmp(current_string->array, "/box3d") == 0) {
+                box3d = 0;
+            }
 
-			/* End of tag and reset buffer */
-			intag = 0;
-			/*i = 0;*/
-			reset_char_array(current_string);
-			/* Reset xml code char list */
-			xmlcode = 0;
-		}
-		/* If start of tag */
-		else if(c == '<')
-		{
-			/* Place /0 at end of buffer to end numbers or string*/
-			/*buffer[i] = 0;*/
-			/* Flag in tag */
-			intag = 1;
-			xmlcomment = 1;
+            /* End of tag and reset buffer */
+            intag = 0;
+            /*i = 0;*/
+            reset_char_array(current_string);
+            /* Reset xml code char list */
+            xmlcode = 0;
+        }
+        /* If start of tag */
+        else if(c == '<') {
+            /* Place /0 at end of buffer to end numbers or string*/
+            /*buffer[i] = 0;*/
+            /* Flag in tag */
+            intag = 1;
+            xmlcomment = 1;
 
-			if(model)
-			{
-				if(enabled)
-				{
-					temp_char = copy_array_to_str(current_string);
-					if(strcmp(temp_char, "true") == 0) current_input_file->enabled = 1;
-					if(strcmp(temp_char, "false") == 0) current_input_file->enabled = 0;
-					free(temp_char);
-				}
-				if(codefile)
-				{
-					temp_char = copy_array_to_str(current_string);
-					temp_char2 = (char *)malloc( (strlen(temp_char) + strlen(directory) + 1) * sizeof(char));
-					strcpy(temp_char2, directory);
-					strcat(temp_char2, temp_char);
-					current_input_file->file = copy_array_to_str(current_string);
-					current_input_file->fullfilepath = copystr(temp_char2);
-					current_input_file->fulldirectory = copystr(temp_char2);
-					current_input_file->localdirectory = copystr(temp_char);
-					temp_char2[0] = 0;
-					free(temp_char2);
-					free(temp_char);
+            if(model) {
+                if(enabled) {
+                    temp_char = copy_array_to_str(current_string);
+                    if(strcmp(temp_char, "true") == 0) current_input_file->enabled = 1;
+                    if(strcmp(temp_char, "false") == 0) current_input_file->enabled = 0;
+                    free(temp_char);
+                }
+                if(codefile) {
+                    temp_char = copy_array_to_str(current_string);
+                    temp_char2 = (char *)malloc( (strlen(temp_char) + strlen(directory) + 1) * sizeof(char));
+                    strcpy(temp_char2, directory);
+                    strcat(temp_char2, temp_char);
+                    current_input_file->file = copy_array_to_str(current_string);
+                    current_input_file->fullfilepath = copystr(temp_char2);
+                    current_input_file->fulldirectory = copystr(temp_char2);
+                    current_input_file->localdirectory = copystr(temp_char);
+                    temp_char2[0] = 0;
+                    free(temp_char2);
+                    free(temp_char);
 
-					/* calculate directory of file */
-					/* Calculate directory where xparser and template files are */
-					i = 0;
-					lastd = 0;
-					while(current_input_file->fulldirectory[i] != '\0')
-					{
-						/* For windows directories */
-						if(current_input_file->fulldirectory[i] == '\\') lastd=i;
-						/* For unix directories */
-						if(current_input_file->fulldirectory[i] == '/') lastd=i;
-						i++;
-					}
-					/* If a directory is in the path */
-					if(lastd != 0)
-					{
-						current_input_file->fulldirectory[lastd+1] = '\0';
-					}
-					else current_input_file->fulldirectory[0] = '\0';
-
-					i = 0;
-					lastd = 0;
-					while(current_input_file->localdirectory[i] != '\0')
-					{
-						/* For windows directories */
-						if(current_input_file->localdirectory[i] == '\\') lastd=i;
-						/* For unix directories */
-						if(current_input_file->localdirectory[i] == '/') lastd=i;
-						i++;
-					}
-					/* If a directory is in the path */
-					if(lastd != 0)
-					{
-						current_input_file->localdirectory[lastd+1] = '\0';
-					}
-					else current_input_file->localdirectory[0] = '\0';
-				}
-			}
-			if(environment)
-			{
-				if(timetag)
-				{
-					if(name)
-					{
-						free(time_name);
-						time_name = copy_array_to_str(current_string);
-					}
-					if(unit)
-					{
-						free(unit_name);
-						unit_name = copy_array_to_str(current_string);
-					}
-					if(period)
-					{
-						period_int = atoi(current_string->array);
-					}
-				}
-				else if(datatype)
-				{
-
-					if(var)
-					{
-						if(type) { handleVariableType(current_string, current_variable, modeldata); }
-						if(name) { handleVariableName(current_string, current_variable); }
-						if(desc) current_variable->description = copy_array_to_str(current_string);
-					}
-					else if(name)
-					{
-						current_datatype->name = copy_array_to_str(current_string);
-						printf("- Datatype : %s\n", current_datatype->name);
-					}
-                    else if(desc)
-                    {
-					    current_datatype->desc = copy_array_to_str(current_string);
+                    /* calculate directory of file */
+                    /* Calculate directory where xparser and template files are */
+                    i = 0;
+                    lastd = 0;
+                    while(current_input_file->fulldirectory[i] != '\0') {
+                        /* For windows directories */
+                        if(current_input_file->fulldirectory[i] == '\\') lastd=i;
+                        /* For unix directories */
+                        if(current_input_file->fulldirectory[i] == '/') lastd=i;
+                        i++;
                     }
-				}
-				else if(var)
-				{
-					if(type)
-					{
-						current_variable->type = copy_array_to_str(current_string);
+                    /* If a directory is in the path */
+                    if(lastd != 0) {
+                        current_input_file->fulldirectory[lastd+1] = '\0';
+                    } else current_input_file->fulldirectory[0] = '\0';
 
-						strcpy(current_variable->defaultvalue, "");
-						strcpy(current_variable->c_type, "");
+                    i = 0;
+                    lastd = 0;
+                    while(current_input_file->localdirectory[i] != '\0') {
+                        /* For windows directories */
+                        if(current_input_file->localdirectory[i] == '\\') lastd=i;
+                        /* For unix directories */
+                        if(current_input_file->localdirectory[i] == '/') lastd=i;
+                        i++;
+                    }
+                    /* If a directory is in the path */
+                    if(lastd != 0) {
+                        current_input_file->localdirectory[lastd+1] = '\0';
+                    } else current_input_file->localdirectory[0] = '\0';
+                }
+            }
+            if(environment) {
+                if(timetag) {
+                    if(name) {
+                        free(time_name);
+                        time_name = copy_array_to_str(current_string);
+                    }
+                    if(unit) {
+                        free(unit_name);
+                        unit_name = copy_array_to_str(current_string);
+                    }
+                    if(period) {
+                        period_int = atoi(current_string->array);
+                    }
+                } else if(datatype) {
 
-						if(strcmp(current_variable->type, "int") == 0 ||
-							strcmp(current_variable->type, "short int") == 0 ||
-							strcmp(current_variable->type, "long int") == 0 ||
-							strcmp(current_variable->type, "unsigned int") == 0 ||
-							strcmp(current_variable->type, "unsigned short int") == 0 ||
-							strcmp(current_variable->type, "unsigned long int") == 0)
-						{
-							strcpy(current_variable->defaultvalue, "0");
-							strcpy(current_variable->c_type, "i");
-						}
+                    if(var) {
+                        if(type) {
+                            handleVariableType(current_string, current_variable, modeldata);
+                        }
+                        if(name) {
+                            handleVariableName(current_string, current_variable);
+                        }
+                        if(desc) current_variable->description = copy_array_to_str(current_string);
+                    } else if(name) {
+                        current_datatype->name = copy_array_to_str(current_string);
+                        printf("- Datatype : %s\n", current_datatype->name);
+                    } else if(desc) {
+                        current_datatype->desc = copy_array_to_str(current_string);
+                    }
+                } else if(var) {
+                    if(type) {
+                        current_variable->type = copy_array_to_str(current_string);
 
-						if(strcmp(current_variable->type, "double") == 0 ||
-							strcmp(current_variable->type, "float") == 0)
-						{
-							strcpy(current_variable->defaultvalue, "0.0");
-							strcpy(current_variable->c_type, "f");
-						}
+                        strcpy(current_variable->defaultvalue, "");
+                        strcpy(current_variable->c_type, "");
 
-						if(strcmp(current_variable->type, "char") == 0 ||
-							strcmp(current_variable->type, "unsigned char") == 0)
-						{
-							strcpy(current_variable->defaultvalue, "' '");
-							strcpy(current_variable->c_type, "c");
-						}
-					}
-					if(name) current_variable->name = copy_array_to_str(current_string);
-					if(desc) current_variable->description = copy_array_to_str(current_string);
-				}
-				else if(define)
-				{
-					if(name) current_envdefine->name = copy_array_to_str(current_string);
-					if(value)
-					{
-						strcpy(current_envdefine->value, "");
-						current_envdefine->value = copy_array_to_str(current_string);
-					}
-					strcpy(current_envdefine->type, "");
-				}
+                        if(strcmp(current_variable->type, "int") == 0 ||
+                                strcmp(current_variable->type, "short int") == 0 ||
+                                strcmp(current_variable->type, "long int") == 0 ||
+                                strcmp(current_variable->type, "unsigned int") == 0 ||
+                                strcmp(current_variable->type, "unsigned short int") == 0 ||
+                                strcmp(current_variable->type, "unsigned long int") == 0) {
+                            strcpy(current_variable->defaultvalue, "0");
+                            strcpy(current_variable->c_type, "i");
+                        }
 
-				if(codefile)
-				{
-					if(functions)
-					{
-						current_envfunc = addenvfunc(modeldata->p_envfuncs);
-						current_envfunc->header = 2;
-					}
+                        if(strcmp(current_variable->type, "double") == 0 ||
+                                strcmp(current_variable->type, "float") == 0) {
+                            strcpy(current_variable->defaultvalue, "0.0");
+                            strcpy(current_variable->c_type, "f");
+                        }
 
+                        if(strcmp(current_variable->type, "char") == 0 ||
+                                strcmp(current_variable->type, "unsigned char") == 0) {
+                            strcpy(current_variable->defaultvalue, "' '");
+                            strcpy(current_variable->c_type, "c");
+                        }
+                    }
+                    if(name) {
+                        current_variable->name = copy_array_to_str(current_string);
+                        if(strcmp(current_variable->name,"GSL_RNG_SEED") == 0) {
+                            printf("- Environment variable GSL_RNG_SEED found: using GSL\n");
+                            modeldata->gsl_lib = 1;
+                        }
+                    }
+                    if(desc) current_variable->description = copy_array_to_str(current_string);
+                } else if(define) {
+                    if(name) current_envdefine->name = copy_array_to_str(current_string);
+                    if(value) {
+                        strcpy(current_envdefine->value, "");
+                        current_envdefine->value = copy_array_to_str(current_string);
+                    }
+                    strcpy(current_envdefine->type, "");
+                }
 
-					/* Place directory at start of chardata */
-					j = 0;
-					while(*inputfile->localdirectory != 0)
-					{
-						chardata[j] = *inputfile->localdirectory;
-						(inputfile->localdirectory)++;
-						j++;
-					}
-					/* Make directory pointer point to start of chars again */
-					for(k = 0; k < j; k++)
-					{
-						(inputfile->localdirectory)--;
-					}
-
-					chardata[j] = '\0';
-					strcat(chardata, current_string->array);
-
-					current_envfunc->filepath = copystr(chardata);
-					//printf("inputfile->directory: %s\n", inputfile->localdirectory);
-					//printf("current_envfunc->filepath: %s\n", current_envfunc->filepath);
-
-
-					/* Place directory at start of chardata */
-					j = 0;
-					while(*inputfile->fulldirectory != 0)
-					{
-						chardata[j] = *inputfile->fulldirectory;
-						(inputfile->fulldirectory)++;
-						j++;
-					}
-					/* Make directory pointer point to start of chars again */
-					for(k = 0; k < j; k++)
-					{
-						(inputfile->fulldirectory)--;
-					}
-
-					chardata[j] = '\0';
-
-
-
-					/* Add file name to chardata on end of directory */
-					/*current_charlist = *p_charlist;
-					while(current_charlist)
-					{
-						chardata[j] = current_charlist->character;
-						j++;
-
-						current_charlist = current_charlist->next;
-					}
-					chardata[j] = 0;*/
-
-					strcat(chardata, current_string->array);
-					/*printf("01\t%s\n", chardata);*/
-
-					/* Open code file read-only */
-					if((filecode = fopen(chardata, "r"))==NULL)
-					{
-						fprintf(stderr, "ERROR - cannot read file: %s\n", chardata);
-						printf("*** xparser aborted ***\n");
-						exit(0);
-					}
-					/* else printf("- Loading file : %s\n", chardata); */
-
-					/*charlist = NULL;*/
-					reset_char_array(current_string);
-
-					if(functions)
-					{
-				         printf("- Functions file : %s\n", chardata); 
-					}
-					else
-					{
-						/* Read characters until the end of the file */
-						while(c != (char)EOF)
-						{
-							/* Get the next char from the file */
-							c = (char)fgetc(filecode);
-
-							if(c != (char)EOF)
-							{
-								/*current_charlist = addchar(p_charlist);*/
-								/*current_charlist->character = c;*/
-								add_char(current_string, c);
-							}
-						}
+                if(codefile) {
+                    if(functions) {
+                        current_envfunc = addenvfunc(modeldata->p_envfuncs);
+                        current_envfunc->header = 2;
+                    }
 
 
-						/*if(environment == 1) current_envfunc->code = *p_charlist;*/
-						/*else current_fcode->code = *p_charlist;*/
-					}
+                    /* Place directory at start of chardata */
+                    j = 0;
+                    while(*inputfile->localdirectory != 0) {
+                        chardata[j] = *inputfile->localdirectory;
+                        (inputfile->localdirectory)++;
+                        j++;
+                    }
+                    /* Make directory pointer point to start of chars again */
+                    for(k = 0; k < j; k++) {
+                        (inputfile->localdirectory)--;
+                    }
 
-					/* Close the file */
-					fclose(filecode);
-				}
+                    chardata[j] = '\0';
+                    strcat(chardata, current_string->array);
 
-				if(code && function)
-				{
-					current_envfunc->code = copy_array_to_str(current_string);
-					current_envfunc->header = 0;
-				}
-				if(header) current_envfunc->header = 1;
-			}
-			else if(var)
-			{
-				if(type) { handleVariableType(current_string, current_variable, modeldata); }
-				if(name) { handleVariableName(current_string, current_variable); }
-				if(constant)
-				{
-					temp_char = copy_array_to_str(current_string);
-					if(strcmp(temp_char, "true") == 0) current_variable->constant = 1;
-					if(strcmp(temp_char, "false") == 0) current_variable->constant = 0;
-					free(temp_char);
-				}
-				if(desc) current_variable->description = copy_array_to_str(current_string);
-			}
-			else if(message)
-			{
-				if(name)
-				{
-					current_message->name = copy_array_to_str(current_string);
-					printf("- Message  : ");
-					printf("%s", current_message->name);
-					printf("\n");
-				}
-				if(desc) current_message->description = copy_array_to_str(current_string);
-			}
+                    current_envfunc->filepath = copystr(chardata);
+                    //printf("inputfile->directory: %s\n", inputfile->localdirectory);
+                    //printf("current_envfunc->filepath: %s\n", current_envfunc->filepath);
+
+
+                    /* Place directory at start of chardata */
+                    j = 0;
+                    while(*inputfile->fulldirectory != 0) {
+                        chardata[j] = *inputfile->fulldirectory;
+                        (inputfile->fulldirectory)++;
+                        j++;
+                    }
+                    /* Make directory pointer point to start of chars again */
+                    for(k = 0; k < j; k++) {
+                        (inputfile->fulldirectory)--;
+                    }
+
+                    chardata[j] = '\0';
+
+
+
+                    /* Add file name to chardata on end of directory */
+                    /*current_charlist = *p_charlist;
+                    while(current_charlist)
+                    {
+                    	chardata[j] = current_charlist->character;
+                    	j++;
+
+                    	current_charlist = current_charlist->next;
+                    }
+                    chardata[j] = 0;*/
+
+                    strcat(chardata, current_string->array);
+                    /*printf("01\t%s\n", chardata);*/
+
+                    /* Open code file read-only */
+                    if((filecode = fopen(chardata, "r"))==NULL) {
+                        fprintf(stderr, "ERROR - cannot read file: %s\n", chardata);
+                        printf("*** xparser aborted ***\n");
+                        exit(0);
+                    }
+                    /* else printf("- Loading file : %s\n", chardata); */
+
+                    /*charlist = NULL;*/
+                    reset_char_array(current_string);
+
+                    if(functions) {
+                        printf("- Functions file : %s\n", chardata);
+                    } else {
+                        /* Read characters until the end of the file */
+                        while(c != (char)EOF) {
+                            /* Get the next char from the file */
+                            c = (char)fgetc(filecode);
+
+                            if(c != (char)EOF) {
+                                /*current_charlist = addchar(p_charlist);*/
+                                /*current_charlist->character = c;*/
+                                add_char(current_string, c);
+                            }
+                        }
+
+
+                        /*if(environment == 1) current_envfunc->code = *p_charlist;*/
+                        /*else current_fcode->code = *p_charlist;*/
+                    }
+
+                    /* Close the file */
+                    fclose(filecode);
+                }
+
+                if(code && function) {
+                    current_envfunc->code = copy_array_to_str(current_string);
+                    current_envfunc->header = 0;
+                }
+                if(header) current_envfunc->header = 1;
+            } else if(var) {
+                if(type) {
+                    handleVariableType(current_string, current_variable, modeldata);
+                }
+                if(name) {
+                    handleVariableName(current_string, current_variable);
+                }
+                if(constant) {
+                    temp_char = copy_array_to_str(current_string);
+                    if(strcmp(temp_char, "true") == 0) current_variable->constant = 1;
+                    if(strcmp(temp_char, "false") == 0) current_variable->constant = 0;
+                    free(temp_char);
+                }
+                if(desc) current_variable->description = copy_array_to_str(current_string);
+            } else if(message) {
+                if(name) {
+                    current_message->name = copy_array_to_str(current_string);
+                    printf("- Message  : ");
+                    printf("%s", current_message->name);
+                    printf("\n");
+                }
+                if(desc) current_message->description = copy_array_to_str(current_string);
+            }
             /*
-             ** (lsc) "current_state" is never assigned. 
+             ** (lsc) "current_state" is never assigned.
              **  Is this legacy code accidentally left behind?
              **  Comment it out just in case. This can go really wrong if branch taken.
              ********
-			else if(state)
-			{
-				if(name) current_state->name = copy_array_to_str(current_string);
-			}
+            else if(state)
+            {
+            	if(name) current_state->name = copy_array_to_str(current_string);
+            }
             */
-			else if(function)
-			{
-				if(codefile)
-				{
-					/* Place directory at start of chardata */
-					/*j = 0;
-					while(*directory != 0)
-					{
-						chardata[j] = *directory;
-						(directory)++;
-						j++;
-					}*/
-					/* Make directory pointer point to start of chars again */
-					/*for(k = 0; k < j; k++)
-					{
-						(directory)--;
-					}*/
-					/* Add file name to chardata on end of directory */
-					/*current_charlist = copy_array_to_str(current_string);
-					while(current_charlist)
-					{
-						chardata[j] = current_charlist->character;
-						j++;
+            else if(function) {
+                if(codefile) {
+                    /* Place directory at start of chardata */
+                    /*j = 0;
+                    while(*directory != 0)
+                    {
+                    	chardata[j] = *directory;
+                    	(directory)++;
+                    	j++;
+                    }*/
+                    /* Make directory pointer point to start of chars again */
+                    /*for(k = 0; k < j; k++)
+                    {
+                    	(directory)--;
+                    }*/
+                    /* Add file name to chardata on end of directory */
+                    /*current_charlist = copy_array_to_str(current_string);
+                    while(current_charlist)
+                    {
+                    	chardata[j] = current_charlist->character;
+                    	j++;
 
-						current_charlist = current_charlist->next;
-					}
-					chardata[j] = 0;*/
-					/*printf("01\t%s\n", chardata);*/
+                    	current_charlist = current_charlist->next;
+                    }
+                    chardata[j] = 0;*/
+                    /*printf("01\t%s\n", chardata);*/
 
-					strcpy(chardata, directory);
-					strcat(chardata, copy_array_to_str(current_string));
+                    strcpy(chardata, directory);
+                    strcat(chardata, copy_array_to_str(current_string));
 
-					/* Open code file read-only */
-					if((filecode = fopen(chardata, "r"))==NULL)
-					{
-						fprintf(stderr, "ERROR - cannot read file: %s\n", chardata);
-						printf("*** xparser aborted ***\n");
-						exit(0);
-					}
-					else printf("reading file: %s\n", chardata);
+                    /* Open code file read-only */
+                    if((filecode = fopen(chardata, "r"))==NULL) {
+                        fprintf(stderr, "ERROR - cannot read file: %s\n", chardata);
+                        printf("*** xparser aborted ***\n");
+                        exit(0);
+                    } else printf("reading file: %s\n", chardata);
 
-					/*charlist = NULL;*/
-					reset_char_array(current_string);
+                    /*charlist = NULL;*/
+                    reset_char_array(current_string);
 
-					/* Read characters until the end of the file */
-					while(c != (char)EOF)
-					{
-						/* Get the next char from the file */
-						c = (char)fgetc(filecode);
+                    /* Read characters until the end of the file */
+                    while(c != (char)EOF) {
+                        /* Get the next char from the file */
+                        c = (char)fgetc(filecode);
 
-						if(c != (char)EOF)
-						{
-							/*current_charlist = addchar(p_charlist);*/
-							/*current_charlist->character = c;*/
-							add_char(current_string, c);
-						}
-					}
+                        if(c != (char)EOF) {
+                            /*current_charlist = addchar(p_charlist);*/
+                            /*current_charlist->character = c;*/
+                            add_char(current_string, c);
+                        }
+                    }
 
-					/*if(environment == 1) current_envfunc->code = *p_charlist;*/
-					/*else current_fcode->code = *p_charlist;*/
+                    /*if(environment == 1) current_envfunc->code = *p_charlist;*/
+                    /*else current_fcode->code = *p_charlist;*/
 
-					/* Close the file */
-					fclose(filecode);
-				}
+                    /* Close the file */
+                    fclose(filecode);
+                }
 
-				if(name && depends == 0) current_function->name = copy_array_to_str(current_string);
-				if(note) current_function->note = copy_array_to_str(current_string);
-				if(code) { current_fcode->code = copy_array_to_str(current_string); }
-				if(cur_state) current_function->current_state = copy_array_to_str(current_string);
-				if(next_state) current_function->next_state = copy_array_to_str(current_string);
-				if(input)
-				{
-					if(messagetype) current_ioput->messagetype = copy_array_to_str(current_string);
-					if(random)
-					{
-						temp_char = copy_array_to_str(current_string);
-						if(strcmp(temp_char, "true") == 0) current_ioput->random = 1;
-						if(strcmp(temp_char, "false") == 0) current_ioput->random = 0;
-						free(temp_char);
-					}
-					if(sort)
-					{
-						if(key) current_ioput->sort_key = copy_array_to_str(current_string);
-						if(order) current_ioput->sort_order = copy_array_to_str(current_string);
-						
-						/*current_ioput->sort_function = copy_array_to_str(current_string);*/
-					}
-					if(filter)
-					{
-						if(lhs && value)
-						{
-							current_rule_data->lhs = copy_array_to_str(current_string);
-							current_rule_data->lhs_print = copy_array_to_str(current_string);
-						}
-						else if(op)
-						{
-							current_rule_data->op = copy_array_to_str(current_string);
-							current_rule_data->op_print = copy_array_to_str(current_string);
-						}
-						else if(rhs && value)
-						{
-							current_rule_data->rhs = copy_array_to_str(current_string);
-							current_rule_data->rhs_print = copy_array_to_str(current_string);
-						}
-						else if(box2d || box3d)
-						{
-						    /* Copy to both lhs and rhs so checkRule* still works */
-						    current_rule_data->lhs = copy_array_to_str(current_string);
+                if(name && depends == 0) current_function->name = copy_array_to_str(current_string);
+                if(note) current_function->note = copy_array_to_str(current_string);
+                if(code) {
+                    current_fcode->code = copy_array_to_str(current_string);
+                }
+                if(cur_state) current_function->current_state = copy_array_to_str(current_string);
+                if(next_state) current_function->next_state = copy_array_to_str(current_string);
+                if(input) {
+                    if(messagetype) current_ioput->messagetype = copy_array_to_str(current_string);
+                    if(random) {
+                        temp_char = copy_array_to_str(current_string);
+                        if(strcmp(temp_char, "true") == 0) current_ioput->random = 1;
+                        if(strcmp(temp_char, "false") == 0) current_ioput->random = 0;
+                        free(temp_char);
+                    }
+                    if(sort) {
+                        if(key) current_ioput->sort_key = copy_array_to_str(current_string);
+                        if(order) current_ioput->sort_order = copy_array_to_str(current_string);
+
+                        /*current_ioput->sort_function = copy_array_to_str(current_string);*/
+                    }
+                    if(filter) {
+                        if(lhs && value) {
+                            current_rule_data->lhs = copy_array_to_str(current_string);
+                            current_rule_data->lhs_print = copy_array_to_str(current_string);
+                        } else if(op) {
+                            current_rule_data->op = copy_array_to_str(current_string);
+                            current_rule_data->op_print = copy_array_to_str(current_string);
+                        } else if(rhs && value) {
+                            current_rule_data->rhs = copy_array_to_str(current_string);
+                            current_rule_data->rhs_print = copy_array_to_str(current_string);
+                        } else if(box2d || box3d) {
+                            /* Copy to both lhs and rhs so checkRule* still works */
+                            current_rule_data->lhs = copy_array_to_str(current_string);
                             current_rule_data->lhs_print = copy_array_to_str(current_string);
                             current_rule_data->rhs = copy_array_to_str(current_string);
                             current_rule_data->rhs_print = copy_array_to_str(current_string);
-						}
-					}
-				}
-				if(output)
-				{
-					if(messagetype) current_ioput->messagetype = copy_array_to_str(current_string);
-				}
-				if(condition)
-				{
-					if(lhs && value)
-					{
-						current_rule_data->lhs = copy_array_to_str(current_string);
-						current_rule_data->lhs_print = copy_array_to_str(current_string);
-					}
-					else if(op)
-					{
-						current_rule_data->op = copy_array_to_str(current_string);
-						current_rule_data->op_print = copy_array_to_str(current_string);
-					}
-					else if(rhs && value)
-					{
-						current_rule_data->rhs = copy_array_to_str(current_string);
-						current_rule_data->rhs_print = copy_array_to_str(current_string);
-					}
-					//else current_function->condition_function = copy_array_to_str(current_string);
-					if(period) current_rule_data->lhs = copy_array_to_str(current_string);
-					if(phase) current_rule_data->rhs = copy_array_to_str(current_string);
-				}
-				if(depends)
-				{
-					if(name) { current_adj_function->name = copy_array_to_str(current_string); }/*charlist = NULL; */
-					if(type) { current_adj_function->type = copy_array_to_str(current_string); }/*charlist = NULL; */
-				}
-				if(desc) current_function->description = copy_array_to_str(current_string);
-			}
-			else if(xmachine && !memory && !function)
-			{
-				if(name)
-				{
-					current_xmachine = addxmachine(modeldata->p_xmachines, current_string->array);
-					printf("- xagent   : ");
-					printf("%s", current_xmachine->name);
-					printf("\n");
-				}
-			}
-			else if(iteration_end_code)
-			{
-				if(code)
-				{
-					end_it_fcode = addfcode(modeldata->p_it_end_code);
-					end_it_fcode->code = copy_array_to_str(current_string);
-				}
-			}
-			else if(name)
-			{
-				if(modeldata->name == NULL) modeldata->name = copy_array_to_str(current_string);
-				printf("- Model name     : ");
-				printf("%s", current_string->array);
-				printf("\n");
-			}
+                        }
+                    }
+                }
+                if(output) {
+                    if(messagetype) current_ioput->messagetype = copy_array_to_str(current_string);
+                }
+                if(condition) {
+                    if(lhs && value) {
+                        current_rule_data->lhs = copy_array_to_str(current_string);
+                        current_rule_data->lhs_print = copy_array_to_str(current_string);
+                    } else if(op) {
+                        current_rule_data->op = copy_array_to_str(current_string);
+                        current_rule_data->op_print = copy_array_to_str(current_string);
+                    } else if(rhs && value) {
+                        current_rule_data->rhs = copy_array_to_str(current_string);
+                        current_rule_data->rhs_print = copy_array_to_str(current_string);
+                    }
+                    //else current_function->condition_function = copy_array_to_str(current_string);
+                    if(period) current_rule_data->lhs = copy_array_to_str(current_string);
+                    if(phase) current_rule_data->rhs = copy_array_to_str(current_string);
+                }
+                if(depends) {
+                    if(name) {
+                        current_adj_function->name = copy_array_to_str(current_string);    /*charlist = NULL; */
+                    }
+                    if(type) {
+                        current_adj_function->type = copy_array_to_str(current_string);    /*charlist = NULL; */
+                    }
+                }
+                if(desc) current_function->description = copy_array_to_str(current_string);
+            } else if(xmachine && !memory && !function) {
+                if(name) {
+                    current_xmachine = addxmachine(modeldata->p_xmachines, current_string->array);
+                    printf("- xagent   : ");
+                    printf("%s", current_xmachine->name);
+                    printf("\n");
+                }
+            } else if(iteration_end_code) {
+                if(code) {
+                    end_it_fcode = addfcode(modeldata->p_it_end_code);
+                    end_it_fcode->code = copy_array_to_str(current_string);
+                }
+            } else if(name) {
+                if(modeldata->name == NULL) modeldata->name = copy_array_to_str(current_string);
+                printf("- Model name     : ");
+                printf("%s", current_string->array);
+                printf("\n");
+            }
 
-			/* Reset buffer */
-			/*i = 0;*/
-			reset_char_array(current_string);
-		}
-		/* If in tag put read char into buffer */
-		else if(intag)
-		{
-			if(xmlcomment > 0)
-			{
-				if(xmlcomment == 1)
-				{
-					if(c == '!') { xmlcomment = 2; }
-					else { xmlcomment = 0; add_char(current_string, c); }
-				}
-				else if(xmlcomment == 2)
-				{
-					if(c == '-') { xmlcomment = 3; }
-					else { xmlcomment = 0; add_char(current_string, '!'); add_char(current_string, c); }
-				}
-				else if(xmlcomment == 3)
-				{
-					if(c == '-') { xmlcomment = 4; }
-					else { xmlcomment = 0; add_char(current_string, '!'); add_char(current_string, '-'); add_char(current_string, c);}
-				}
-			}
-			else
-			{
-				/*buffer[i] = c;*/
-				/*i++;*/
-				add_char(current_string, c);
-			}
-		}
-		/* If in data read char into buffer */
-		else if(model || enabled || codefile || ((iteration_end_code && code) || codefile || name || type || desc || (memory && (var && (type || name || constant || desc)))) ||
-					(message && (name || (var && (type || name))))
-                    /* (lsc) rule trimmed as "attribute" and "transition" never set! */
-					|| (state && (name /* attribute || (transition && (func || dest))*/ ))
-						|| (function && (not || name || note || code || depends || type || cur_state ||
-						        next_state || input || output || messagetype || value || period ||
-						        phase || var || order || box2d || box3d))
-							|| (define && (name || value)) || (timetag && (name || unit || period)) || condition )
-		{
-			/*current_charlist = addchar(p_charlist);*/
-			/*current_charlist->character = c;*/
-			add_char(current_string, c);
-		}
-	}
+            /* Reset buffer */
+            /*i = 0;*/
+            reset_char_array(current_string);
+        }
+        /* If in tag put read char into buffer */
+        else if(intag) {
+            if(xmlcomment > 0) {
+                if(xmlcomment == 1) {
+                    if(c == '!') {
+                        xmlcomment = 2;
+                    } else {
+                        xmlcomment = 0;
+                        add_char(current_string, c);
+                    }
+                } else if(xmlcomment == 2) {
+                    if(c == '-') {
+                        xmlcomment = 3;
+                    } else {
+                        xmlcomment = 0;
+                        add_char(current_string, '!');
+                        add_char(current_string, c);
+                    }
+                } else if(xmlcomment == 3) {
+                    if(c == '-') {
+                        xmlcomment = 4;
+                    } else {
+                        xmlcomment = 0;
+                        add_char(current_string, '!');
+                        add_char(current_string, '-');
+                        add_char(current_string, c);
+                    }
+                }
+            } else {
+                /*buffer[i] = c;*/
+                /*i++;*/
+                add_char(current_string, c);
+            }
+        }
+        /* If in data read char into buffer */
+        else if(model || enabled || codefile || ((iteration_end_code && code) || codefile || name || type || desc || (memory && (var && (type || name || constant || desc)))) ||
+                (message && (name || (var && (type || name))))
+                /* (lsc) rule trimmed as "attribute" and "transition" never set! */
+                || (state && (name /* attribute || (transition && (func || dest))*/ ))
+                || (function && (not || name || note || code || depends || type || cur_state ||
+                                 next_state || input || output || messagetype || value || period ||
+                                 phase || var || order || box2d || box3d))
+                || (define && (name || value)) || (timetag && (name || unit || period)) || condition ) {
+            /*current_charlist = addchar(p_charlist);*/
+            /*current_charlist->character = c;*/
+            add_char(current_string, c);
+        }
+    }
 
-	/* Free memory */
-	free(time_name);
-	free(unit_name);
-	free_char_array(current_string);
+    /* Free memory */
+    free(time_name);
+    free(unit_name);
+    free_char_array(current_string);
 
-	/* Close the file */
-	fclose(file);
+    /* Close the file */
+    fclose(file);
 }
 
 void handleRuleValue(char ** p_value, variable ** p_variable, rule_data * current_rule_data, xmachine_function * current_function, xmachine * current_xmachine, char * messagetype, model_data * modeldata)
 {
-	variable * current_variable;
-	xmachine_message * current_message;
-	//xmachine * current_xmachine2;
-	char buffer[1000];
-	int found, i, j;
+    variable * current_variable;
+    xmachine_message * current_message;
+    //xmachine * current_xmachine2;
+    char buffer[1000];
+    int found, i, j;
 
-	/* Check if the value is empty */
-	if(strcmp(*p_value, "") == 0) {
-	    fprintf(stderr, "ERROR: value missing in filter rule\n");
+    /* Check if the value is empty */
+    if(strcmp(*p_value, "") == 0) {
+        fprintf(stderr, "ERROR: value missing in filter rule\n");
         fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
         fprintf(stderr, "       in file: '%s'\n", current_function->file);
         exit(0);
-	}
+    }
 
-	/* If starts with 'a.' change to 'a->' and check rest is a valid agent memory variable */
-	if(strncmp(*p_value, "a.", 2) == 0)
-	{
-		/* check valid agent memory variable */
-		found = 0;
-		strcpy(buffer, *p_value+2);
-		current_variable = current_xmachine->variables;
-		while(current_variable)
-		{
-			if(strcmp(buffer, current_variable->name) == 0)
-			{	
-				found = 1;
-				*p_variable = current_variable;
-			}
+    /* If starts with 'a.' change to 'a->' and check rest is a valid agent memory variable */
+    if(strncmp(*p_value, "a.", 2) == 0) {
+        /* check valid agent memory variable */
+        found = 0;
+        strcpy(buffer, *p_value+2);
+        current_variable = current_xmachine->variables;
+        while(current_variable) {
+            if(strcmp(buffer, current_variable->name) == 0) {
+                found = 1;
+                *p_variable = current_variable;
+            }
 
-			current_variable = current_variable->next;
-		}
-		if(found == 0)
-		{
-			fprintf(stderr, "ERROR: value '%s' in filter rule not in agent memory\n", buffer);
-			fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
-			fprintf(stderr, "       in file: '%s'\n", current_function->file);
-			exit(0);
-		}
+            current_variable = current_variable->next;
+        }
+        if(found == 0) {
+            fprintf(stderr, "ERROR: value '%s' in filter rule not in agent memory\n", buffer);
+            fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
+            fprintf(stderr, "       in file: '%s'\n", current_function->file);
+            exit(0);
+        }
 
-		/* Save agent variable to message type agent_var filter list */
-/*		current_message = *modeldata->p_xmessages;
-		if(messagetype == NULL) current_message = NULL;
-		while(current_message)
-		{
-			if(strcmp(messagetype, current_message->name) == 0)
-			{
-				// Check agent variable not already in list
-				found = 0;
+        /* Save agent variable to message type agent_var filter list */
+        /*		current_message = *modeldata->p_xmessages;
+        		if(messagetype == NULL) current_message = NULL;
+        		while(current_message)
+        		{
+        			if(strcmp(messagetype, current_message->name) == 0)
+        			{
+        				// Check agent variable not already in list
+        				found = 0;
 
 
-				for(current_xmachine2 = current_message->agents; current_xmachine2; current_xmachine2 = current_xmachine2->next)
-				{
-					if(strcmp(current_xmachine2->name, current_xmachine->name) == 0)
-					{
-						for(current_variable = current_xmachine2->variables; current_variable; current_variable = current_variable->next)
-						{
-							if(strcmp(current_variable->name, buffer) == 0) found = 1;
-						}
-					}
-				}
+        				for(current_xmachine2 = current_message->agents; current_xmachine2; current_xmachine2 = current_xmachine2->next)
+        				{
+        					if(strcmp(current_xmachine2->name, current_xmachine->name) == 0)
+        					{
+        						for(current_variable = current_xmachine2->variables; current_variable; current_variable = current_variable->next)
+        						{
+        							if(strcmp(current_variable->name, buffer) == 0) found = 1;
+        						}
+        					}
+        				}
 
 
 
-				if(found == 0)
-				{
-					current_xmachine2 = addxmachine(&current_message->agents, current_xmachine->name);
-					// TODO
+        				if(found == 0)
+        				{
+        					current_xmachine2 = addxmachine(&current_message->agents, current_xmachine->name);
+        					// TODO
 
-					current_variable = addvariable(&current_xmachine2->variables);
-					current_variable->name = copystr(buffer);
-					current_variable->type = copystr((*p_variable)->type);
-					current_variable->agent = current_xmachine;
-					strcpy(current_variable->c_type, (*p_variable)->c_type);
-				}
-			}
+        					current_variable = addvariable(&current_xmachine2->variables);
+        					current_variable->name = copystr(buffer);
+        					current_variable->type = copystr((*p_variable)->type);
+        					current_variable->agent = current_xmachine;
+        					strcpy(current_variable->c_type, (*p_variable)->c_type);
+        				}
+        			}
 
-			current_message = current_message->next;
-		}*/
+        			current_message = current_message->next;
+        		}*/
 
-		/* Update value */
-		strcpy(buffer, "a->");
-		strcat(buffer, *p_value+2);
-		free(*p_value);
-		*p_value = copystr(buffer);
-	}
-	/* If starts with 'm.' change to 'm->' and check rest is a valid message variable */
-	else if(strncmp(*p_value, "m.", 2) == 0)
-	{
-		found = 0;
-		strcpy(buffer, *p_value+2);
-		current_message = *modeldata->p_xmessages;
-		while(current_message)
-		{
-			if(strcmp(messagetype, current_message->name) == 0)
-			{
-				current_variable = current_message->vars;
-				while(current_variable)
-				{
-					if(strcmp(buffer, current_variable->name) == 0)
-					{
-						found = 1;
-						*p_variable = current_variable;
-					}
+        /* Update value */
+        strcpy(buffer, "a->");
+        strcat(buffer, *p_value+2);
+        free(*p_value);
+        *p_value = copystr(buffer);
+    }
+    /* If starts with 'm.' change to 'm->' and check rest is a valid message variable */
+    else if(strncmp(*p_value, "m.", 2) == 0) {
+        found = 0;
+        strcpy(buffer, *p_value+2);
+        current_message = *modeldata->p_xmessages;
+        while(current_message) {
+            if(strcmp(messagetype, current_message->name) == 0) {
+                current_variable = current_message->vars;
+                while(current_variable) {
+                    if(strcmp(buffer, current_variable->name) == 0) {
+                        found = 1;
+                        *p_variable = current_variable;
+                    }
 
-					current_variable = current_variable->next;
-				}
-			}
+                    current_variable = current_variable->next;
+                }
+            }
 
-			current_message = current_message->next;
-		}
-		if(found == 0)
-		{
-			fprintf(stderr, "ERROR: value '%s' in filter rule not in message variables\n", buffer);
-			fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
-			fprintf(stderr, "       in file: '%s'\n", current_function->file);
-			exit(0);
-		}
+            current_message = current_message->next;
+        }
+        if(found == 0) {
+            fprintf(stderr, "ERROR: value '%s' in filter rule not in message variables\n", buffer);
+            fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
+            fprintf(stderr, "       in file: '%s'\n", current_function->file);
+            exit(0);
+        }
 
-		strcpy(buffer, "m->");
-		strcat(buffer, *p_value+2);
-		free(*p_value);
-		*p_value = copystr(buffer);
-	}
-	/* If algorithm (i.e. radius check) then parser a. and m. to a-> and m-> */
-	else
-	{
-		//printf("%s\n", *p_value);
-		j = 0;
-		for(i = 0; i < (int)strlen(*p_value); i++)
-		{
-			//printf("[%d] %c\n", i, (*p_value)[i]);
-			if(i > 0)
-			{
-				if(((*p_value)[i-1] == 'a' || (*p_value)[i-1] == 'm') && (*p_value)[i] == '.')
-				{
-					buffer[j] = '-';
-					buffer[++j] = '>';
-				}
-				else buffer[j] = (*p_value)[i];
-			}
-			else buffer[j] = (*p_value)[i];
+        strcpy(buffer, "m->");
+        strcat(buffer, *p_value+2);
+        free(*p_value);
+        *p_value = copystr(buffer);
+    }
+    /* If algorithm (i.e. radius check) then parser a. and m. to a-> and m-> */
+    else {
+        //printf("%s\n", *p_value);
+        j = 0;
+        for(i = 0; i < (int)strlen(*p_value); i++) {
+            //printf("[%d] %c\n", i, (*p_value)[i]);
+            if(i > 0) {
+                if(((*p_value)[i-1] == 'a' || (*p_value)[i-1] == 'm') && (*p_value)[i] == '.') {
+                    buffer[j] = '-';
+                    buffer[++j] = '>';
+                } else buffer[j] = (*p_value)[i];
+            } else buffer[j] = (*p_value)[i];
 
-			j++;
-		}
-		buffer[j++] = 0;
-		//printf("buffer = [%s]\n", buffer);
-		free(*p_value);
-		*p_value = copystr(buffer);
-	}
+            j++;
+        }
+        buffer[j++] = 0;
+        //printf("buffer = [%s]\n", buffer);
+        free(*p_value);
+        *p_value = copystr(buffer);
+    }
 
-	/* Check if a number */
+    /* Check if a number */
 
-	/* Check if a time */
+    /* Check if a time */
 
-	/* What else can the value (be allowed) be? environment_constant? */
+    /* What else can the value (be allowed) be? environment_constant? */
 
 }
 
 void handleRule(rule_data * current_rule_data, xmachine_function * current_function, xmachine * current_xmachine, char * messagetype, model_data * modeldata)
 {
-	time_data * current_time_unit;
-	char buffer[100];
+    time_data * current_time_unit;
+    char buffer[100];
 
-	/* If current_rule_data is NULL */
-	if(current_rule_data != NULL)
-	{
-		if(current_rule_data->time_rule == 1)
-		{
-			/* Check period with time units */
-			current_time_unit = * modeldata->p_time_units;
-			while(current_time_unit)
-			{
-				if(strcmp(current_rule_data->lhs, current_time_unit->name) == 0)
-				{
-					sprintf(buffer, "%%%d", current_time_unit->iterations);
-					current_rule_data->op = copystr(buffer);
-				}
+    /* If current_rule_data is NULL */
+    if(current_rule_data != NULL) {
+        if(current_rule_data->time_rule == 1) {
+            /* Check period with time units */
+            current_time_unit = * modeldata->p_time_units;
+            while(current_time_unit) {
+                if(strcmp(current_rule_data->lhs, current_time_unit->name) == 0) {
+                    sprintf(buffer, "%%%d", current_time_unit->iterations);
+                    current_rule_data->op = copystr(buffer);
+                }
 
-				current_time_unit = current_time_unit->next;
-			}
-			if(strcmp(current_rule_data->lhs, "iteration") == 0)
-			{
-				current_rule_data->op = copystr("");
-			}
-			if(current_rule_data->op == NULL)
-			{
-				fprintf(stderr, "ERROR: condition period '%s' is not a time unit\n", current_rule_data->lhs);
-				exit(0);
-			}
-
-			handleRuleValue(&current_rule_data->rhs, &current_rule_data->rhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
-		}
-		else if(current_rule_data->box > 0)
-		{
-		    if(current_rule_data->lhs != NULL)  handleRuleValue(&current_rule_data->lhs, &current_rule_data->lhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
-		    else {
-		        fprintf(stderr, "ERROR: The value of a box filter is missing\n");
+                current_time_unit = current_time_unit->next;
+            }
+            if(strcmp(current_rule_data->lhs, "iteration") == 0) {
+                current_rule_data->op = copystr("");
+            }
+            if(current_rule_data->op == NULL) {
+                fprintf(stderr, "ERROR: condition period '%s' is not a time unit\n", current_rule_data->lhs);
                 exit(0);
             }
+
+            handleRuleValue(&current_rule_data->rhs, &current_rule_data->rhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
+        } else if(current_rule_data->box > 0) {
+            if(current_rule_data->lhs != NULL)  handleRuleValue(&current_rule_data->lhs, &current_rule_data->lhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
+            else {
+                fprintf(stderr, "ERROR: The value of a box filter is missing\n");
+                exit(0);
+            }
+        } else {
+            /* Handle values */
+            if(current_rule_data->lhs != NULL) handleRuleValue(&current_rule_data->lhs, &current_rule_data->lhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
+            else if(current_rule_data->lhs_rule != NULL) handleRule(current_rule_data->lhs_rule, current_function, current_xmachine, messagetype, modeldata);
+            else {
+                fprintf(stderr, "ERROR: The lhs of a rule is missing\n");
+                exit(0);
+            }
+
+            if(current_rule_data->rhs != NULL) handleRuleValue(&current_rule_data->rhs, &current_rule_data->rhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
+            else if(current_rule_data->rhs_rule != NULL) handleRule(current_rule_data->rhs_rule, current_function, current_xmachine, messagetype, modeldata);
+            else {
+                fprintf(stderr, "ERROR: The rhs of a rule is missing\n");
+                exit(0);
+            }
+
+            /* Handle op */
+            if(strcmp(current_rule_data->op, "EQ") == 0) {
+                strcpy(current_rule_data->op, "==");
+            } else if(strcmp(current_rule_data->op, "NEQ") == 0) {
+                strcpy(current_rule_data->op, "!=");
+            } else if(strcmp(current_rule_data->op, "LEQ") == 0) {
+                strcpy(current_rule_data->op, "<=");
+            } else if(strcmp(current_rule_data->op, "GEQ") == 0) {
+                strcpy(current_rule_data->op, ">=");
+            } else if(strcmp(current_rule_data->op, "LT") == 0) {
+                strcpy(current_rule_data->op, "<");
+            } else if(strcmp(current_rule_data->op, "GT") == 0) {
+                strcpy(current_rule_data->op, ">");
+            } else if(strcmp(current_rule_data->op, "AND") == 0) {
+                strcpy(current_rule_data->op, "&&");
+            } else if(strcmp(current_rule_data->op, "OR") == 0) {
+                strcpy(current_rule_data->op, "||");
+            } else if(strcmp(current_rule_data->op, "IN") == 0) { }
+            else {
+                fprintf(stderr, "ERROR: '%s' operator not one of EQ/NEQ/LEQ/GEQ/LT/GT/AND/OR/IN\n", current_rule_data->op);
+                fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
+                fprintf(stderr, "       in file: '%s'\n", current_function->file);
+                exit(0);
+            }
+
+            /* If op is 'IN' */
+            if(strcmp(current_rule_data->op, "IN") == 0) {
+                /* LHS is not a single integer */
+                if(current_rule_data->lhs_variable->arraylength != 0 || strcmp(current_rule_data->lhs_variable->type, "int") != 0) {
+                    fprintf(stderr, "ERROR: lhs value '%s' in filter rule using op 'IN' is not a single integer\n", current_rule_data->lhs_variable->name);
+                    fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
+                    fprintf(stderr, "       in file: '%s'\n", current_function->file);
+                    exit(0);
+                }
+
+                /* RHS is not a list of integers */
+                if(current_rule_data->rhs_variable->arraylength == 0 || strcmp(current_rule_data->lhs_variable->type, "int") != 0) {
+                    fprintf(stderr, "ERROR: rhs value '%s' in filter rule using op 'IN' is not an array of integers\n", current_rule_data->lhs_variable->name);
+                    fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
+                    fprintf(stderr, "       in file: '%s'\n", current_function->file);
+                    exit(0);
+                }
+            }
         }
-		else
-		{
-			/* Handle values */
-			if(current_rule_data->lhs != NULL) handleRuleValue(&current_rule_data->lhs, &current_rule_data->lhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
-			else if(current_rule_data->lhs_rule != NULL) handleRule(current_rule_data->lhs_rule, current_function, current_xmachine, messagetype, modeldata);
-			else {
-				fprintf(stderr, "ERROR: The lhs of a rule is missing\n");
-				exit(0);
-			}
-
-			if(current_rule_data->rhs != NULL) handleRuleValue(&current_rule_data->rhs, &current_rule_data->rhs_variable, current_rule_data, current_function, current_xmachine, messagetype, modeldata);
-			else if(current_rule_data->rhs_rule != NULL) handleRule(current_rule_data->rhs_rule, current_function, current_xmachine, messagetype, modeldata);
-			else {
-				fprintf(stderr, "ERROR: The rhs of a rule is missing\n");
-				exit(0);
-			}
-
-			/* Handle op */
-			if(strcmp(current_rule_data->op, "EQ") == 0) { strcpy(current_rule_data->op, "=="); }
-			else if(strcmp(current_rule_data->op, "NEQ") == 0) { strcpy(current_rule_data->op, "!="); }
-			else if(strcmp(current_rule_data->op, "LEQ") == 0) { strcpy(current_rule_data->op, "<="); }
-			else if(strcmp(current_rule_data->op, "GEQ") == 0) { strcpy(current_rule_data->op, ">="); }
-			else if(strcmp(current_rule_data->op, "LT") == 0) { strcpy(current_rule_data->op, "<"); }
-			else if(strcmp(current_rule_data->op, "GT") == 0) { strcpy(current_rule_data->op, ">"); }
-			else if(strcmp(current_rule_data->op, "AND") == 0) { strcpy(current_rule_data->op, "&&"); }
-			else if(strcmp(current_rule_data->op, "OR") == 0) { strcpy(current_rule_data->op, "||"); }
-			else if(strcmp(current_rule_data->op, "IN") == 0) { }
-			else
-			{
-				fprintf(stderr, "ERROR: '%s' operator not one of EQ/NEQ/LEQ/GEQ/LT/GT/AND/OR/IN\n", current_rule_data->op);
-				fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
-				fprintf(stderr, "       in file: '%s'\n", current_function->file);
-				exit(0);
-			}
-			
-			/* If op is 'IN' */
-			if(strcmp(current_rule_data->op, "IN") == 0)
-			{
-				/* LHS is not a single integer */
-				if(current_rule_data->lhs_variable->arraylength != 0 || strcmp(current_rule_data->lhs_variable->type, "int") != 0)
-				{
-					fprintf(stderr, "ERROR: lhs value '%s' in filter rule using op 'IN' is not a single integer\n", current_rule_data->lhs_variable->name);
-					fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
-					fprintf(stderr, "       in file: '%s'\n", current_function->file);
-					exit(0);
-				}
-				
-				/* RHS is not a list of integers */
-				if(current_rule_data->rhs_variable->arraylength == 0 || strcmp(current_rule_data->lhs_variable->type, "int") != 0)
-				{
-					fprintf(stderr, "ERROR: rhs value '%s' in filter rule using op 'IN' is not an array of integers\n", current_rule_data->lhs_variable->name);
-					fprintf(stderr, "       in function '%s' %s->%s in agent '%s'\n", current_function->name, current_function->current_state, current_function->next_state, current_xmachine->name);
-					fprintf(stderr, "       in file: '%s'\n", current_function->file);
-					exit(0);
-				}
-			}
-		}
-	}
+    }
 }
 
 int checkmodel(model_data * modeldata)
 {
-	xmachine * current_xmachine;
-	xmachine * current_xmachine2;
-	variable * current_variable;
-	variable * current_variable2;
-	model_datatype * current_datatype;
-	xmachine_function * current_function;
-	xmachine_function * current_function2;
-	adj_function * current_adj_function;
-	xmachine_ioput * current_ioput;
-	xmachine_message * current_message;
-	xmachine_message * current_message2;
-	variable * allvar;
-	char buffer[1000];
-	int variable_count;
-	int found;
-	int state_number;
-	int newlayer = 0;
-	int totallayers = 0;
-	int m = 0;
-	int k;
-	int has_x = 0;
+    xmachine * current_xmachine;
+    xmachine * current_xmachine2;
+    variable * current_variable;
+    variable * current_variable2;
+    model_datatype * current_datatype;
+    xmachine_function * current_function;
+    xmachine_function * current_function2;
+    adj_function * current_adj_function;
+    xmachine_ioput * current_ioput;
+    xmachine_message * current_message;
+    xmachine_message * current_message2;
+    variable * allvar;
+    char buffer[1000];
+    int variable_count;
+    int found;
+    int state_number;
+    int newlayer = 0;
+    int totallayers = 0;
+    int m = 0;
+    int k;
+    int has_x = 0;
     int has_y = 0;
     int has_z = 0;
 
-	/* Check model for:
-	 * agent/message variables are only known data types
-	 * agent/message variables only appear once, show warning for duplicates and show from which files
-	 * try and parse functions files for implementations of functions defined in model xml
-	 * */
-
-	/* Check for no agents */
-	if(*modeldata->p_xmachines == NULL)
-	{
-		fprintf(stderr, "ERROR: no agents defined\n");
-		return -1;
-	}
-
-	/* Check duplicate message names */
-	current_message = * modeldata->p_xmessages;
-	while(current_message)
-	{
-		current_message2 = * modeldata->p_xmessages;
-		{
-			if(current_message != current_message2)
-			{
-				if(strcmp(current_message->name, current_message2->name) == 0)
-				{
-					fprintf(stderr, "ERROR: multiple definitions of message '%s'\n", current_message->name);
-					fprintf(stderr, "       in file: '%s'\n", current_message->file);
-					fprintf(stderr, "       in file: '%s'\n", current_message2->file);
-					return -1;
-				}
-			}
-
-			current_message2 = current_message2->next;
-		}
-
-		current_message = current_message->next;
-	}
-
-	/* Check agent memory variables for being a model data type and update variable attributes */
-	current_xmachine = *modeldata->p_xmachines;
-	current_xmachine2 = NULL;
-	while(current_xmachine)
-	{
-		current_variable = current_xmachine->variables;
-
-		/* Error if no variables */
-		if(current_variable == NULL)
-		{
-			/*fprintf(stderr, "ERROR: agent '%s' has no memory variables\n", current_xmachine->name);
-			return -1;*/
-			fprintf(stderr, "WARNING: no memory variables found in '%s' agent, agent removed from model\n", current_xmachine->name);
-			/* Remove agent from the agent list */
-			if(current_xmachine2 == NULL) * modeldata->p_xmachines = current_xmachine->next;
-			else current_xmachine2->next = current_xmachine->next;
-
-			free(current_xmachine->name);
-			freevariables(&current_xmachine->variables);
-			freexstates(&current_xmachine->states);
-			freexfunctions(&current_xmachine->functions);
-			freestateholder(&current_xmachine->end_states);
-			free(current_xmachine);
-
-			if(current_xmachine2 == NULL) current_xmachine = * modeldata->p_xmachines;
-			else current_xmachine = current_xmachine2->next;
-		}
-		else
-		{
-			/* Error if variables type is not a C type or a data type or an array of these */
-			while(current_variable)
-			{
-				found = 0;
-				if(strcmp(current_variable->type, "int") == 0 ||
-					strcmp(current_variable->type, "short int") == 0 ||
-					strcmp(current_variable->type, "long int") == 0 ||
-					strcmp(current_variable->type, "unsigned int") == 0 ||
-					strcmp(current_variable->type, "unsigned short int") == 0 ||
-					strcmp(current_variable->type, "unsigned long int") == 0 ||
-					strcmp(current_variable->type, "int_array") == 0 ||
-					strcmp(current_variable->type, "double") == 0 ||
-					strcmp(current_variable->type, "float") == 0 ||
-					strcmp(current_variable->type, "double_array") == 0 ||
-					strcmp(current_variable->type, "float_array") == 0 ||
-					strcmp(current_variable->type, "char") == 0 ||
-					strcmp(current_variable->type, "unsigned char") == 0 ||
-					strcmp(current_variable->type, "char_array") == 0)
-					{
-						found = 1;
-					}
-
-					/* Handle model defined data types */
-					current_datatype = * modeldata->p_datatypes;
-					while(current_datatype)
-					{
-						if(strcmp(current_variable->type, current_datatype->name) == 0)
-						{
-							found = 1;
-						}
-
-						strcpy(buffer, current_datatype->name);
-						strcat(buffer, "_array");
-
-						if(strcmp(current_variable->type, buffer) == 0)
-						{
-							found = 1;
-						}
-
-						current_datatype = current_datatype->next;
-					}
-
-					if(found == 0)
-					{
-						fprintf(stderr, "ERROR: type variable '%s' in variable '%s' in agent '%s' doesn't exist\n", current_variable->type, current_variable->name, current_xmachine->name);
-						fprintf(stderr, "       in file: '%s'\n", current_variable->file);
-						return -1;
-					}
-
-				current_variable = current_variable->next;
-			}
-
-				/* Error if a variable name is defined twice in same agent */
-			current_variable = current_xmachine->variables;
-			while(current_variable)
-			{
-				current_variable2 = current_xmachine->variables;
-				while(current_variable2)
-				{
-					if(strcmp(current_variable->name, current_variable2->name) == 0 && current_variable != current_variable2)
-					{
-						fprintf(stderr, "ERROR: multiple uses of variable '%s' in agent '%s'\n", current_variable->name, current_xmachine->name);
-						fprintf(stderr, "       in file: '%s'\n", current_variable->file);
-						fprintf(stderr, "       in file: '%s'\n", current_variable2->file);
-						return -1;
-					}
-
-					current_variable2 = current_variable2->next;
-				}
-
-				current_variable = current_variable->next;
-			}
-
-			current_variable = current_xmachine->variables;
-			while(current_variable)
-			{
-				/* Handle model defined data types */
-				current_datatype = * modeldata->p_datatypes;
-				while(current_datatype)
-				{
-					if(strcmp(current_variable->type, current_datatype->name) == 0)
-					{
-						current_variable->ismodeldatatype = 1;
-						current_variable->datatype = current_datatype;
-					}
-
-					strcpy(buffer, current_datatype->name);
-					strcat(buffer, "_array");
-
-					if(strcmp(current_variable->type, buffer) == 0)
-					{
-						current_variable->ismodeldatatype = 1;
-						current_variable->datatype = current_datatype;
-						current_variable->arraylength = -1;
-					}
-
-					current_datatype = current_datatype->next;
-				}
-
-				current_variable = current_variable->next;
-			}
-
-			/* Compute x,y,z location variables in memory */
-			/* Check for x-axis component as 'posx' or 'px' or 'x' */
-			strcpy(current_xmachine->xvar, "0.0");
-			strcpy(current_xmachine->yvar, "0.0");
-			strcpy(current_xmachine->zvar, "0.0");
-			variable_count = 0;
-
-			current_variable = current_xmachine->variables;
-			while(current_variable)
-			{
-				if(current_variable->arraylength != 0) modeldata->agents_include_array_variables = 1;
-
-				/*copycharlist(&current_variable->name, &chardata[0]);*/
-				if(strcmp(current_variable->name, "x") == 0)    strcpy(current_xmachine->xvar, "x");
-				if(strcmp(current_variable->name, "px") == 0)   strcpy(current_xmachine->xvar, "px");
-				if(strcmp(current_variable->name, "posx") == 0) strcpy(current_xmachine->xvar, "posx");
-				if(strcmp(current_variable->name, "y") == 0)    strcpy(current_xmachine->yvar, "y");
-				if(strcmp(current_variable->name, "py") == 0)   strcpy(current_xmachine->yvar, "py");
-				if(strcmp(current_variable->name, "posy") == 0) strcpy(current_xmachine->yvar, "posy");
-				if(strcmp(current_variable->name, "z") == 0)    strcpy(current_xmachine->zvar, "z");
-				if(strcmp(current_variable->name, "pz") == 0)   strcpy(current_xmachine->zvar, "pz");
-				if(strcmp(current_variable->name, "posz") == 0) strcpy(current_xmachine->zvar, "posz");
-				if(strcmp(current_variable->name, "range") == 0) strcpy(current_xmachine->rangevar, "range");
-				if(strcmp(current_variable->name, "radius") == 0) strcpy(current_xmachine->rangevar, "radius");
-
-				if(strcmp(current_variable->name, "id") == 0) strcpy(current_xmachine->idvar, "id");
-				if(strcmp(current_variable->name, "agent_id") == 0) strcpy(current_xmachine->idvar, "agent_id");
-
-				found = 0;
-				allvar = * modeldata->p_allvars;
-				while(allvar)
-				{
-					/*copycharlist(&allvar->name, &chardata2[0]);*/
-					if(strcmp(current_variable->name, allvar->name) == 0)
-					{
-						found = 1;
-
-						/* If same variable name but different type, this breaks get_ and set_ methods */
-						if(strcmp(current_variable->type, allvar->type) != 0)
-						{
-							fprintf(stderr, "ERROR: variable '%s' defined twice but with different types\n", current_variable->name);
-							return -1;
-						}
-					}
-
-					allvar = allvar->next;
-				}
-				if(found == 0)
-				{
-					allvar = addvariable(modeldata->p_allvars);
-					allvar->name = copystr(current_variable->name);
-					allvar->type = copystr(current_variable->type);
-					allvar->arraylength = current_variable->arraylength;
-					allvar->ismodeldatatype = current_variable->ismodeldatatype;
-					allvar->datatype = current_variable->datatype;
-					allvar->typenotarray = copystr(current_variable->typenotarray);
-					strcpy(allvar->defaultvalue, current_variable->defaultvalue);
-					strcpy(allvar->c_type, current_variable->c_type);
-				}
-
-				variable_count++;
-
-				current_variable = current_variable->next;
-			}
-
-			current_xmachine->var_number = variable_count;
-
-			modeldata->number_xmachines++;
-
-			current_xmachine = current_xmachine->next;
-		}
-	}
-	
-	/* If functions have old style depends tags create states */
-	if(modeldata->depends_style == 1)
-	{
-		/* Go through all adj functions in depends
-		 * and link the function pointer to the actual function */
-		current_xmachine = *modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				current_adj_function = current_function->depends;
-				while(current_adj_function)
-				{
-					current_xmachine2 = *modeldata->p_xmachines;
-					while(current_xmachine2)
-					{
-						current_function2 = current_xmachine2->functions;
-						while(current_function2)
-						{
-							if(strcmp(current_adj_function->name, current_function2->name) == 0)
-							{
-								//printf("** %s -> %s == %s\n", current_function->name, current_adj_function->name, current_function2->name);
-								current_adj_function->function = current_function2;
-							}
-
-							current_function2 = current_function2->next;
-						}
-
-						current_xmachine2 = current_xmachine2->next;
-					}
-
-					current_adj_function = current_adj_function->next;
-				}
-
-				current_function = current_function->next;
-			}
-
-			current_xmachine = current_xmachine->next;
-		}
-
-		/* Find order of functions in each agent */
-		newlayer = 0;
-		m = 0;
-		while(m == 0)
-		{
-			/* For each agent */
-			current_xmachine = * modeldata->p_xmachines;
-			while(current_xmachine)
-			{
-				/* For each function */
-				current_function = current_xmachine->functions;
-				while(current_function)
-				{
-					/* If rank_in is unknown */
-					if(current_function->rank_in == -1)
-					{
-						k = 0;
-						/* Search dependencies on the current function */
-						current_adj_function = current_function->depends;
-						while(current_adj_function)
-						{
-							/* Check if the function has a dependency on it (and not from itself) */
-							/* Check to see if the dependency is a function and not be assigned a layer in last layers */
-							if(current_adj_function->function->rank_in == -1 || current_adj_function->function->rank_in == newlayer)
-							{
-								/* Change flag to say there is a dependency */
-								k = 1;
-							}
-
-							current_adj_function = current_adj_function->next;
-						}
-						if(k == 0)
-						{
-							current_function->rank_in = newlayer;
-
-							printf("%s - %s - %d\n", current_xmachine->name, current_function->name, newlayer);
-
-							//addfunction_pointer(&current_layer->functions, current_function);
-						}
-					}
-
-					current_function = current_function->next;
-				}
-
-				current_xmachine = current_xmachine->next;
-			}
-			/* Increment layer */
-			newlayer++;
-			/* If all the functions have layers then stop */
-			/* Set flag to all functions have a layer */
-			k = 0;
-			current_xmachine = * modeldata->p_xmachines;
-			while(current_xmachine)
-			{
-				/* For each function */
-				current_function = current_xmachine->functions;
-				while(current_function)
-				{
-					/* If a function does not have a layer yet */
-					if(current_function->rank_in == -1) k = 1;
-
-					current_function = current_function->next;
-				}
-
-				current_xmachine = current_xmachine->next;
-			}
-			/* If flag is still zero then stop */
-			if(k == 0) m = 1;
-			else
-			{
-				//current_layer = addlayer(modeldata->p_layers);
-			}
-		}
-
-		totallayers = newlayer;
-
-		current_xmachine = *modeldata->p_xmachines;
-		while(current_xmachine)
-		{
-			state_number = 0;
-
-			//qwerty
-			newlayer = 0;
-			m = 0;
-			while(newlayer <= totallayers)
-			{
-				/* For each function */
-				current_function = current_xmachine->functions;
-				while(current_function)
-				{
-					if(current_function->rank_in == newlayer)
-					{
-						if(state_number == 0) sprintf(buffer, "%s", "start");
-						else sprintf(buffer, "%i", state_number);
-						current_function->current_state = copystr(buffer);
-						state_number++;
-						sprintf(buffer, "%i", state_number);
-						current_function->next_state = copystr(buffer);
-						addxstate(current_function->current_state, current_function->agent_name, &current_xmachine->states);
-						/* Save last function */
-						current_function2 = current_function;
-					}
-
-					current_function = current_function->next;
-				}
-
-				newlayer++;
-			}
-
-			free(current_function2->next_state);
-			sprintf(buffer, "%s", "end");
-			current_function2->next_state = copystr(buffer);
-			addxstate(current_function2->next_state, current_function2->agent_name, &current_xmachine->states);
-
-			current_function = current_xmachine->functions;
-			while(current_function)
-			{
-				current_function->rank_in = -1;
-
-				current_adj_function = current_function->depends;
-				while(current_adj_function)
-				{
-					// Find pointers to functions for function names
-					current_xmachine2 = *modeldata->p_xmachines;
-					while(current_xmachine2)
-					{
-						current_function2 = current_xmachine2->functions;
-						while(current_function2)
-						{
-							if(strcmp(current_adj_function->name, current_function2->name) == 0)
-							{
-								current_adj_function->function = current_function2;
-							}
-
-							current_function2 = current_function2->next;
-						}
-
-						current_xmachine2 = current_xmachine2->next;
-					}
-
-					if(current_adj_function->function == NULL)
-					{
-						fprintf(stderr, "ERROR: depends function '%s' does not exist\n",
-						current_adj_function->name);
-						return -1;
-					}
-
-					if(strcmp(current_adj_function->type, "internal") != 0)
-					{
-						/* If communication dependency */
-						/* Add input to current function */
-						/* check if already exists */
-						found = 0;
-						current_ioput = current_function->inputs;
-						while(current_ioput)
-						{
-							if(strcmp(current_adj_function->type, current_ioput->messagetype) == 0) found = 1;
-
-							current_ioput = current_ioput->next;
-						}
-						if(found == 0)
-						{
-							current_ioput = addioput(&current_function->inputs);
-							current_ioput->function = current_function;
-							current_ioput->messagetype = copystr(current_adj_function->type);
-						}
-						/* Add output to depends on function */
-						found = 0;
-						current_ioput = current_adj_function->function->outputs;
-						while(current_ioput)
-						{
-							if(strcmp(current_adj_function->type, current_ioput->messagetype) == 0) found = 1;
-
-							current_ioput = current_ioput->next;
-						}
-						if(found == 0)
-						{
-							current_ioput = addioput(&current_adj_function->function->outputs);
-							current_ioput->messagetype = copystr(current_adj_function->type);
-							current_ioput->function = current_function;
-						}
-					}
-
-					current_adj_function = current_adj_function->next;
-				}
-
-				current_function = current_function->next;
-			}
-
-			current_xmachine = current_xmachine->next;
-		}
-	}
-
-	/* Check condition/filter rules */
-	current_xmachine = *modeldata->p_xmachines;
-	while(current_xmachine)
-	{
-		/* Message filters */
-		current_function = current_xmachine->functions;
-		while(current_function)
-		{
-			/* If function has a condition... */
-			if(current_function->condition_rule != NULL)
-			{
-				strcpy(buffer, "FLAME_condition_");
-				strcat(buffer, current_xmachine->name);
-				strcat(buffer, "_");
-				strcat(buffer, current_function->name);
-				strcat(buffer, "_");
-				strcat(buffer, current_function->current_state);
-				strcat(buffer, "_");
-				strcat(buffer, current_function->next_state);
-				current_function->condition_function = copystr(buffer);
-
-				handleRule(current_function->condition_rule, current_function, current_xmachine, NULL, modeldata);
-			}
-
-			current_ioput = current_function->inputs;
-			while(current_ioput)
-			{
-				/* Check if message type exists */
-				found = 0;
-				current_message = * modeldata->p_xmessages;
-				while(current_message)
-				{
-					if(strcmp(current_ioput->messagetype, current_message->name) == 0)
-					{
-						found = 1;
-						current_ioput->message = current_message;
-					}
-
-					current_message = current_message->next;
-				}
-				if(found == 0)
-				{
-					fprintf(stderr, "ERROR: input message type '%s' in function '%s' in agent '%s' in file '%s' doesn't exist\n",
-								current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
-					return -1;
-				}
-				
-				/* If input message has a filter */
-				if(current_ioput->filter_rule != NULL)
-				{
-					strcpy(buffer, "FLAME_filter_");
-					strcat(buffer, current_xmachine->name);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->name);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->current_state);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->next_state);
-					strcat(buffer, "_");
-					strcat(buffer, current_ioput->messagetype);
-					current_ioput->filter_function = copystr(buffer);
-
-					handleRule(current_ioput->filter_rule, current_function, current_xmachine, current_ioput->messagetype, modeldata);
-
-					/* Check if agent has x, y and z variables */
-					has_x = 0;
+    /* Check model for:
+     * agent/message variables are only known data types
+     * agent/message variables only appear once, show warning for duplicates and show from which files
+     * try and parse functions files for implementations of functions defined in model xml
+     * */
+
+    /* Check for no agents */
+    if(*modeldata->p_xmachines == NULL) {
+        fprintf(stderr, "ERROR: no agents defined\n");
+        return -1;
+    }
+
+    /* Check duplicate message names */
+    current_message = * modeldata->p_xmessages;
+    while(current_message) {
+        current_message2 = * modeldata->p_xmessages;
+        {
+            if(current_message != current_message2) {
+                if(strcmp(current_message->name, current_message2->name) == 0) {
+                    fprintf(stderr, "ERROR: multiple definitions of message '%s'\n", current_message->name);
+                    fprintf(stderr, "       in file: '%s'\n", current_message->file);
+                    fprintf(stderr, "       in file: '%s'\n", current_message2->file);
+                    return -1;
+                }
+            }
+
+            current_message2 = current_message2->next;
+        }
+
+        current_message = current_message->next;
+    }
+
+    /* Check agent memory variables for being a model data type and update variable attributes */
+    current_xmachine = *modeldata->p_xmachines;
+    current_xmachine2 = NULL;
+    while(current_xmachine) {
+        current_variable = current_xmachine->variables;
+
+        /* Error if no variables */
+        if(current_variable == NULL) {
+            /*fprintf(stderr, "ERROR: agent '%s' has no memory variables\n", current_xmachine->name);
+            return -1;*/
+            fprintf(stderr, "WARNING: no memory variables found in '%s' agent, agent removed from model\n", current_xmachine->name);
+            /* Remove agent from the agent list */
+            if(current_xmachine2 == NULL) * modeldata->p_xmachines = current_xmachine->next;
+            else current_xmachine2->next = current_xmachine->next;
+
+            free(current_xmachine->name);
+            freevariables(&current_xmachine->variables);
+            freexstates(&current_xmachine->states);
+            freexfunctions(&current_xmachine->functions);
+            freestateholder(&current_xmachine->end_states);
+            free(current_xmachine);
+
+            if(current_xmachine2 == NULL) current_xmachine = * modeldata->p_xmachines;
+            else current_xmachine = current_xmachine2->next;
+        } else {
+            /* Error if variables type is not a C type or a data type or an array of these */
+            while(current_variable) {
+                found = 0;
+                if(strcmp(current_variable->type, "int") == 0 ||
+                        strcmp(current_variable->type, "short int") == 0 ||
+                        strcmp(current_variable->type, "long int") == 0 ||
+                        strcmp(current_variable->type, "unsigned int") == 0 ||
+                        strcmp(current_variable->type, "unsigned short int") == 0 ||
+                        strcmp(current_variable->type, "unsigned long int") == 0 ||
+                        strcmp(current_variable->type, "int_array") == 0 ||
+                        strcmp(current_variable->type, "double") == 0 ||
+                        strcmp(current_variable->type, "float") == 0 ||
+                        strcmp(current_variable->type, "double_array") == 0 ||
+                        strcmp(current_variable->type, "float_array") == 0 ||
+                        strcmp(current_variable->type, "char") == 0 ||
+                        strcmp(current_variable->type, "unsigned char") == 0 ||
+                        strcmp(current_variable->type, "char_array") == 0) {
+                    found = 1;
+                }
+
+                /* Handle model defined data types */
+                current_datatype = * modeldata->p_datatypes;
+                while(current_datatype) {
+                    if(strcmp(current_variable->type, current_datatype->name) == 0) {
+                        found = 1;
+                    }
+
+                    strcpy(buffer, current_datatype->name);
+                    strcat(buffer, "_array");
+
+                    if(strcmp(current_variable->type, buffer) == 0) {
+                        found = 1;
+                    }
+
+                    current_datatype = current_datatype->next;
+                }
+
+                if(found == 0) {
+                    fprintf(stderr, "ERROR: type variable '%s' in variable '%s' in agent '%s' doesn't exist\n", current_variable->type, current_variable->name, current_xmachine->name);
+                    fprintf(stderr, "       in file: '%s'\n", current_variable->file);
+                    return -1;
+                }
+
+                current_variable = current_variable->next;
+            }
+
+            /* Error if a variable name is defined twice in same agent */
+            current_variable = current_xmachine->variables;
+            while(current_variable) {
+                current_variable2 = current_xmachine->variables;
+                while(current_variable2) {
+                    if(strcmp(current_variable->name, current_variable2->name) == 0 && current_variable != current_variable2) {
+                        fprintf(stderr, "ERROR: multiple uses of variable '%s' in agent '%s'\n", current_variable->name, current_xmachine->name);
+                        fprintf(stderr, "       in file: '%s'\n", current_variable->file);
+                        fprintf(stderr, "       in file: '%s'\n", current_variable2->file);
+                        return -1;
+                    }
+
+                    current_variable2 = current_variable2->next;
+                }
+
+                current_variable = current_variable->next;
+            }
+
+            current_variable = current_xmachine->variables;
+            while(current_variable) {
+                /* Handle model defined data types */
+                current_datatype = * modeldata->p_datatypes;
+                while(current_datatype) {
+                    if(strcmp(current_variable->type, current_datatype->name) == 0) {
+                        current_variable->ismodeldatatype = 1;
+                        current_variable->datatype = current_datatype;
+                    }
+
+                    strcpy(buffer, current_datatype->name);
+                    strcat(buffer, "_array");
+
+                    if(strcmp(current_variable->type, buffer) == 0) {
+                        current_variable->ismodeldatatype = 1;
+                        current_variable->datatype = current_datatype;
+                        current_variable->arraylength = -1;
+                    }
+
+                    current_datatype = current_datatype->next;
+                }
+
+                current_variable = current_variable->next;
+            }
+
+            /* Compute x,y,z location variables in memory */
+            /* Check for x-axis component as 'posx' or 'px' or 'x' */
+            strcpy(current_xmachine->xvar, "0.0");
+            strcpy(current_xmachine->yvar, "0.0");
+            strcpy(current_xmachine->zvar, "0.0");
+            variable_count = 0;
+
+            current_variable = current_xmachine->variables;
+            while(current_variable) {
+                if(current_variable->arraylength != 0) modeldata->agents_include_array_variables = 1;
+
+                /*copycharlist(&current_variable->name, &chardata[0]);*/
+                sprintf(buffer,"%s_x",current_xmachine->name);
+                if(strcmp(current_variable->name, buffer) == 0)    strcpy(current_xmachine->xvar, buffer);
+                if(strcmp(current_variable->name, "x") == 0)    strcpy(current_xmachine->xvar, "x");
+                if(strcmp(current_variable->name, "px") == 0)   strcpy(current_xmachine->xvar, "px");
+                if(strcmp(current_variable->name, "posx") == 0) strcpy(current_xmachine->xvar, "posx");
+                sprintf(buffer,"%s_y",current_xmachine->name);
+                if(strcmp(current_variable->name, buffer) == 0)    strcpy(current_xmachine->yvar, buffer);
+                if(strcmp(current_variable->name, "y") == 0)    strcpy(current_xmachine->yvar, "y");
+                if(strcmp(current_variable->name, "py") == 0)   strcpy(current_xmachine->yvar, "py");
+                if(strcmp(current_variable->name, "posy") == 0) strcpy(current_xmachine->yvar, "posy");
+                sprintf(buffer,"%s_z",current_xmachine->name);
+                if(strcmp(current_variable->name, buffer) == 0)    strcpy(current_xmachine->zvar, buffer);
+                if(strcmp(current_variable->name, "z") == 0)    strcpy(current_xmachine->zvar, "z");
+                if(strcmp(current_variable->name, "pz") == 0)   strcpy(current_xmachine->zvar, "pz");
+                if(strcmp(current_variable->name, "posz") == 0) strcpy(current_xmachine->zvar, "posz");
+
+                if(strcmp(current_variable->name, "range") == 0) strcpy(current_xmachine->rangevar, "range");
+                if(strcmp(current_variable->name, "radius") == 0) strcpy(current_xmachine->rangevar, "radius");
+
+                if(strcmp(current_variable->name, "id") == 0) strcpy(current_xmachine->idvar, "id");
+                if(strcmp(current_variable->name, "agent_id") == 0) strcpy(current_xmachine->idvar, "agent_id");
+
+                found = 0;
+                allvar = * modeldata->p_allvars;
+                while(allvar) {
+                    /*copycharlist(&allvar->name, &chardata2[0]);*/
+                    if(strcmp(current_variable->name, allvar->name) == 0) {
+                        found = 1;
+
+                        /* If same variable name but different type, this breaks get_ and set_ methods */
+                        if(strcmp(current_variable->type, allvar->type) != 0) {
+                            fprintf(stderr, "ERROR: variable '%s' defined twice but with different types\n", current_variable->name);
+                            return -1;
+                        }
+                    }
+
+                    allvar = allvar->next;
+                }
+                if(found == 0) {
+                    allvar = addvariable(modeldata->p_allvars);
+                    allvar->name = copystr(current_variable->name);
+                    allvar->type = copystr(current_variable->type);
+                    allvar->arraylength = current_variable->arraylength;
+                    allvar->ismodeldatatype = current_variable->ismodeldatatype;
+                    allvar->datatype = current_variable->datatype;
+                    allvar->typenotarray = copystr(current_variable->typenotarray);
+                    strcpy(allvar->defaultvalue, current_variable->defaultvalue);
+                    strcpy(allvar->c_type, current_variable->c_type);
+                }
+
+                variable_count++;
+
+                current_variable = current_variable->next;
+            }
+
+            current_xmachine->var_number = variable_count;
+
+            modeldata->number_xmachines++;
+
+            current_xmachine = current_xmachine->next;
+        }
+    }
+
+    /* If functions have old style depends tags create states */
+    if(modeldata->depends_style == 1) {
+        /* Go through all adj functions in depends
+         * and link the function pointer to the actual function */
+        current_xmachine = *modeldata->p_xmachines;
+        while(current_xmachine) {
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                current_adj_function = current_function->depends;
+                while(current_adj_function) {
+                    current_xmachine2 = *modeldata->p_xmachines;
+                    while(current_xmachine2) {
+                        current_function2 = current_xmachine2->functions;
+                        while(current_function2) {
+                            if(strcmp(current_adj_function->name, current_function2->name) == 0) {
+                                //printf("** %s -> %s == %s\n", current_function->name, current_adj_function->name, current_function2->name);
+                                current_adj_function->function = current_function2;
+                            }
+
+                            current_function2 = current_function2->next;
+                        }
+
+                        current_xmachine2 = current_xmachine2->next;
+                    }
+
+                    current_adj_function = current_adj_function->next;
+                }
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+
+        /* Find order of functions in each agent */
+        newlayer = 0;
+        m = 0;
+        while(m == 0) {
+            /* For each agent */
+            current_xmachine = * modeldata->p_xmachines;
+            while(current_xmachine) {
+                /* For each function */
+                current_function = current_xmachine->functions;
+                while(current_function) {
+                    /* If rank_in is unknown */
+                    if(current_function->rank_in == -1) {
+                        k = 0;
+                        /* Search dependencies on the current function */
+                        current_adj_function = current_function->depends;
+                        while(current_adj_function) {
+                            /* Check if the function has a dependency on it (and not from itself) */
+                            /* Check to see if the dependency is a function and not be assigned a layer in last layers */
+                            if(current_adj_function->function->rank_in == -1 || current_adj_function->function->rank_in == newlayer) {
+                                /* Change flag to say there is a dependency */
+                                k = 1;
+                            }
+
+                            current_adj_function = current_adj_function->next;
+                        }
+                        if(k == 0) {
+                            current_function->rank_in = newlayer;
+
+                            printf("%s - %s - %d\n", current_xmachine->name, current_function->name, newlayer);
+
+                            //addfunction_pointer(&current_layer->functions, current_function);
+                        }
+                    }
+
+                    current_function = current_function->next;
+                }
+
+                current_xmachine = current_xmachine->next;
+            }
+            /* Increment layer */
+            newlayer++;
+            /* If all the functions have layers then stop */
+            /* Set flag to all functions have a layer */
+            k = 0;
+            current_xmachine = * modeldata->p_xmachines;
+            while(current_xmachine) {
+                /* For each function */
+                current_function = current_xmachine->functions;
+                while(current_function) {
+                    /* If a function does not have a layer yet */
+                    if(current_function->rank_in == -1) k = 1;
+
+                    current_function = current_function->next;
+                }
+
+                current_xmachine = current_xmachine->next;
+            }
+            /* If flag is still zero then stop */
+            if(k == 0) m = 1;
+            else {
+                //current_layer = addlayer(modeldata->p_layers);
+            }
+        }
+
+        totallayers = newlayer;
+
+        current_xmachine = *modeldata->p_xmachines;
+        while(current_xmachine) {
+            state_number = 0;
+
+            //qwerty
+            newlayer = 0;
+            m = 0;
+            while(newlayer <= totallayers) {
+                /* For each function */
+                current_function = current_xmachine->functions;
+                while(current_function) {
+                    if(current_function->rank_in == newlayer) {
+                        if(state_number == 0) sprintf(buffer, "%s", "start");
+                        else sprintf(buffer, "%i", state_number);
+                        current_function->current_state = copystr(buffer);
+                        state_number++;
+                        sprintf(buffer, "%i", state_number);
+                        current_function->next_state = copystr(buffer);
+                        addxstate(current_function->current_state, current_function->agent_name, &current_xmachine->states);
+                        /* Save last function */
+                        current_function2 = current_function;
+                    }
+
+                    current_function = current_function->next;
+                }
+
+                newlayer++;
+            }
+
+            free(current_function2->next_state);
+            sprintf(buffer, "%s", "end");
+            current_function2->next_state = copystr(buffer);
+            addxstate(current_function2->next_state, current_function2->agent_name, &current_xmachine->states);
+
+            current_function = current_xmachine->functions;
+            while(current_function) {
+                current_function->rank_in = -1;
+
+                current_adj_function = current_function->depends;
+                while(current_adj_function) {
+                    // Find pointers to functions for function names
+                    current_xmachine2 = *modeldata->p_xmachines;
+                    while(current_xmachine2) {
+                        current_function2 = current_xmachine2->functions;
+                        while(current_function2) {
+                            if(strcmp(current_adj_function->name, current_function2->name) == 0) {
+                                current_adj_function->function = current_function2;
+                            }
+
+                            current_function2 = current_function2->next;
+                        }
+
+                        current_xmachine2 = current_xmachine2->next;
+                    }
+
+                    if(current_adj_function->function == NULL) {
+                        fprintf(stderr, "ERROR: depends function '%s' does not exist\n",
+                                current_adj_function->name);
+                        return -1;
+                    }
+
+                    if(strcmp(current_adj_function->type, "internal") != 0) {
+                        /* If communication dependency */
+                        /* Add input to current function */
+                        /* check if already exists */
+                        found = 0;
+                        current_ioput = current_function->inputs;
+                        while(current_ioput) {
+                            if(strcmp(current_adj_function->type, current_ioput->messagetype) == 0) found = 1;
+
+                            current_ioput = current_ioput->next;
+                        }
+                        if(found == 0) {
+                            current_ioput = addioput(&current_function->inputs);
+                            current_ioput->function = current_function;
+                            current_ioput->messagetype = copystr(current_adj_function->type);
+                        }
+                        /* Add output to depends on function */
+                        found = 0;
+                        current_ioput = current_adj_function->function->outputs;
+                        while(current_ioput) {
+                            if(strcmp(current_adj_function->type, current_ioput->messagetype) == 0) found = 1;
+
+                            current_ioput = current_ioput->next;
+                        }
+                        if(found == 0) {
+                            current_ioput = addioput(&current_adj_function->function->outputs);
+                            current_ioput->messagetype = copystr(current_adj_function->type);
+                            current_ioput->function = current_function;
+                        }
+                    }
+
+                    current_adj_function = current_adj_function->next;
+                }
+
+                current_function = current_function->next;
+            }
+
+            current_xmachine = current_xmachine->next;
+        }
+    }
+
+    /* Check condition/filter rules */
+    current_xmachine = *modeldata->p_xmachines;
+    while(current_xmachine) {
+        /* Message filters */
+        current_function = current_xmachine->functions;
+        while(current_function) {
+            /* If function has a condition... */
+            if(current_function->condition_rule != NULL) {
+                strcpy(buffer, "FLAME_condition_");
+                strcat(buffer, current_xmachine->name);
+                strcat(buffer, "_");
+                strcat(buffer, current_function->name);
+                strcat(buffer, "_");
+                strcat(buffer, current_function->current_state);
+                strcat(buffer, "_");
+                strcat(buffer, current_function->next_state);
+                current_function->condition_function = copystr(buffer);
+
+                handleRule(current_function->condition_rule, current_function, current_xmachine, NULL, modeldata);
+            }
+
+            current_ioput = current_function->inputs;
+            while(current_ioput) {
+                /* Check if message type exists */
+                found = 0;
+                current_message = * modeldata->p_xmessages;
+                while(current_message) {
+                    if(strcmp(current_ioput->messagetype, current_message->name) == 0) {
+                        found = 1;
+                        current_ioput->message = current_message;
+                    }
+
+                    current_message = current_message->next;
+                }
+                if(found == 0) {
+                    fprintf(stderr, "ERROR: input message type '%s' in function '%s' in agent '%s' in file '%s' doesn't exist\n",
+                            current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
+                    return -1;
+                }
+
+                /* If input message has a filter */
+                if(current_ioput->filter_rule != NULL) {
+                    strcpy(buffer, "FLAME_filter_");
+                    strcat(buffer, current_xmachine->name);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->name);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->current_state);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->next_state);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_ioput->messagetype);
+                    current_ioput->filter_function = copystr(buffer);
+
+                    handleRule(current_ioput->filter_rule, current_function, current_xmachine, current_ioput->messagetype, modeldata);
+
+                    /* Check if agent has x, y and z variables */
+                    has_x = 0;
                     has_y = 0;
                     has_z = 0;
                     current_variable = current_xmachine->variables;
@@ -2286,134 +2200,126 @@ int checkmodel(model_data * modeldata)
                         current_variable = current_variable->next;
                     }
 
-					/* If function has box2/3d filter then tell message board */
-					if(current_ioput->filter_rule->box == 2) {
-					    current_ioput->message->has_box2d = 1;
-					    /* Check agent has x and y variables */
-					    if(has_x == 0 || has_y == 0) {
-					        fprintf(stderr, "ERROR: agent '%s' contains a box2d filter but does not contain memory variables called x and y\n",
+                    /* If function has box2/3d filter then tell message board */
+                    if(current_ioput->filter_rule->box == 2) {
+                        current_ioput->message->has_box2d = 1;
+                        /* Check agent has x and y variables */
+                        if(has_x == 0 || has_y == 0) {
+                            fprintf(stderr, "ERROR: agent '%s' contains a box2d filter but does not contain memory variables called x and y\n",
                                     current_xmachine->name);
                             return -1;
-					    }
-					}
-					if(current_ioput->filter_rule->box == 3) {
-					    current_ioput->message->has_box3d = 1;
-					    /* Check agent has x, y and z variables */
-					    if(has_x == 0 || has_y == 0 || has_z == 0) {
+                        }
+                    }
+                    if(current_ioput->filter_rule->box == 3) {
+                        current_ioput->message->has_box3d = 1;
+                        /* Check agent has x, y and z variables */
+                        if(has_x == 0 || has_y == 0 || has_z == 0) {
                             fprintf(stderr, "ERROR: agent '%s' contains a box3d filter but does not contain memory variables called x, y and z\n",
                                     current_xmachine->name);
                             return -1;
                         }
-					}
+                    }
 
-					/* Save box apothem string to box_apothem */
-					if(current_ioput->filter_rule->box > 0)
-					{
-					    /* If use agent variable, remove first 'a' */
-					    if(strncmp(current_ioput->filter_rule->lhs, "a", 1) == 0) {
-					        current_ioput->box_apothem =
-					                (char *)malloc( (
-					                        strlen(current_ioput->filter_rule->lhs) +
-                                            strlen(current_xmachine->name) +
-                                            strlen("current_xmachine_") + 1) * sizeof(char));
-					        strcpy(current_ioput->box_apothem, "current_xmachine_");
-					        strcat(current_ioput->box_apothem, current_xmachine->name);
-					        strcat(current_ioput->box_apothem, current_ioput->filter_rule->lhs+1);
-					    } else {
-					        current_ioput->box_apothem =
-                                    (char *)malloc( (
-                                            strlen(current_ioput->filter_rule->lhs) + 1) * sizeof(char));
-					        strcpy(current_ioput->box_apothem, current_ioput->filter_rule->lhs);
-					    }
-					}
-				}
+                    /* Save box apothem string to box_apothem */
+                    if(current_ioput->filter_rule->box > 0) {
+                        /* If use agent variable, remove first 'a' */
+                        if(strncmp(current_ioput->filter_rule->lhs, "a", 1) == 0) {
+                            current_ioput->box_apothem =
+                                (char *)malloc( (
+                                                    strlen(current_ioput->filter_rule->lhs) +
+                                                    strlen(current_xmachine->name) +
+                                                    strlen("current_xmachine_") + 1) * sizeof(char));
+                            strcpy(current_ioput->box_apothem, "current_xmachine_");
+                            strcat(current_ioput->box_apothem, current_xmachine->name);
+                            strcat(current_ioput->box_apothem, current_ioput->filter_rule->lhs+1);
+                        } else {
+                            current_ioput->box_apothem =
+                                (char *)malloc( (
+                                                    strlen(current_ioput->filter_rule->lhs) + 1) * sizeof(char));
+                            strcpy(current_ioput->box_apothem, current_ioput->filter_rule->lhs);
+                        }
+                    }
+                }
 
-				/*printf("%s - %d\n", current_ioput->filter_function, current_ioput->random);*/
-				/*if(current_ioput->sort_function != NULL) printf("*** %s - %s\n", 
-										current_ioput->messagetype, current_ioput->sort_function);*/
-				
-				/* If sort variable defined */
-				if(current_ioput->sort_key != NULL || current_ioput->sort_order != NULL)
-				{
-					if(current_ioput->sort_key == NULL)
-					{
-						fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a sort variable\n",
-								current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
-						return -1;
-					}
-					if(current_ioput->sort_order == NULL)
-					{
-						fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a sort order\n",
-								current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
-						return -1;
-					}
-					
-					/* Variable must be a valid message variable */
-					found = 0;
-					for(current_variable = current_ioput->message->vars;
-					current_variable != NULL; current_variable = current_variable->next)
-					{
-						if(strcmp(current_variable->name, current_ioput->sort_key) == 0) found = 1;
-					}
-					if(found == 0)
-					{
-						fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a valid sort variable '%s'\n",
-								current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file, current_ioput->sort_key);
-						return -1;
-					}
-					
-					/* Sort order must be either ascend or descend */
-					if(strcmp(current_ioput->sort_order, "ascend") != 0 &&
-						strcmp(current_ioput->sort_order, "descend") != 0)
-					{
-						fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' has an order '%s' that is not ascend or descend\n",
-								current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file, current_ioput->sort_order);
-						return -1;
-					}
-					
-					/* Create and copy sort_function name */
-					strcpy(buffer, "FLAME_sort_");
-					strcat(buffer, current_xmachine->name);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->name);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->current_state);
-					strcat(buffer, "_");
-					strcat(buffer, current_function->next_state);
-					strcat(buffer, "_");
-					strcat(buffer, current_ioput->messagetype);
-					current_ioput->sort_function = copystr(buffer);
-				}
-				
-				/* If sort function is defined then turn off randomisation
-				 * because random function called on the sorted iterator */
-				//if(current_ioput->sort_function != NULL) current_ioput->random = 0;
-				
-				current_ioput = current_ioput->next;
-			}
+                /*printf("%s - %d\n", current_ioput->filter_function, current_ioput->random);*/
+                /*if(current_ioput->sort_function != NULL) printf("*** %s - %s\n",
+                						current_ioput->messagetype, current_ioput->sort_function);*/
 
-			current_function = current_function->next;
-		}
+                /* If sort variable defined */
+                if(current_ioput->sort_key != NULL || current_ioput->sort_order != NULL) {
+                    if(current_ioput->sort_key == NULL) {
+                        fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a sort variable\n",
+                                current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
+                        return -1;
+                    }
+                    if(current_ioput->sort_order == NULL) {
+                        fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a sort order\n",
+                                current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file);
+                        return -1;
+                    }
 
-		current_xmachine = current_xmachine->next;
-	}
+                    /* Variable must be a valid message variable */
+                    found = 0;
+                    for(current_variable = current_ioput->message->vars;
+                            current_variable != NULL; current_variable = current_variable->next) {
+                        if(strcmp(current_variable->name, current_ioput->sort_key) == 0) found = 1;
+                    }
+                    if(found == 0) {
+                        fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' doesn't have a valid sort variable '%s'\n",
+                                current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file, current_ioput->sort_key);
+                        return -1;
+                    }
 
-	/* Check messages that have box2/3d input filters contain x,y,(z) */
+                    /* Sort order must be either ascend or descend */
+                    if(strcmp(current_ioput->sort_order, "ascend") != 0 &&
+                            strcmp(current_ioput->sort_order, "descend") != 0) {
+                        fprintf(stderr, "ERROR: sort of message type '%s' in function '%s' in agent '%s' in file '%s' has an order '%s' that is not ascend or descend\n",
+                                current_ioput->messagetype, current_function->name, current_xmachine->name, current_function->file, current_ioput->sort_order);
+                        return -1;
+                    }
+
+                    /* Create and copy sort_function name */
+                    strcpy(buffer, "FLAME_sort_");
+                    strcat(buffer, current_xmachine->name);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->name);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->current_state);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_function->next_state);
+                    strcat(buffer, "_");
+                    strcat(buffer, current_ioput->messagetype);
+                    current_ioput->sort_function = copystr(buffer);
+                }
+
+                /* If sort function is defined then turn off randomisation
+                 * because random function called on the sorted iterator */
+                //if(current_ioput->sort_function != NULL) current_ioput->random = 0;
+
+                current_ioput = current_ioput->next;
+            }
+
+            current_function = current_function->next;
+        }
+
+        current_xmachine = current_xmachine->next;
+    }
+
+    /* Check messages that have box2/3d input filters contain x,y,(z) */
     current_message = * modeldata->p_xmessages;
-    while(current_message)
-    {
+    while(current_message) {
         int has_x = 0;
         int has_y = 0;
         int has_z = 0;
+
         for(current_variable = current_message->vars;
-        current_variable != NULL; current_variable = current_variable->next)
-        {
+                current_variable != NULL; current_variable = current_variable->next) {
             if(strcmp(current_variable->name, "x") == 0) has_x = 1;
             if(strcmp(current_variable->name, "y") == 0) has_y = 1;
             if(strcmp(current_variable->name, "z") == 0) has_z = 1;
         }
 
-        printf("%s\n", current_message->name);
+        /*        printf("%s\n", current_message->name);*/
         if(current_message->has_box2d) {
             /*printf("\thas box2d\n");*/
             if(has_x == 0 || has_y == 0) {
@@ -2439,5 +2345,5 @@ int checkmodel(model_data * modeldata)
         current_message = current_message->next;
     }
 
-	return 0;
+    return 0;
 }

--- a/xparser.c
+++ b/xparser.c
@@ -5,8 +5,7 @@
  *     Added to and Modified: 	David Worth (STFC)
  *				Lee Shawn Chin (STFC)
  *				Chris Greenough (STFC)
- *     Copyright (c) 2006 Simon Coakley
- *     License:      n/a
+ *     Copyright (c) 2014 STFC Rutherford Appleton Laboratory/Sheffield University
  * \endcode
  * \brief Architecture for agent-based modelling based on X-machines.
  */
@@ -15,8 +14,8 @@
  *
  * \section intro_sec Introduction
  *
- * This program is the FLAME XMML parser. It accepts a model description 
- * in X-agent XML and produces source code for the model in either serial 
+ * This program is the FLAME XMML parser. It accepts a model description
+ * in X-agent XML and produces source code for the model in either serial
  * (default) or in parallel (via MPI libraries).
  *
  * The command line is:
@@ -37,7 +36,7 @@
  * \section install_sec Installation
  *
  * Compile using a C compiler. A Make file is provided. xparser has been tested
- * on a large number of UNIX based systems. 
+ * on a large number of UNIX based systems.
  */
 
 #include "header.h"
@@ -50,250 +49,294 @@
  */
 int main(int argc, char * argv[])
 {
-	/* Variables for parsing directories */
-	int lastd;
-	int i;
-	/* Error value */
-	int rc;
-	
-	/* Variable to read in command line input */
-	char inputfile[1000];
-	char directory[1000];
-	char filename[1000];
-	char templatename[1000];
-	char templatedirectory[1000];
-	
-	/* For reading input files */
-	input_file * current_input_file;
-	/* Structure to hold model data */
-	model_data * modeldata;
-	
-	/* Hold modeldata data */
-	xmachine * xmachines;
-	xmachine_message * xmessage;
-	variable * envvar;
-	env_func * envfunc;
-	variable * envdefine;
-	variable * allvars;
-	variable * constant_filter_vars;
-	f_code * it_end_code;
-	layer * layers;
-	flame_communication * communications;
-	model_datatype * datatypes;
-	time_data * time_units;
-	input_file * temp_input_file;
-	
-	/* Allocate memory for modeldata */
-	modeldata = (model_data *)malloc(sizeof(model_data));
-	/* 0=serial(default) 1=parallel 2=grid */
-	modeldata->code_type = 0;
-	/* 0=dgraph.dot 1=stategraph.dot */
-	modeldata->depends_style = 0;
-	modeldata->debug_mode = 1;
+    /* Variables for parsing directories */
+    int lastd;
+    int i;
+    /* Error value */
+    int rc;
 
-	inputfile[1]='\0';
-	
-	/* Initialise pointers */
-	modeldata->name = NULL;
-	modeldata->p_xmachines = &xmachines;
-	xmachines = NULL;
-	modeldata->p_xmessages = &xmessage;
-	xmessage = NULL;
-	modeldata->p_envvars = &envvar;
-	envvar = NULL;
-	modeldata->p_envfuncs = &envfunc;
-	envfunc = NULL;
-	modeldata->p_envdefines = &envdefine;
-	envdefine = NULL;
-	modeldata->p_allvars = &allvars;
-	allvars = NULL;
-	modeldata->p_it_end_code = &it_end_code;
-	it_end_code = NULL;
-	modeldata->p_layers = &layers;
-	layers = NULL;
-	modeldata->p_communications = &communications;
-	communications = NULL;
-	modeldata->p_datatypes = &datatypes;
-	datatypes = NULL;
-	modeldata->p_time_units = &time_units;
-	time_units = NULL;
-	modeldata->p_files = &temp_input_file;
-	temp_input_file = NULL;
-	modeldata->p_constant_filter_vars = &constant_filter_vars;
-	constant_filter_vars = NULL;
-	
-	printf("xparser (Version %d.%d.%d)\n", VERSIONMAJOR, VERSIONMINOR, VERSIONMICRO);
-	
-	/* Must be at least the input file name */
-	if(argc < 2)
-	{
-		printf("Usage: xparser [XMML file] [-s | -p] [-f]\n");
-		printf("\t-s\tSerial mode\n");
-		printf("\t-p\tParallel mode\n");
-		printf("\t-f\tFinal production mode\n");
-		free_modeldata(modeldata);
-		return 0;
-	}
-	
-	/* Copy location of xparser */
-	strcpy(templatedirectory,argv[0]);
-	
-	/* parser command line */
-	while(argc >1){
-		if(argv[1][0] == '-') {
-			switch (argv[1][1]){
-			case 's': modeldata->code_type = 0;
-				  break;
-			case 'p': modeldata->code_type = 1;
-				  break;
-			case 'f' : modeldata->debug_mode = 0;
-				  break;
-			default:  printf("xparser: Error - unknown option %s\n",argv[1]);
-				free_modeldata(modeldata);
-				return 0;
-			}
-		}
-		else
-		{
-			strcpy(inputfile,argv[1]);
-			/* printf("XMML input file : %s\n",argv[1]); */
-		}
-		argc--;
-		argv++;
-	}
-	
-	if(inputfile[1] == '\0') {
-		printf("xparser: Error - XMML must be specified\n");
-		free_modeldata(modeldata);
-		return 0;
-	}
-	
-	/* Print what type of code writing */
+    /* Variable to read in command line input */
+    char inputfile[1000];
+    char directory[1000];
+    char filename[1000];
+    char tmpl_name[1000];
+    char tmpl_directory[1000];
+    char *locxparser;
+
+    /* Usage message */
+
+    char *usage =
+        "Usage: xparser [XMML file] [-s | -p] [-f]\n" \
+        "\t-s\tSerial mode\n" \
+        "\t-p\tParallel mode\n" \
+        "\t-f\tFinal production mode\n";
+
+    /* For reading input files */
+    input_file * current_input_file;
+    /* Structure to hold model data */
+    model_data * modeldata;
+
+    /* Hold modeldata data */
+    xmachine * xmachines;
+    xmachine_message * xmessage;
+    variable * envvar;
+    env_func * envfunc;
+    variable * envdefine;
+    variable * allvars;
+    variable * constant_filter_vars;
+    f_code * it_end_code;
+    layer * layers;
+    flame_communication * communications;
+    model_datatype * datatypes;
+    time_data * time_units;
+    input_file * temp_input_file;
+
+    /* Allocate memory for modeldata */
+    modeldata = (model_data *)malloc(sizeof(model_data));
+    /* 0=serial(default) 1=parallel 2=grid */
+    modeldata->code_type = 0;
+    /* 0=dgraph.dot 1=stategraph.dot */
+    modeldata->depends_style = 0;
+    modeldata->debug_mode = 1;
+
+    inputfile[1]='\0';
+
+    /* Initialise pointers */
+    modeldata->name = NULL;
+    modeldata->p_xmachines = &xmachines;
+    xmachines = NULL;
+    modeldata->p_xmessages = &xmessage;
+    xmessage = NULL;
+    modeldata->p_envvars = &envvar;
+    envvar = NULL;
+    modeldata->p_envfuncs = &envfunc;
+    envfunc = NULL;
+    modeldata->p_envdefines = &envdefine;
+    envdefine = NULL;
+    modeldata->p_allvars = &allvars;
+    allvars = NULL;
+    modeldata->p_it_end_code = &it_end_code;
+    it_end_code = NULL;
+    modeldata->p_layers = &layers;
+    layers = NULL;
+    modeldata->p_communications = &communications;
+    communications = NULL;
+    modeldata->p_datatypes = &datatypes;
+    datatypes = NULL;
+    modeldata->p_time_units = &time_units;
+    time_units = NULL;
+    modeldata->p_files = &temp_input_file;
+    temp_input_file = NULL;
+    modeldata->p_constant_filter_vars = &constant_filter_vars;
+    constant_filter_vars = NULL;
+
+    printf("xparser (Version %d.%d.%d)\n", VERSIONMAJOR, VERSIONMINOR, VERSIONMICRO);
+
+    /* Must be at least the input file name */
+    if(argc < 2) {
+        printf("%s",usage);
+        free_modeldata(modeldata);
+        return 0;
+    }
+
+    /* Location of xparser */
+
+    locxparser = getenv("FLAME_XPARSER_DIR");
+
+    if(!locxparser) { /* Checking for empty string */
+        strcpy(tmpl_directory,FLAME_XPARSER_DIR);
+        if(strcmp(tmpl_directory,".") != 0) {
+            printf("\n***Warning: Environment variable FLAME_XPARSER_DIR not set - looking in %s for Templates\n",tmpl_directory);
+        } else {
+            printf("\n***Warning: Environment variable FLAME_XPARSER_DIR not set - looking in current directory for Templates\n");
+        }
+    } else {
+        strcpy(tmpl_directory,locxparser);
+        printf("\n***Info: Evnironment variable FLAME_XPARSER_DIR set - looking in %s for Templates\n",tmpl_directory);
+    };
+
+    /* Check directory path and make sure it ends with '/' or '\' */
+    if(strchr(tmpl_directory,'/') != NULL) {
+
+        tmpl_directory[strlen(tmpl_directory)]='/';
+        tmpl_directory[strlen(tmpl_directory)+1]='\0';
+
+    }
+
+    /* parser command line */
+    while(argc >1) {
+        if(argv[1][0] == '-') {
+            switch (argv[1][1]) {
+            case 's':
+                modeldata->code_type = 0;
+                break;
+            case 'p':
+                modeldata->code_type = 1;
+                break;
+            case 'f' :
+                modeldata->debug_mode = 0;
+                break;
+            case 't' :
+                break;
+            default:
+                printf("xparser: Error - unknown option %s\n",argv[1]);
+                printf("%s",usage);
+                free_modeldata(modeldata);
+                return 0;
+            }
+        } else {
+            strcpy(inputfile,argv[1]);
+            /* printf("XMML input file : %s\n",argv[1]); */
+        }
+        argc--;
+        argv++;
+    }
+
+    if(inputfile[1] == '\0') {
+        printf("xparser: Error - XMML must be specified\n");
+        free_modeldata(modeldata);
+        return 0;
+    }
+
+    /* Print what type of code writing */
     printf("\n");
     printf("Code type       : ");
-	if(modeldata->code_type == 0) printf("Serial");
-	if(modeldata->code_type == 1) printf("Parallel");
-	if(modeldata->debug_mode == 1) printf(" (DEBUG)");
+    if(modeldata->code_type == 0) printf("Serial");
+    if(modeldata->code_type == 1) printf("Parallel");
+    if(modeldata->debug_mode == 1) printf(" (DEBUG)");
     printf("\n");
-	
-	/* Calculate directory to write files to */
-	i = 0;
-	lastd = 0;
-	while(inputfile[i] != '\0')
-	{
-	/* For windows directories */
-		if(inputfile[i] == '\\') lastd=i;
-	/* For unix directories */
-		if(inputfile[i] == '/') lastd=i;
-		i++;
-	}
-	/* If a directory is in the path */
-	if(lastd != 0)
-	{
-		strcpy(directory, inputfile);
-		directory[lastd+1] = '\0';
-	}
-	else directory[0] = '\0';
-	
-	/* Calculate directory where xparser and template files are */
-	i = 0;
-	lastd = 0;
-	while(templatedirectory[i] != '\0')
-	{
-		/* For windows directories */
-		if(templatedirectory[i] == '\\') lastd=i;
-		/* For unix directories */
-		if(templatedirectory[i] == '/') lastd=i;
-		i++;
-	}
-	/* If a directory is in the path */
-	if(lastd != 0)
-	{
-		templatedirectory[lastd+1] = '\0';
-	}
-	else templatedirectory[0] = '\0';
-	
-	printf("Input XMML file : %s\n", inputfile);
-	printf("Model root dir  : %s\n", directory);
-	printf("Template dir    : %s\n", templatedirectory);
+
+    /* Calculate directory to write files to */
+    i = 0;
+    lastd = 0;
+    while(inputfile[i] != '\0') {
+        /* For windows directories */
+        if(inputfile[i] == '\\') lastd=i;
+        /* For unix directories */
+        if(inputfile[i] == '/') lastd=i;
+        i++;
+    }
+    /* If a directory is in the path */
+    if(lastd != 0) {
+        strcpy(directory, inputfile);
+        directory[lastd+1] = '\0';
+    } else directory[0] = '\0';
+
+    /* Calculate directory where xparser and template files are */
+    i = 0;
+    lastd = 0;
+    while(tmpl_directory[i] != '\0') {
+        /* For windows directories */
+        if(tmpl_directory[i] == '\\') lastd=i;
+        /* For unix directories */
+        if(tmpl_directory[i] == '/') lastd=i;
+        i++;
+    }
+    /* If a directory is in the path */
+    if(lastd != 0) {
+        tmpl_directory[lastd+1] = '\0';
+    } else tmpl_directory[0] = '\0';
+
+    printf("Input XMML file : %s\n", inputfile);
+    printf("Model root dir  : %s\n", directory);
+    printf("Template dir    : %s\n", tmpl_directory);
     printf("\n");
-	
-	current_input_file = add_input_file(modeldata->p_files);
-	current_input_file->fullfilepath = copystr(inputfile);
-	current_input_file->fulldirectory = copystr(directory);
-	current_input_file->localdirectory = copystr("");
-	
-	/* Read model from model xml file */
-	current_input_file = * modeldata->p_files;
-	while(current_input_file)
-	{
-		if(current_input_file->enabled == 1)
-			readModel(current_input_file, directory, modeldata);
-		
-		current_input_file = current_input_file->next;
-	}
-	rc = checkmodel(modeldata);
-	if(rc == -1)
-	{
-		free_modeldata(modeldata);
-		return 0;
-	}
-	
-	/* Calculate dependency graph for model functions */
-	rc = create_dependency_graph(directory, modeldata);
-	if(rc == -1)
-	{
-		free_modeldata(modeldata);
-		return 0;
-	}
-	
-	strcpy(filename, directory); strcat(filename, "Makefile");
-	strcpy(templatename, templatedirectory); strcat(templatename, "Makefile.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "xml.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "xml.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "main.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "main.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "header.h");
-	strcpy(templatename, templatedirectory); strcat(templatename, "header.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "memory.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "memory.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "low_primes.h");
-	strcpy(templatename, templatedirectory); strcat(templatename, "low_primes.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "messageboards.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "messageboards.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "partitioning.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "partitioning.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "timing.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "timing.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "Doxyfile");
-	strcpy(templatename, templatedirectory); strcat(templatename, "Doxyfile.tmpl");
-	parseTemplate(filename, templatename, modeldata);
-	strcpy(filename, directory); strcat(filename, "rules.c");
-	strcpy(templatename, templatedirectory); strcat(templatename, "rules.tmpl");
-	parseTemplate(filename, templatename, modeldata);
+
+    current_input_file = add_input_file(modeldata->p_files);
+    current_input_file->fullfilepath = copystr(inputfile);
+    current_input_file->fulldirectory = copystr(directory);
+    current_input_file->localdirectory = copystr("");
+
+    /* Read model from model xml file */
+    current_input_file = * modeldata->p_files;
+    while(current_input_file) {
+        if(current_input_file->enabled == 1)
+            readModel(current_input_file, directory, modeldata);
+
+        current_input_file = current_input_file->next;
+    }
+    rc = checkmodel(modeldata);
+    if(rc == -1) {
+        free_modeldata(modeldata);
+        return 0;
+    }
+
+    /* Calculate dependency graph for model functions */
+    rc = create_dependency_graph(directory, modeldata);
+    if(rc == -1) {
+        free_modeldata(modeldata);
+        return 0;
+    }
+
+    strcpy(filename, directory);
+    strcat(filename, "Makefile");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "Makefile.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "xml.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "xml.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "main.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "main.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "header.h");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "header.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "memory.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "memory.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "low_primes.h");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "low_primes.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "messageboards.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "messageboards.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "partitioning.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "partitioning.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "timing.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "timing.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "Doxyfile");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "Doxyfile.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
+    strcpy(filename, directory);
+    strcat(filename, "rules.c");
+    strcpy(tmpl_name, tmpl_directory);
+    strcat(tmpl_name, "rules.tmpl");
+    parseTemplate(filename, tmpl_name, modeldata);
 
     printf("\n");
-	parseAgentHeaderTemplate(directory, modeldata);
-	/*parseUnittest(directory, modeldata);*/
-	/*parser0dtd(directory, modeldata);*/
-	/*parser0xsd(directory, modeldata);*/
-	
-	free_modeldata(modeldata);
-	
-	printf("\n--- xparser finished ---\n\n");
-    
+    parseAgentHeaderTemplate(directory, modeldata);
+    /*parseUnittest(directory, modeldata);*/
+    /*parser0dtd(directory, modeldata);*/
+    /*parser0xsd(directory, modeldata);*/
+
+    free_modeldata(modeldata);
+
+    printf("\n--- xparser finished ---\n\n");
+
     printf("To compile and run the generated code, you will need:\n");
     printf(" * libmboard (version %s or newer)\n", LIBMBOARD_MINVER_STR);
-	
-	/* Exit successfully by returning zero to Operating System */
-	return 0;
+
+    /* Exit successfully by returning zero to Operating System */
+    return 0;
 }


### PR DESCRIPTION
This version of xparser was released by Chris Greenough in Feb. 2014.
It contains:
- Support for GNU GSL library for statistical functions
- System and FLAME environment variables (see Readme.txt):
1. System environment: FLAME_XPARSER_DIR: If this is set, xparser assumes the flame templates are in that folder. If not set, xparser looks in the current folder for templates.

2. Flame environment constant in model.xml to set the random seed: GSL_RNG_SEED.
If this constant is present in model.xml, then the Makefile_templ will include code to link in the GSL libraries. The RNG is initialized by code in main.templ as replacement for the standard RNG of C.

3. Setting the GSL random seed depends on whether xparser is run in debug or production mode:
a. In debug mode: value depends on user-defined constant GSL_RNG_SEED:
a1. If GSL_RNG_SEED == 0: set gsl_seed=gsl_rng_default_seed (0 by default).
a2. If GSL_RNG_SEED =!= 0: set gsl_seed=GSL_RNG_SEED (user-defined).
b. In production mode: value depends on value of gsl_rng_default_seed:
b1. If gsl_rng_default_seed ==0: gsl_seed is initialized on time (default).
b2. If gsl_rng_default_seed =!= 0: gsl_seed=gsl_rng_default_seed (see 4. below)

4. System environment: GSL_RNG_TYPE and GSL_RNG_SEED
- Without any environment variables, GSL uses the initial defaults, an mt19937 generator with a default seed of gsl_rng_default_seed=0.
- See also: https://www.gnu.org/software/gsl/manual/html_node/Random-number-environment-variables.html
