### PR TITLE
Set inputpath as global variable in main.tmpl

### DIFF
--- a/main.tmpl
+++ b/main.tmpl
@@ -16,6 +16,9 @@ unsigned long int gsl_seed;
 #endif
 <?end if?>
 
+/* Set inputpath as global variable */
+char inputpath[1000];
+
 #define COMPACT_PRINTOUT_P_THRESHOLD 8
 
 /** \fn int main(int argc, char * argv[])
@@ -30,7 +33,6 @@ int main(int argc, char * argv[])
 	FILE *file;
 	char data[100];
 	char logfilepath[1000];
-	char inputpath[1000];
 	char * c;
 	int lastd = 0;
 	int i;


### PR DESCRIPTION
The inputpath is the 2nd argument to the main executable, specifying the full path to the 0.xml file, including the filename (it is passed as argv[1] to the main executable). Here we expose it as a global variable, such that it can be used by other functions and in different files. This is useful for logging purposes as it is convenient to place the log files in the outputpath, which is constructed from the inputpath variable; outputpath is basically set equal to the input folder in the main.c by srtcpy(outputpath, inputpath) ).