### PR TITLE
IGNORE - Set inputfilepath as global variable

### DIFF
--- a/Readme2.txt
+++ b/Readme2.txt
@@ -21,3 +21,9 @@ b2. If gsl_rng_default_seed =!= 0: gsl_seed=gsl_rng_default_seed (see 4. below)
 4. System environment: GSL_RNG_TYPE and GSL_RNG_SEED
 - Without any environment variables, GSL uses the initial defaults, an mt19937 generator with a default seed of gsl_rng_default_seed=0.
 - See also: https://www.gnu.org/software/gsl/manual/html_node/Random-number-environment-variables.html
+
+5. Version of GSL
+
+The version of GSL that includes support for sampling from a multivariate normal distibution is:
+
+https://fossies.org/linux/misc/gsl-2.4.tar.gz/

--- a/header.tmpl
+++ b/header.tmpl
@@ -17,12 +17,24 @@
 #include <stdio.h>
 #include <math.h>
 #include <limits.h>
+#include <float.h>
 #include "mboard.h"
 
+/* Set ranges for FLAME write-out functions */
+
+/*User-defined ranges*/
+/*
 #define FLAME_INT_MAX (int)1e+12
 #define FLAME_DOUBLE_MAX 1e+12
 #define FLAME_INT_MIN (int)-1e+12
 #define FLAME_DOUBLE_MIN -1e+12
+*/
+
+/* Default C ranges (float.h, limits.h) */
+#define FLAME_INT_MAX INT_MAX
+#define FLAME_DOUBLE_MAX DBL_MAX
+#define FLAME_INT_MIN INT_MIN
+#define FLAME_DOUBLE_MIN -DBL_MAX
 
 #define FLAME_TEST_PRINT_START_AND_END_OF_MODEL_FUNCTIONS 0
 #define FLAME_TEST_PRINT_START_AND_END_OF_LIBMBOARD_CALLS 0

--- a/memory.tmpl
+++ b/memory.tmpl
@@ -461,8 +461,8 @@ void set_$name($type <?if dynamic_array?>* <?end if?><?if static_array?>*<?end i
 {
 <?foreach xagent?><?if allvar_in_agent?>	if(current_xmachine->xmachine_$name)
 	{
-		assert($allvar_name < FLAME_DOUBLE_MAX);
-		assert($allvar_name > FLAME_DOUBLE_MIN);
+		//assert($allvar_name < FLAME_DOUBLE_MAX);
+		//assert($allvar_name > FLAME_DOUBLE_MIN);
 		(*current_xmachine->xmachine_$name).$allvar_name = $allvar_name;
 	}
 <?end if?><?end foreach?>}

--- a/tests/test_agent_order/models/basic_agent_order/0.xml
+++ b/tests/test_agent_order/models/basic_agent_order/0.xml
@@ -1,0 +1,29 @@
+<states>
+<itno>0</itno>
+<environment>
+</environment>
+<xagent>
+<name>Agent</name>
+  <id>1</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>2</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>3</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>4</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>5</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>6</id>
+</xagent>
+</states>

--- a/tests/test_agent_order/models/basic_agent_order/agent_functions.c
+++ b/tests/test_agent_order/models/basic_agent_order/agent_functions.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include "header.h"
+#include "Agent_agent_header.h"
+
+int print_id(void)
+{
+	fprintf(stderr, "\nIT %d ID %d prints own ID", iteration_loop, ID);
+
+	return 0;
+}
+

--- a/tests/test_agent_order/models/basic_agent_order/model.xml
+++ b/tests/test_agent_order/models/basic_agent_order/model.xml
@@ -1,0 +1,35 @@
+ <xmodel version="2">
+ <name>Test Model - Xparser 0.17.1 Message randomization</name>
+ <version>Version 1.0, 18.01.2018</version>
+ <description>Author: Sander van der Hoog (svdhoog@gmail.com)</description>
+ <models/>
+  <environment>
+  <functionFiles>
+   <file>agent_functions.c</file>
+  </functionFiles>
+  </environment>
+  <agents>
+  <xagent>
+   <name>Agent</name>
+   <description></description>
+   <memory>
+    <variable>
+     <type>int</type>
+     <name>id</name>
+     <description>Agent ID.</description>
+    </variable>
+   </memory>
+    <functions>
+    <function>
+     <name>print_id</name>
+     <description></description>
+     <currentState>start_Agent</currentState>
+     <nextState>end_Agent</nextState>
+     <inputs/>
+     <outputs/>
+    </function>
+    </functions>
+  </xagent>
+ </agents>
+ <messages/>
+</xmodel>

--- a/tests/test_agent_order/models/basic_agent_order/test_output/test_output.txt
+++ b/tests/test_agent_order/models/basic_agent_order/test_output/test_output.txt
@@ -1,26 +1,23 @@
 Test basic_agent_order: 
-------------------------
+
 IT 1 ID 6 prints own ID
 IT 1 ID 5 prints own ID
 IT 1 ID 4 prints own ID
 IT 1 ID 3 prints own ID
 IT 1 ID 2 prints own ID
 IT 1 ID 1 prints own ID
-------------------------
 IT 2 ID 6 prints own ID
 IT 2 ID 5 prints own ID
 IT 2 ID 4 prints own ID
 IT 2 ID 3 prints own ID
 IT 2 ID 2 prints own ID
 IT 2 ID 1 prints own ID
-------------------------
 IT 3 ID 6 prints own ID
 IT 3 ID 5 prints own ID
 IT 3 ID 4 prints own ID
 IT 3 ID 3 prints own ID
 IT 3 ID 2 prints own ID
 IT 3 ID 1 prints own ID
-------------------------
 IT 4 ID 6 prints own ID
 IT 4 ID 5 prints own ID
 IT 4 ID 4 prints own ID

--- a/tests/test_agent_order/models/basic_agent_order/test_output/test_output.txt
+++ b/tests/test_agent_order/models/basic_agent_order/test_output/test_output.txt
@@ -1,0 +1,30 @@
+Test basic_agent_order: 
+------------------------
+IT 1 ID 6 prints own ID
+IT 1 ID 5 prints own ID
+IT 1 ID 4 prints own ID
+IT 1 ID 3 prints own ID
+IT 1 ID 2 prints own ID
+IT 1 ID 1 prints own ID
+------------------------
+IT 2 ID 6 prints own ID
+IT 2 ID 5 prints own ID
+IT 2 ID 4 prints own ID
+IT 2 ID 3 prints own ID
+IT 2 ID 2 prints own ID
+IT 2 ID 1 prints own ID
+------------------------
+IT 3 ID 6 prints own ID
+IT 3 ID 5 prints own ID
+IT 3 ID 4 prints own ID
+IT 3 ID 3 prints own ID
+IT 3 ID 2 prints own ID
+IT 3 ID 1 prints own ID
+------------------------
+IT 4 ID 6 prints own ID
+IT 4 ID 5 prints own ID
+IT 4 ID 4 prints own ID
+IT 4 ID 3 prints own ID
+IT 4 ID 2 prints own ID
+IT 4 ID 1 prints own ID
+------------------------

--- a/tests/test_agent_order/models/message_reading/0.xml
+++ b/tests/test_agent_order/models/message_reading/0.xml
@@ -1,0 +1,29 @@
+<states>
+<itno>0</itno>
+<environment>
+</environment>
+<xagent>
+<name>Agent</name>
+  <id>1</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>2</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>3</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>4</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>5</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>6</id>
+</xagent>
+</states>

--- a/tests/test_agent_order/models/message_reading/agent_functions.c
+++ b/tests/test_agent_order/models/message_reading/agent_functions.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include "header.h"
+#include "Agent_agent_header.h"
+
+int send(void)
+{
+	fprintf(stderr, "\nIT %d ID %d adds ID message", iteration_loop, ID);
+	add_info_message(ID);
+
+	return 0;
+}
+
+
+
+int print_id(void)
+{
+	fprintf(stderr, "\nIT %d ID %d prints own ID", iteration_loop, ID);
+
+	return 0;
+}
+
+int read(void)
+{
+	fprintf(stderr, "\nIT %d ID %d reads ID messages:\t", iteration_loop, ID);
+	START_INFO_MESSAGE_LOOP
+		fprintf(stderr, "%d ", info_message->id);
+	FINISH_INFO_MESSAGE_LOOP
+
+	return 0;
+}
+

--- a/tests/test_agent_order/models/message_reading/model.xml
+++ b/tests/test_agent_order/models/message_reading/model.xml
@@ -1,0 +1,74 @@
+ <xmodel version="2">
+ <name>Test Model - Xparser 0.17.1 Message randomization</name>
+ <version>Version 1.0, 18.01.2018</version>
+ <description>Author: Sander van der Hoog (svdhoog@gmail.com)</description>
+ <models/>
+  <environment>
+  <functionFiles>
+   <file>agent_functions.c</file>
+  </functionFiles>
+  </environment>
+  <agents>
+  <xagent>
+   <name>Agent</name>
+   <description></description>
+   <memory>
+    <variable>
+     <type>int</type>
+     <name>id</name>
+     <description>Agent ID.</description>
+    </variable>
+   </memory>
+    <functions>
+    <function>
+     <name>send</name>
+     <description></description>
+     <currentState>start_Agent</currentState>
+     <nextState>print_id</nextState>
+     <inputs/>
+     <outputs>
+      <output>
+       <messageName>info</messageName>
+      </output>
+     </outputs>
+    </function>
+
+
+    <function>
+     <name>print_id</name>
+     <description></description>
+     <currentState>print_id</currentState>
+     <nextState>read</nextState>
+     <inputs/>
+     <outputs/>
+    </function>
+
+    <function>
+     <name>read</name>
+     <description></description>
+     <currentState>read</currentState>
+     <nextState>end_Agent</nextState>
+     <inputs>
+      <input>
+       <messageName>info</messageName>
+      </input>
+      </inputs>
+     <outputs/>
+    </function>
+    </functions>
+  </xagent>
+ </agents>
+ <messages>
+  <message>
+   <name>info</name>
+   <description></description>
+   <variables>
+    <variable>
+     <type>int</type>
+     <name>id</name>
+     <description></description>
+    </variable>
+   </variables>
+  </message>
+ </messages>
+</xmodel>

--- a/tests/test_agent_order/models/message_reading/test_output/test_output.txt
+++ b/tests/test_agent_order/models/message_reading/test_output/test_output.txt
@@ -1,0 +1,86 @@
+Test message_reading: 
+------------------------
+IT 1 ID 6 adds ID message
+IT 1 ID 5 adds ID message
+IT 1 ID 4 adds ID message
+IT 1 ID 3 adds ID message
+IT 1 ID 2 adds ID message
+IT 1 ID 1 adds ID message
+------------------------
+IT 1 ID 1 prints own ID
+IT 1 ID 2 prints own ID
+IT 1 ID 3 prints own ID
+IT 1 ID 4 prints own ID
+IT 1 ID 5 prints own ID
+IT 1 ID 6 prints own ID
+------------------------
+IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 2 ID 6 adds ID message
+IT 2 ID 5 adds ID message
+IT 2 ID 4 adds ID message
+IT 2 ID 3 adds ID message
+IT 2 ID 2 adds ID message
+IT 2 ID 1 adds ID message
+------------------------
+IT 2 ID 1 prints own ID
+IT 2 ID 2 prints own ID
+IT 2 ID 3 prints own ID
+IT 2 ID 4 prints own ID
+IT 2 ID 5 prints own ID
+IT 2 ID 6 prints own ID
+------------------------
+IT 2 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 3 ID 6 adds ID message
+IT 3 ID 5 adds ID message
+IT 3 ID 4 adds ID message
+IT 3 ID 3 adds ID message
+IT 3 ID 2 adds ID message
+IT 3 ID 1 adds ID message
+------------------------
+IT 3 ID 1 prints own ID
+IT 3 ID 2 prints own ID
+IT 3 ID 3 prints own ID
+IT 3 ID 4 prints own ID
+IT 3 ID 5 prints own ID
+IT 3 ID 6 prints own ID
+------------------------
+IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 4 ID 6 adds ID message
+IT 4 ID 5 adds ID message
+IT 4 ID 4 adds ID message
+IT 4 ID 3 adds ID message
+IT 4 ID 2 adds ID message
+IT 4 ID 1 adds ID message
+------------------------
+IT 4 ID 1 prints own ID
+IT 4 ID 2 prints own ID
+IT 4 ID 3 prints own ID
+IT 4 ID 4 prints own ID
+IT 4 ID 5 prints own ID
+IT 4 ID 6 prints own ID
+------------------------
+IT 4 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------

--- a/tests/test_agent_order/models/message_reading/test_output/test_output.txt
+++ b/tests/test_agent_order/models/message_reading/test_output/test_output.txt
@@ -1,86 +1,51 @@
 Test message_reading: 
-------------------------
+
 IT 1 ID 6 adds ID message
 IT 1 ID 5 adds ID message
 IT 1 ID 4 adds ID message
 IT 1 ID 3 adds ID message
 IT 1 ID 2 adds ID message
 IT 1 ID 1 adds ID message
-------------------------
-IT 1 ID 1 prints own ID
-IT 1 ID 2 prints own ID
-IT 1 ID 3 prints own ID
-IT 1 ID 4 prints own ID
-IT 1 ID 5 prints own ID
-IT 1 ID 6 prints own ID
-------------------------
-IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
-IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
-IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
-IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
-IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
 IT 1 ID 1 reads ID messages:	6 5 4 3 2 1 
-------------------------
-IT 2 ID 6 adds ID message
-IT 2 ID 5 adds ID message
-IT 2 ID 4 adds ID message
-IT 2 ID 3 adds ID message
-IT 2 ID 2 adds ID message
+IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
 IT 2 ID 1 adds ID message
-------------------------
-IT 2 ID 1 prints own ID
-IT 2 ID 2 prints own ID
-IT 2 ID 3 prints own ID
-IT 2 ID 4 prints own ID
-IT 2 ID 5 prints own ID
-IT 2 ID 6 prints own ID
-------------------------
-IT 2 ID 6 reads ID messages:	6 5 4 3 2 1 
-IT 2 ID 5 reads ID messages:	6 5 4 3 2 1 
-IT 2 ID 4 reads ID messages:	6 5 4 3 2 1 
-IT 2 ID 3 reads ID messages:	6 5 4 3 2 1 
-IT 2 ID 2 reads ID messages:	6 5 4 3 2 1 
-IT 2 ID 1 reads ID messages:	6 5 4 3 2 1 
-------------------------
+IT 2 ID 2 adds ID message
+IT 2 ID 3 adds ID message
+IT 2 ID 4 adds ID message
+IT 2 ID 5 adds ID message
+IT 2 ID 6 adds ID message
+IT 2 ID 6 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 5 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 4 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 3 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 2 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 1 reads ID messages:	1 2 3 4 5 6 
 IT 3 ID 6 adds ID message
 IT 3 ID 5 adds ID message
 IT 3 ID 4 adds ID message
 IT 3 ID 3 adds ID message
 IT 3 ID 2 adds ID message
 IT 3 ID 1 adds ID message
-------------------------
-IT 3 ID 1 prints own ID
-IT 3 ID 2 prints own ID
-IT 3 ID 3 prints own ID
-IT 3 ID 4 prints own ID
-IT 3 ID 5 prints own ID
-IT 3 ID 6 prints own ID
-------------------------
-IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
-IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
-IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
-IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
-IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
 IT 3 ID 1 reads ID messages:	6 5 4 3 2 1 
-------------------------
-IT 4 ID 6 adds ID message
-IT 4 ID 5 adds ID message
-IT 4 ID 4 adds ID message
-IT 4 ID 3 adds ID message
-IT 4 ID 2 adds ID message
+IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
 IT 4 ID 1 adds ID message
-------------------------
-IT 4 ID 1 prints own ID
-IT 4 ID 2 prints own ID
-IT 4 ID 3 prints own ID
-IT 4 ID 4 prints own ID
-IT 4 ID 5 prints own ID
-IT 4 ID 6 prints own ID
-------------------------
-IT 4 ID 6 reads ID messages:	6 5 4 3 2 1 
-IT 4 ID 5 reads ID messages:	6 5 4 3 2 1 
-IT 4 ID 4 reads ID messages:	6 5 4 3 2 1 
-IT 4 ID 3 reads ID messages:	6 5 4 3 2 1 
-IT 4 ID 2 reads ID messages:	6 5 4 3 2 1 
-IT 4 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 2 adds ID message
+IT 4 ID 3 adds ID message
+IT 4 ID 4 adds ID message
+IT 4 ID 5 adds ID message
+IT 4 ID 6 adds ID message
+IT 4 ID 6 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 5 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 4 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 3 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 2 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 1 reads ID messages:	1 2 3 4 5 6 
 ------------------------

--- a/tests/test_agent_order/models/message_reading_print/0.xml
+++ b/tests/test_agent_order/models/message_reading_print/0.xml
@@ -1,0 +1,29 @@
+<states>
+<itno>0</itno>
+<environment>
+</environment>
+<xagent>
+<name>Agent</name>
+  <id>1</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>2</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>3</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>4</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>5</id>
+</xagent>
+<xagent>
+<name>Agent</name>
+  <id>6</id>
+</xagent>
+</states>

--- a/tests/test_agent_order/models/message_reading_print/agent_functions.c
+++ b/tests/test_agent_order/models/message_reading_print/agent_functions.c
@@ -11,6 +11,14 @@ int send(void)
 }
 
 
+
+int print_id(void)
+{
+	fprintf(stderr, "\nIT %d ID %d prints own ID", iteration_loop, ID);
+
+	return 0;
+}
+
 int read(void)
 {
 	fprintf(stderr, "\nIT %d ID %d reads ID messages:\t", iteration_loop, ID);

--- a/tests/test_agent_order/models/message_reading_print/model.xml
+++ b/tests/test_agent_order/models/message_reading_print/model.xml
@@ -24,13 +24,23 @@
      <name>send</name>
      <description></description>
      <currentState>start_Agent</currentState>
-     <nextState>read</nextState>
+     <nextState>print_id</nextState>
      <inputs/>
      <outputs>
       <output>
        <messageName>info</messageName>
       </output>
      </outputs>
+    </function>
+
+
+    <function>
+     <name>print_id</name>
+     <description></description>
+     <currentState>print_id</currentState>
+     <nextState>read</nextState>
+     <inputs/>
+     <outputs/>
     </function>
 
     <function>

--- a/tests/test_agent_order/models/message_reading_print/test_output/test_output.txt
+++ b/tests/test_agent_order/models/message_reading_print/test_output/test_output.txt
@@ -1,0 +1,75 @@
+Test message_reading_print: 
+
+IT 1 ID 6 adds ID message
+IT 1 ID 5 adds ID message
+IT 1 ID 4 adds ID message
+IT 1 ID 3 adds ID message
+IT 1 ID 2 adds ID message
+IT 1 ID 1 adds ID message
+IT 1 ID 1 prints own ID
+IT 1 ID 2 prints own ID
+IT 1 ID 3 prints own ID
+IT 1 ID 4 prints own ID
+IT 1 ID 5 prints own ID
+IT 1 ID 6 prints own ID
+IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 6 adds ID message
+IT 2 ID 5 adds ID message
+IT 2 ID 4 adds ID message
+IT 2 ID 3 adds ID message
+IT 2 ID 2 adds ID message
+IT 2 ID 1 adds ID message
+IT 2 ID 1 prints own ID
+IT 2 ID 2 prints own ID
+IT 2 ID 3 prints own ID
+IT 2 ID 4 prints own ID
+IT 2 ID 5 prints own ID
+IT 2 ID 6 prints own ID
+IT 2 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 6 adds ID message
+IT 3 ID 5 adds ID message
+IT 3 ID 4 adds ID message
+IT 3 ID 3 adds ID message
+IT 3 ID 2 adds ID message
+IT 3 ID 1 adds ID message
+IT 3 ID 1 prints own ID
+IT 3 ID 2 prints own ID
+IT 3 ID 3 prints own ID
+IT 3 ID 4 prints own ID
+IT 3 ID 5 prints own ID
+IT 3 ID 6 prints own ID
+IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 6 adds ID message
+IT 4 ID 5 adds ID message
+IT 4 ID 4 adds ID message
+IT 4 ID 3 adds ID message
+IT 4 ID 2 adds ID message
+IT 4 ID 1 adds ID message
+IT 4 ID 1 prints own ID
+IT 4 ID 2 prints own ID
+IT 4 ID 3 prints own ID
+IT 4 ID 4 prints own ID
+IT 4 ID 5 prints own ID
+IT 4 ID 6 prints own ID
+IT 4 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------

--- a/tests/test_agent_order/parse.sh
+++ b/tests/test_agent_order/parse.sh
@@ -7,7 +7,7 @@ cd $FLAME_XPARSER_DIR
 
 echo "Now here: $PWD"
 
-export TESTS="basic_agent_order message_reading"
+export TESTS="basic_agent_order message_reading message_reading_print"
 
 for i in $TESTS; do
 

--- a/tests/test_agent_order/parse.sh
+++ b/tests/test_agent_order/parse.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Path to xparser
+export FLAME_XPARSER_DIR="$PWD/../.."
+
+cd $FLAME_XPARSER_DIR
+
+echo "Now here: $PWD"
+
+export TESTS="basic_agent_order message_reading"
+
+for i in $TESTS; do
+
+	# Parse model 
+	export MODEL_DIR="$FLAME_XPARSER_DIR/tests/test_agent_order/models/$i"
+
+	cd $FLAME_XPARSER_DIR
+
+	./xparser $MODEL_DIR/model.xml
+
+	cd $MODEL_DIR
+
+	# Build model
+	make clean all
+
+done
+
+echo 'Script done.'

--- a/tests/test_agent_order/readme.md
+++ b/tests/test_agent_order/readme.md
@@ -7,10 +7,10 @@ This test is meant for checking agent order of function execution.
 Observations:
 
 1. The original order of agents in the 0.xml file is inverted due to the xml read-in function.
-2. If the agents only print out their IDs (no messages send and read), then the order is maintained.
-3. If messages are send and read, then the order gets inverted upon activating the read function, and then remains that order also for the next add-message functions, until the next message loop.
+2. If the agents only print out their IDs (no messages send and read), then this inversed order is maintained throughout.
+3. If messages are send and read, then the order gets inverted again upon activating a read function, and then remains that order also for the next add-message functions, until the next function that has a read message loop.
 4. If, in addition, a function is inserted between the write and read functions, then the order is again reversed.
-5. Each new iteration starts with the same agent order as at the end of the previous iteration.
+5. Each new iteration starts with the same agent order as it was at the end of the previous iteration. (So it is not true that the agent order gets reset to its reversed read-in order from 0.xml)
 
 Hypothesis:
 

--- a/tests/test_agent_order/readme.md
+++ b/tests/test_agent_order/readme.md
@@ -23,6 +23,7 @@ Test model:
 
 Output:
 
+```
 ------------------------
 IT 1 ID 6
 IT 1 ID 5
@@ -52,6 +53,7 @@ IT 4 ID 3
 IT 4 ID 2
 IT 4 ID 1
 ------------------------
+```
 
 3. However, if messages are send and read, the order is again inverted upon activating the read function (function with message input).
 Also note that the agent order at the start of a new iteration is the same as at the end of the previous iteration, so it does not revert to the original order it has after reading from the 0.xml.
@@ -61,60 +63,61 @@ Test model:
 
 Output:
 
+```
 ------------------------
-IT 1 ID 6 adds info message
-IT 1 ID 5 adds info message
-IT 1 ID 4 adds info message
-IT 1 ID 3 adds info message
-IT 1 ID 2 adds info message
-IT 1 ID 1 adds info message
-IT 1 ID: 1 reads info messages:     6 5 4 3 
-IT 1 ID: 2 reads info messages:     6 5 4 3 
-IT 1 ID: 3 reads info messages:     6 5 4 3 
-IT 1 ID: 4 reads info messages:     6 5 4 3 
-IT 1 ID: 5 reads info messages:     6 5 4 3 
-IT 1 ID: 6 reads info messages:     6 5 4 3 
+IT 1 ID 6 adds ID message
+IT 1 ID 5 adds ID message
+IT 1 ID 4 adds ID message
+IT 1 ID 3 adds ID message
+IT 1 ID 2 adds ID message
+IT 1 ID 1 adds ID message
+IT 1 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
 ------------------------
-IT 2 ID 1 adds info message
-IT 2 ID 2 adds info message
-IT 2 ID 3 adds info message
-IT 2 ID 4 adds info message
-IT 2 ID 5 adds info message
-IT 2 ID 6 adds info message
-IT 2 ID: 6 reads info messages:     3 4 5 6 
-IT 2 ID: 5 reads info messages:     3 4 5 6 
-IT 2 ID: 4 reads info messages:     3 4 5 6 
-IT 2 ID: 3 reads info messages:     3 4 5 6 
-IT 2 ID: 2 reads info messages:     3 4 5 6 
-IT 2 ID: 1 reads info messages:     3 4 5 6 
+IT 2 ID 1 adds ID message
+IT 2 ID 2 adds ID message
+IT 2 ID 3 adds ID message
+IT 2 ID 4 adds ID message
+IT 2 ID 5 adds ID message
+IT 2 ID 6 adds ID message
+IT 2 ID 6 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 5 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 4 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 3 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 2 reads ID messages:	1 2 3 4 5 6 
+IT 2 ID 1 reads ID messages:	1 2 3 4 5 6 
 ------------------------
-IT 3 ID 6 adds info message
-IT 3 ID 5 adds info message
-IT 3 ID 4 adds info message
-IT 3 ID 3 adds info message
-IT 3 ID 2 adds info message
-IT 3 ID 1 adds info message
-IT 3 ID: 1 reads info messages:     6 5 4 3 
-IT 3 ID: 2 reads info messages:     6 5 4 3 
-IT 3 ID: 3 reads info messages:     6 5 4 3 
-IT 3 ID: 4 reads info messages:     6 5 4 3 
-IT 3 ID: 5 reads info messages:     6 5 4 3 
-IT 3 ID: 6 reads info messages:     6 5 4 3 
+IT 3 ID 6 adds ID message
+IT 3 ID 5 adds ID message
+IT 3 ID 4 adds ID message
+IT 3 ID 3 adds ID message
+IT 3 ID 2 adds ID message
+IT 3 ID 1 adds ID message
+IT 3 ID 1 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
 ------------------------
-IT 4 ID 1 adds info message
-IT 4 ID 2 adds info message
-IT 4 ID 3 adds info message
-IT 4 ID 4 adds info message
-IT 4 ID 5 adds info message
-IT 4 ID 6 adds info message
-IT 4 ID: 6 reads info messages:     3 4 5 6 
-IT 4 ID: 5 reads info messages:     3 4 5 6 
-IT 4 ID: 4 reads info messages:     3 4 5 6 
-IT 4 ID: 3 reads info messages:     3 4 5 6 
-IT 4 ID: 2 reads info messages:     3 4 5 6 
-IT 4 ID: 1 reads info messages:     3 4 5 6 
+IT 4 ID 1 adds ID message
+IT 4 ID 2 adds ID message
+IT 4 ID 3 adds ID message
+IT 4 ID 4 adds ID message
+IT 4 ID 5 adds ID message
+IT 4 ID 6 adds ID message
+IT 4 ID 6 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 5 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 4 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 3 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 2 reads ID messages:	1 2 3 4 5 6 
+IT 4 ID 1 reads ID messages:	1 2 3 4 5 6 
 ------------------------
-
+```
 
 4. Now we add an additional function inbetween the write-read functions that only prints out the agent IDs.
 
@@ -123,7 +126,7 @@ Test model:
 
 Output:
 
-Test message_reading: 
+```
 ------------------------
 IT 1 ID 6 adds ID message
 IT 1 ID 5 adds ID message
@@ -209,5 +212,6 @@ IT 4 ID 3 reads ID messages:	6 5 4 3 2 1
 IT 4 ID 2 reads ID messages:	6 5 4 3 2 1 
 IT 4 ID 1 reads ID messages:	6 5 4 3 2 1 
 ------------------------
+```
  
 5. Note that here, again, each new iteration starts with the same agent order as at the end of the previous iteration.

--- a/tests/test_agent_order/readme.md
+++ b/tests/test_agent_order/readme.md
@@ -1,0 +1,101 @@
+Tests for XParser
+Author: Sander van der Hoog
+Date: 5 Sept 2018
+
+This test is meant for checking agent order of function execution.
+
+1. The original order of agents in the 0.xml file is inverted due to the xml read-in function.
+2. If the agents only print out their IDs (no messages send and read), the order is maintained:
+
+Output:
+
+------------------------
+IT 1 ID 6
+IT 1 ID 5
+IT 1 ID 4
+IT 1 ID 3
+IT 1 ID 2
+IT 1 ID 1
+------------------------
+IT 2 ID 6
+IT 2 ID 5
+IT 2 ID 4
+IT 2 ID 3
+IT 2 ID 2
+IT 2 ID 1
+------------------------
+IT 3 ID 6
+IT 3 ID 5
+IT 3 ID 4
+IT 3 ID 3
+IT 3 ID 2
+IT 3 ID 1
+------------------------
+IT 4 ID 6
+IT 4 ID 5
+IT 4 ID 4
+IT 4 ID 3
+IT 4 ID 2
+IT 4 ID 1
+------------------------
+
+3. However, if messages are send and read, the order is again inverted upon activating the read function (function with message input).:
+
+Test model:
+- test_filtering: 
+
+Output:
+
+------------------------
+IT 1 ID 6 adds info message
+IT 1 ID 5 adds info message
+IT 1 ID 4 adds info message
+IT 1 ID 3 adds info message
+IT 1 ID 2 adds info message
+IT 1 ID 1 adds info message
+IT 1 ID: 1 reads info messages:     6 5 4 3 
+IT 1 ID: 2 reads info messages:     6 5 4 3 
+IT 1 ID: 3 reads info messages:     6 5 4 3 
+IT 1 ID: 4 reads info messages:     6 5 4 3 
+IT 1 ID: 5 reads info messages:     6 5 4 3 
+IT 1 ID: 6 reads info messages:     6 5 4 3 
+------------------------
+IT 2 ID 1 adds info message
+IT 2 ID 2 adds info message
+IT 2 ID 3 adds info message
+IT 2 ID 4 adds info message
+IT 2 ID 5 adds info message
+IT 2 ID 6 adds info message
+IT 2 ID: 6 reads info messages:     3 4 5 6 
+IT 2 ID: 5 reads info messages:     3 4 5 6 
+IT 2 ID: 4 reads info messages:     3 4 5 6 
+IT 2 ID: 3 reads info messages:     3 4 5 6 
+IT 2 ID: 2 reads info messages:     3 4 5 6 
+IT 2 ID: 1 reads info messages:     3 4 5 6 
+------------------------
+IT 3 ID 6 adds info message
+IT 3 ID 5 adds info message
+IT 3 ID 4 adds info message
+IT 3 ID 3 adds info message
+IT 3 ID 2 adds info message
+IT 3 ID 1 adds info message
+IT 3 ID: 1 reads info messages:     6 5 4 3 
+IT 3 ID: 2 reads info messages:     6 5 4 3 
+IT 3 ID: 3 reads info messages:     6 5 4 3 
+IT 3 ID: 4 reads info messages:     6 5 4 3 
+IT 3 ID: 5 reads info messages:     6 5 4 3 
+IT 3 ID: 6 reads info messages:     6 5 4 3 
+------------------------
+IT 4 ID 1 adds info message
+IT 4 ID 2 adds info message
+IT 4 ID 3 adds info message
+IT 4 ID 4 adds info message
+IT 4 ID 5 adds info message
+IT 4 ID 6 adds info message
+IT 4 ID: 6 reads info messages:     3 4 5 6 
+IT 4 ID: 5 reads info messages:     3 4 5 6 
+IT 4 ID: 4 reads info messages:     3 4 5 6 
+IT 4 ID: 3 reads info messages:     3 4 5 6 
+IT 4 ID: 2 reads info messages:     3 4 5 6 
+IT 4 ID: 1 reads info messages:     3 4 5 6 
+------------------------

--- a/tests/test_agent_order/readme.md
+++ b/tests/test_agent_order/readme.md
@@ -4,8 +4,22 @@ Date: 5 Sept 2018
 
 This test is meant for checking agent order of function execution.
 
+Observations:
+
 1. The original order of agents in the 0.xml file is inverted due to the xml read-in function.
-2. If the agents only print out their IDs (no messages send and read), the order is maintained:
+2. If the agents only print out their IDs (no messages send and read), then the order is maintained.
+3. If messages are send and read, then the order gets inverted upon activating the read function, and then remains that order also for the next add-message functions, until the next message loop.
+4. If, in addition, a function is inserted between the write and read functions, then the order is again reversed.
+5. Each new iteration starts with the same agent order as at the end of the previous iteration.
+
+Hypothesis:
+
+The reversal is caused by an agent-iterator related to functions that have message input/output.
+
+The problem is *not* related to the message iterator itself (in the message loop), since the order in which messages appear in the message loop (for a single agent) is the same order as the messages were added by the agents.
+
+Test model:
+- basic_agent_order
 
 Output:
 
@@ -39,10 +53,11 @@ IT 4 ID 2
 IT 4 ID 1
 ------------------------
 
-3. However, if messages are send and read, the order is again inverted upon activating the read function (function with message input).:
+3. However, if messages are send and read, the order is again inverted upon activating the read function (function with message input).
+Also note that the agent order at the start of a new iteration is the same as at the end of the previous iteration, so it does not revert to the original order it has after reading from the 0.xml.
 
 Test model:
-- test_filtering: 
+- message_reading: 
 
 Output:
 
@@ -99,3 +114,100 @@ IT 4 ID: 3 reads info messages:     3 4 5 6
 IT 4 ID: 2 reads info messages:     3 4 5 6 
 IT 4 ID: 1 reads info messages:     3 4 5 6 
 ------------------------
+
+
+4. Now we add an additional function inbetween the write-read functions that only prints out the agent IDs.
+
+Test model:
+- message_reading_print: 
+
+Output:
+
+Test message_reading: 
+------------------------
+IT 1 ID 6 adds ID message
+IT 1 ID 5 adds ID message
+IT 1 ID 4 adds ID message
+IT 1 ID 3 adds ID message
+IT 1 ID 2 adds ID message
+IT 1 ID 1 adds ID message
+------------------------
+IT 1 ID 1 prints own ID
+IT 1 ID 2 prints own ID
+IT 1 ID 3 prints own ID
+IT 1 ID 4 prints own ID
+IT 1 ID 5 prints own ID
+IT 1 ID 6 prints own ID
+------------------------
+IT 1 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 1 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 2 ID 6 adds ID message
+IT 2 ID 5 adds ID message
+IT 2 ID 4 adds ID message
+IT 2 ID 3 adds ID message
+IT 2 ID 2 adds ID message
+IT 2 ID 1 adds ID message
+------------------------
+IT 2 ID 1 prints own ID
+IT 2 ID 2 prints own ID
+IT 2 ID 3 prints own ID
+IT 2 ID 4 prints own ID
+IT 2 ID 5 prints own ID
+IT 2 ID 6 prints own ID
+------------------------
+IT 2 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 2 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 3 ID 6 adds ID message
+IT 3 ID 5 adds ID message
+IT 3 ID 4 adds ID message
+IT 3 ID 3 adds ID message
+IT 3 ID 2 adds ID message
+IT 3 ID 1 adds ID message
+------------------------
+IT 3 ID 1 prints own ID
+IT 3 ID 2 prints own ID
+IT 3 ID 3 prints own ID
+IT 3 ID 4 prints own ID
+IT 3 ID 5 prints own ID
+IT 3 ID 6 prints own ID
+------------------------
+IT 3 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 3 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+IT 4 ID 6 adds ID message
+IT 4 ID 5 adds ID message
+IT 4 ID 4 adds ID message
+IT 4 ID 3 adds ID message
+IT 4 ID 2 adds ID message
+IT 4 ID 1 adds ID message
+------------------------
+IT 4 ID 1 prints own ID
+IT 4 ID 2 prints own ID
+IT 4 ID 3 prints own ID
+IT 4 ID 4 prints own ID
+IT 4 ID 5 prints own ID
+IT 4 ID 6 prints own ID
+------------------------
+IT 4 ID 6 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 5 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 4 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 3 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 2 reads ID messages:	6 5 4 3 2 1 
+IT 4 ID 1 reads ID messages:	6 5 4 3 2 1 
+------------------------
+ 
+5. Note that here, again, each new iteration starts with the same agent order as at the end of the previous iteration.

--- a/tests/test_agent_order/readme.md
+++ b/tests/test_agent_order/readme.md
@@ -1,5 +1,7 @@
 Tests for XParser
+
 Author: Sander van der Hoog
+
 Date: 5 Sept 2018
 
 This test is meant for checking agent order of function execution.

--- a/tests/test_agent_order/run_all_tests.sh
+++ b/tests/test_agent_order/run_all_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export TESTS="basic_agent_order message_reading"
+export TESTS="basic_agent_order message_reading message_reading_print"
 
 export BASE=$PWD
 

--- a/tests/test_agent_order/run_all_tests.sh
+++ b/tests/test_agent_order/run_all_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+export TESTS="basic_agent_order message_reading"
+
+export BASE=$PWD
+
+for i in $TESTS; do
+	
+	# Cleanup files
+	rm $BASE/models/$i/test_output/test_output.txt
+
+	echo "Running model_$i"
+
+	cd $BASE/models/$i
+		
+	echo "Test $i: " >>"$BASE/models/$i/test_output/test_output.txt"
+
+	./main 4 0.xml 2>>"$BASE/models/$i/test_output/test_output.txt"
+
+	echo "" >> "$BASE/models/$i/test_output/test_output.txt"
+	
+	echo "------------------------" >> "$BASE/models/$i/test_output/test_output.txt"
+	echo "------------------------"
+done

--- a/xml.tmpl
+++ b/xml.tmpl
@@ -1352,6 +1352,7 @@ void write_int_static_array(FILE *file, int * temp, int size)
 	fputs("{", file);
 	for(i=0; i<size; i++)
 	{
+		assert(!((temp[i])!=(temp[i])));
 		assert(temp[i] < FLAME_INT_MAX);
 		assert(temp[i] > FLAME_INT_MIN);
 		sprintf(data, "%i", temp[i]);
@@ -1372,6 +1373,7 @@ void write_float_static_array(FILE *file, float * temp, int size)
 	fputs("{", file);
 	for(i=0; i<size; i++)
 	{
+		assert(!((temp[i])!=(temp[i])));
 		assert(temp[i] < FLAME_DOUBLE_MAX);
 		assert(temp[i] > FLAME_DOUBLE_MIN);
 		sprintf(data, "%f", temp[i]);
@@ -1392,6 +1394,7 @@ void write_double_static_array(FILE *file, double * temp, int size)
 	fputs("{", file);
 	for(i=0; i<size; i++)
 	{
+		assert(!((temp[i])!=(temp[i])));
 		assert(temp[i] < FLAME_DOUBLE_MAX);
 		assert(temp[i] > FLAME_DOUBLE_MIN);
 		sprintf(data, "%f", temp[i]);
@@ -1430,6 +1433,7 @@ void write_int_dynamic_array(FILE *file, int_array * temp)
 	fputs("{", file);
 	for(i=0; i<(*temp).size; i++)
 	{
+		assert(!(((*temp).array[i])!=((*temp).array[i])));
 		assert((*temp).array[i] < FLAME_INT_MAX);
 		assert((*temp).array[i] > FLAME_INT_MIN);
 		sprintf(data, "%i", (*temp).array[i]);
@@ -1450,6 +1454,7 @@ void write_float_dynamic_array(FILE *file, float_array * temp)
 	fputs("{", file);
 	for(i=0; i<(*temp).size; i++)
 	{
+		assert(!(((*temp).array[i])!=((*temp).array[i])));
 		assert((*temp).array[i] < FLAME_DOUBLE_MAX);
 		assert((*temp).array[i] > FLAME_DOUBLE_MIN);
 		sprintf(data, "%f", (*temp).array[i]);
@@ -1470,6 +1475,7 @@ void write_double_dynamic_array(FILE *file, double_array * temp)
 	fputs("{", file);
 	for(i=0; i<(*temp).size; i++)
 	{
+		assert(!(((*temp).array[i])!=((*temp).array[i])));
 		assert((*temp).array[i] < FLAME_DOUBLE_MAX);
 		assert((*temp).array[i] > FLAME_DOUBLE_MIN);
 		sprintf(data, "%f", (*temp).array[i]);
@@ -1502,7 +1508,11 @@ void write_$name(FILE *file, $name * temp_datatype)
 	<?if single_vars?>char data[1000];<?end if?>
 
 	fputs("{", file);
-<?foreach datatypevar?>	<?if not_modeldatatype?><?if not_array?>sprintf(data, "%$c_type", (*temp_datatype).$name);
+<?foreach datatypevar?>	<?if not_modeldatatype?><?if not_array?>
+	assert(!(((*temp_datatype).$name)!=((*temp_datatype).$name)));
+	assert((*temp_datatype).$name < FLAME_DOUBLE_MAX);
+	assert((*temp_datatype).$name > FLAME_DOUBLE_MIN);
+	sprintf(data, "%$c_type", (*temp_datatype).$name);
 	fputs(data, file);<?end if?><?if static_array?>write_$type_static_array(file, (*temp_datatype).$name, $arraylength);<?end if?><?if dynamic_array?>write_$notarraytype_dynamic_array(file, &(*temp_datatype).$name);<?end if?><?end if?><?if modeldatatype?><?if not_array?>write_$type(file, &(*temp_datatype).$name);<?end if?><?if static_array?>write_$type_static_array(file, (*temp_datatype).$name, $arraylength);<?end if?><?if dynamic_array?>write_$notarraytype_dynamic_array(file, &(*temp_datatype).$name);<?end if?><?end if?><?if notlast?>
 	fputs(", ", file);<?end if?><?end foreach?>
 	fputs("}", file);
@@ -1544,9 +1554,10 @@ void write_$name_agent(FILE *file, xmachine_memory_$name * current)
 	fputs("<xagent>\n" , file);
 	fputs("<name>$name</name>\n", file);
 <?foreach xagentvar?>		fputs("<$name>", file);
-	<?if not_array?><?if not_modeldatatype?>	
-	//assert(current->$name < FLAME_DOUBLE_MAX);
-	//assert(current->$name > FLAME_DOUBLE_MIN);
+	<?if not_array?><?if not_modeldatatype?>
+	assert(!((current->$name)!=(current->$name)));
+	assert(current->$name < FLAME_DOUBLE_MAX);
+	assert(current->$name > FLAME_DOUBLE_MIN);
 	sprintf(data, "%$c_type", current->$name);
 	fputs(data, file);<?end if?><?if modeldatatype?>write_$type(file, &current->$name);<?end if?><?end if?><?if static_array?>write_$type_static_array(file, current->$name, $arraylength);<?end if?><?if dynamic_array?>write_$notarraytype_dynamic_array(file, &current->$name);<?end if?>
 	fputs("</$name>\n", file);

--- a/xml.tmpl
+++ b/xml.tmpl
@@ -5,6 +5,8 @@
 
 #include "header.h"
 
+#define CONST_BUFFER_SIZE 1000000
+
 /** \fn void read_int_static_array(char * buffer, int * j, int ** int_static_array)
  * \brief Reads integer static array.
  */
@@ -12,7 +14,7 @@ int read_int_static_array(char * buffer, int /*@unused@*/ buffer_size, int * j, 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 	
 	while(buffer[(*j)] != '{')
 	{
@@ -55,7 +57,7 @@ int read_float_static_array(char * buffer, int /*@unused@*/ buffer_size, int * j
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -98,7 +100,7 @@ int read_double_static_array(char * buffer, int /*@unused@*/ buffer_size, int * 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -163,7 +165,7 @@ int read_int_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * j,
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -200,7 +202,7 @@ int read_float_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -237,7 +239,7 @@ int read_double_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int *
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -295,7 +297,7 @@ int read_char_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * j
 int read_$name(char * buffer, int /*@unused@*/ buffer_size, int * j, $name * temp_datatype)
 {
 	<?if single_vars?>int array_k;
-	char arraydata[100000];<?end if?>
+	char arraydata[CONST_BUFFER_SIZE];<?end if?>
 	<?if has_arrays_or_adts?>int rc;<?end if?>
 	
 	while(buffer[(*j)] != '{')
@@ -405,7 +407,7 @@ int readEnvironmentXML(char * location)
 {
 	FILE * file;
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	int index = 0;
 	int in_environment = 0;
 	<?foreach envvar?>int in_$name = 0;
@@ -450,7 +452,13 @@ int readEnvironmentXML(char * location)
 		else
 		{
 			buffer[index] = c;
-			if(index < 999) index++;
+			if(index < CONST_BUFFER_SIZE-1) index++;
+            else
+            {
+                printf("Error: environment reading buffer too small\n");
+                printf("%s\n", buffer);
+                exit(0);
+            }            
 		}
 	}
 	/* Close file */
@@ -469,7 +477,7 @@ int readAgentXML(char * location,
 {
 	FILE * file;
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char agentname[10000];
 	int index = 0;
 	int j; /* Index for reading arrays */
@@ -626,10 +634,10 @@ int readAgentXML(char * location,
 		else
 		{
 			buffer[index] = c;
-			if(index < 99999) index++;
+            if(index < CONST_BUFFER_SIZE-1) index++;
 			else
 			{
-				printf("Error: agent reading buffer too small\n");
+                printf("Error: agent reading buffer too small\nAt index: %d Buffer size: %d", index, CONST_BUFFER_SIZE);
 				printf("%s\n", buffer);
 				exit(0);
 			}
@@ -680,7 +688,7 @@ void readprepartitionedinitialstates(char * fileroot, char * filelocation, int *
 	FILE *file;
 	/* Char and char buffer for reading file to */
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char FLAME_location[10000];
 	char FLAME_format[10000];
 	char FLAME_type[10000];
@@ -709,7 +717,7 @@ void readprepartitionedinitialstates(char * fileroot, char * filelocation, int *
 	int node_number=0;
 	int agent_count = 0;
 	/* Filename must be constructed from fileroot argument */ 
-	char filename[100000];
+	char filename[1000000];
 	/* Following variables required by readAgentXML. */
 	double cloud_data[6];
 	int flag = 0; /* Set flag=0 so readAgentXML reads and adds agents and does nothing else. */
@@ -992,7 +1000,7 @@ void readinitialstates(char * filename, char * filelocation, int * itno, double 
 	FILE *file;
 	/* Char and char buffer for reading file to */
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char FLAME_location[10000];
 	char FLAME_format[10000];
 	char FLAME_type[10000];

--- a/xml.tmpl
+++ b/xml.tmpl
@@ -5,6 +5,8 @@
 
 #include "header.h"
 
+#define CONST_BUFFER_SIZE 1000000
+
 /** \fn void read_int_static_array(char * buffer, int * j, int ** int_static_array)
  * \brief Reads integer static array.
  */
@@ -12,7 +14,7 @@ int read_int_static_array(char * buffer, int /*@unused@*/ buffer_size, int * j, 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 	
 	while(buffer[(*j)] != '{')
 	{
@@ -55,7 +57,7 @@ int read_float_static_array(char * buffer, int /*@unused@*/ buffer_size, int * j
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -98,7 +100,7 @@ int read_double_static_array(char * buffer, int /*@unused@*/ buffer_size, int * 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -163,7 +165,7 @@ int read_int_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * j,
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -200,7 +202,7 @@ int read_float_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * 
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -237,7 +239,7 @@ int read_double_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int *
 {
 	int arraycount = 0;
 	int array_k;
-	char arraydata[100000];
+	char arraydata[CONST_BUFFER_SIZE];
 
 	while(buffer[(*j)] != '{')
 	{
@@ -295,7 +297,7 @@ int read_char_dynamic_array(char * buffer, int /*@unused@*/ buffer_size, int * j
 int read_$name(char * buffer, int /*@unused@*/ buffer_size, int * j, $name * temp_datatype)
 {
 	<?if single_vars?>int array_k;
-	char arraydata[100000];<?end if?>
+	char arraydata[CONST_BUFFER_SIZE];<?end if?>
 	<?if has_arrays_or_adts?>int rc;<?end if?>
 	
 	while(buffer[(*j)] != '{')
@@ -405,7 +407,7 @@ int readEnvironmentXML(char * location)
 {
 	FILE * file;
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	int index = 0;
 	int in_environment = 0;
 	<?foreach envvar?>int in_$name = 0;
@@ -450,7 +452,13 @@ int readEnvironmentXML(char * location)
 		else
 		{
 			buffer[index] = c;
-			if(index < 999) index++;
+			if(index < CONST_BUFFER_SIZE-1) index++;
+            else
+            {
+                printf("Error: environment reading buffer too small\n");
+                printf("%s\n", buffer);
+                exit(0);
+            }            
 		}
 	}
 	/* Close file */
@@ -469,7 +477,7 @@ int readAgentXML(char * location,
 {
 	FILE * file;
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char agentname[10000];
 	int index = 0;
 	int j; /* Index for reading arrays */
@@ -626,10 +634,10 @@ int readAgentXML(char * location,
 		else
 		{
 			buffer[index] = c;
-			if(index < 99999) index++;
+            if(index < CONST_BUFFER_SIZE-1) index++;
 			else
 			{
-				printf("Error: agent reading buffer too small\n");
+                printf("Error: agent reading buffer too small\nAt index: %d Buffer sizeÖ %d", index);
 				printf("%s\n", buffer);
 				exit(0);
 			}
@@ -680,7 +688,7 @@ void readprepartitionedinitialstates(char * fileroot, char * filelocation, int *
 	FILE *file;
 	/* Char and char buffer for reading file to */
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char FLAME_location[10000];
 	char FLAME_format[10000];
 	char FLAME_type[10000];
@@ -709,7 +717,7 @@ void readprepartitionedinitialstates(char * fileroot, char * filelocation, int *
 	int node_number=0;
 	int agent_count = 0;
 	/* Filename must be constructed from fileroot argument */ 
-	char filename[100000];
+	char filename[1000000];
 	/* Following variables required by readAgentXML. */
 	double cloud_data[6];
 	int flag = 0; /* Set flag=0 so readAgentXML reads and adds agents and does nothing else. */
@@ -992,7 +1000,7 @@ void readinitialstates(char * filename, char * filelocation, int * itno, double 
 	FILE *file;
 	/* Char and char buffer for reading file to */
 	char c = '\0';
-	char buffer[100000];
+	char buffer[CONST_BUFFER_SIZE];
 	char FLAME_location[10000];
 	char FLAME_format[10000];
 	char FLAME_type[10000];


### PR DESCRIPTION
This patch declares the variable inputfilepath as a global variable, instead of as a local variable in the main() function in the file main.tmpl. This allows other functions to use it to refer to the input folder of the 0.xml file (this is passed as 2nd argument to the main executable).